### PR TITLE
Add headers to docker resolver

### DIFF
--- a/pkg/auth/docker/resolver.go
+++ b/pkg/auth/docker/resolver.go
@@ -3,19 +3,33 @@ package docker
 import (
 	"context"
 	"net/http"
+	"strings"
 
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	ctypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/registry"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
 // Resolver returns a new authenticated resolver.
 func (c *Client) Resolver(_ context.Context, client *http.Client, plainHTTP bool) (remotes.Resolver, error) {
+	header := http.Header{}
+	header.Set("Accept", strings.Join([]string{
+		images.MediaTypeDockerSchema2Manifest,
+		images.MediaTypeDockerSchema2ManifestList,
+		ocispec.MediaTypeImageManifest,
+		ocispec.MediaTypeImageIndex,
+		artifactspec.MediaTypeArtifactManifest,
+		"*/*",
+	}, ", "))
 	return docker.NewResolver(docker.ResolverOptions{
 		Credentials: c.Credential,
 		Client:      client,
 		PlainHTTP:   plainHTTP,
+		Headers:     header,
 	}), nil
 }
 


### PR DESCRIPTION
This fixes the `oras discover` on auth credentials from config files.