### PR TITLE
Fix error handling

### DIFF
--- a/pkg/oras/discover.go
+++ b/pkg/oras/discover.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
@@ -21,6 +22,11 @@ func Discover(ctx context.Context, resolver remotes.Resolver, ref, artifactType 
 
 	_, desc, err := resolver.Resolve(ctx, ref)
 	if err != nil {
+
+		if errdefs.IsNotFound(err) { //Handle 404
+			return ocispec.Descriptor{}, nil, nil
+		}
+
 		return ocispec.Descriptor{}, nil, err
 	}
 


### PR DESCRIPTION
/cc @juliusl - I honestly don't know if this is the proper fix to support tree output when you have only one artifact. 

The following is the repro of the issue - 

```
 ~/temp
➜ oras discover -o json sajay.azurecr-test.io/hello-world:latest  -u $REGISTRY_USERNAME -p $PASSWORD
{
  "digest": "sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4",
  "references": [
    {
      "digest": "sha256:79c864f2b513a2c62e400e9a01bbe60feb022063e657f76640af890b4706083a",
      "artifactType": "application/vnd.cncf.notary.v2.signature"
    }
  ]
}
 ~/temp
➜ oras -o tree discover sajay.azurecr-test.io/hello-world:latest  -u $REGISTRY_USERNAME -p $PASSWORD
Error: sajay.azurecr-test.io/hello-world@sha256:79c864f2b513a2c62e400e9a01bbe60feb022063e657f76640af890b4706083a: not found
```
