### PR TITLE
Fix permission issue on PUT artifact manifest

### DIFF
--- a/pkg/remotes/docker/artifacts.go
+++ b/pkg/remotes/docker/artifacts.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	remoteserrors "github.com/containerd/containerd/remotes/errors"
@@ -27,6 +28,15 @@ func (d *dockerDiscoverer) Pusher(ctx context.Context, ref string) (remotes.Push
 func (d *dockerDiscoverer) Push(ctx context.Context, desc ocispec.Descriptor) (content.Writer, error) {
 	switch desc.MediaType {
 	case artifactspec.MediaTypeArtifactManifest:
+		r, err := reference.Parse(d.reference)
+		if err != nil {
+			return nil, err
+		}
+		ctx, err := docker.ContextWithRepositoryScope(ctx, r, true)
+		if err != nil {
+			return nil, err
+		}
+
 		h, err := d.filterHosts(docker.HostCapabilityPush)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Artifact manifests failed to PUT with the following error message:
```
Error: failed commit on ref "myregistry/myrepo": retry request, cannot reset the stream
```
The reason is that incorrect access token is used by the customized `containerd` implementation, and it tries to re-read the request body for new requests. Since piped I/O cannot be rewinded, the PUT fails.

Even if the request body is rewindable, the Authorizator reuses the old token with insufficient scope, which does not match the requested scope in the returned challenge of the 401 response.

This PR constructs a proper scope before doing any requests. The implementation follows the `containerd` [implementation](https://github.com/containerd/containerd/blob/v1.5.7/remotes/docker/pusher.go#L73).