### PR TITLE
Support certificate authority configuration

### DIFF
--- a/cmd/oras/login.go
+++ b/cmd/oras/login.go
@@ -44,7 +44,7 @@ type loginOptions struct {
 	username   string
 	password   string
 	insecure   bool
-	plainHttp  bool
+	plainHTTP  bool
 	verbose    bool
 }
 
@@ -87,7 +87,7 @@ Example - Login with insecure registry from command line:
 	cmd.Flags().BoolVarP(&opts.fromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	cmd.Flags().BoolVarP(&opts.insecure, "insecure", "k", false, "allow connections to SSL registry without certs")
 	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "server certificate authority file for the remote registry")
-	cmd.Flags().BoolVarP(&opts.plainHttp, "plain-http", "", false, "allow insecure connections to registry without SSL")
+	cmd.Flags().BoolVarP(&opts.plainHTTP, "plain-http", "", false, "allow insecure connections to registry without SSL")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	return cmd
 }
@@ -147,7 +147,7 @@ func runLogin(opts loginOptions) (err error) {
 	if err != nil {
 		return err
 	}
-	remote.PlainHTTP = opts.plainHttp
+	remote.PlainHTTP = opts.plainHTTP
 	cred := credential.Credential(opts.username, opts.password)
 	rootCAs, err := http.LoadCertPool(opts.caFilePath)
 	if err != nil {

--- a/cmd/oras/login.go
+++ b/cmd/oras/login.go
@@ -86,7 +86,7 @@ Example - Login with insecure registry from command line:
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password or identity token")
 	cmd.Flags().BoolVarP(&opts.fromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	cmd.Flags().BoolVarP(&opts.insecure, "insecure", "k", false, "allow connections to SSL registry without certs")
-	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "allow connections to SSL registry without certs")
+	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "user specified certificate authority file for the registry client")
 	cmd.Flags().BoolVarP(&opts.plainHttp, "plain-http", "", false, "allow insecure connections to registry without SSL")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	return cmd

--- a/cmd/oras/login.go
+++ b/cmd/oras/login.go
@@ -38,14 +38,14 @@ type loginOptions struct {
 	hostname  string
 	fromStdin bool
 
-	debug       bool
-	configs     []string
-	caFilePaths []string
-	username    string
-	password    string
-	insecure    bool
-	plainHttp   bool
-	verbose     bool
+	debug      bool
+	configs    []string
+	caFilePath string
+	username   string
+	password   string
+	insecure   bool
+	plainHttp  bool
+	verbose    bool
 }
 
 func loginCmd() *cobra.Command {
@@ -86,7 +86,7 @@ Example - Login with insecure registry from command line:
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password or identity token")
 	cmd.Flags().BoolVarP(&opts.fromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	cmd.Flags().BoolVarP(&opts.insecure, "insecure", "k", false, "allow connections to SSL registry without certs")
-	cmd.Flags().StringArrayVarP(&opts.caFilePaths, "insecure-ca-files", "", nil, "allow connections to SSL registry without certs")
+	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "allow connections to SSL registry without certs")
 	cmd.Flags().BoolVarP(&opts.plainHttp, "plain-http", "", false, "allow insecure connections to registry without SSL")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	return cmd
@@ -149,7 +149,7 @@ func runLogin(opts loginOptions) (err error) {
 	}
 	remote.PlainHTTP = opts.plainHttp
 	cred := credential.Credential(opts.username, opts.password)
-	rootCAs, err := http.LoadRootCAs(opts.caFilePaths)
+	rootCAs, err := http.LoadRootCAs(opts.caFilePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/login.go
+++ b/cmd/oras/login.go
@@ -86,7 +86,7 @@ Example - Login with insecure registry from command line:
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password or identity token")
 	cmd.Flags().BoolVarP(&opts.fromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	cmd.Flags().BoolVarP(&opts.insecure, "insecure", "k", false, "allow connections to SSL registry without certs")
-	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "user specified certificate authority file for the registry target")
+	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "server certificate authority file for the remote registry")
 	cmd.Flags().BoolVarP(&opts.plainHttp, "plain-http", "", false, "allow insecure connections to registry without SSL")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	return cmd
@@ -149,7 +149,7 @@ func runLogin(opts loginOptions) (err error) {
 	}
 	remote.PlainHTTP = opts.plainHttp
 	cred := credential.Credential(opts.username, opts.password)
-	rootCAs, err := http.LoadRootCAs(opts.caFilePath)
+	rootCAs, err := http.LoadCertPool(opts.caFilePath)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/login.go
+++ b/cmd/oras/login.go
@@ -86,7 +86,7 @@ Example - Login with insecure registry from command line:
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "registry password or identity token")
 	cmd.Flags().BoolVarP(&opts.fromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	cmd.Flags().BoolVarP(&opts.insecure, "insecure", "k", false, "allow connections to SSL registry without certs")
-	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "user specified certificate authority file for the registry client")
+	cmd.Flags().StringVarP(&opts.caFilePath, "ca-file", "", "", "user specified certificate authority file for the registry target")
 	cmd.Flags().BoolVarP(&opts.plainHttp, "plain-http", "", false, "allow insecure connections to registry without SSL")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "verbose output")
 	return cmd

--- a/internal/http/certificate.go
+++ b/internal/http/certificate.go
@@ -6,17 +6,14 @@ import (
 	"os"
 )
 
-func LoadRootCAs(path string) (*x509.CertPool, error) {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, err
-	}
+func LoadCertPool(path string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
 	pemBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 	if ok := pool.AppendCertsFromPEM(pemBytes); !ok {
-		return nil, errors.New("Failed to add certificate authority in file: " + path)
+		return nil, errors.New("Failed to load certificate in file: " + path)
 	}
 	return pool, nil
 }

--- a/internal/http/certificate.go
+++ b/internal/http/certificate.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"crypto/x509"
+	"errors"
+	"os"
+)
+
+func LoadRootCAs(paths []string) (pool *x509.CertPool, err error) {
+	pool, err = x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range paths {
+		pemBytes, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if ok := pool.AppendCertsFromPEM(pemBytes); !ok {
+			return nil, errors.New("Failed to add certificate authority in file: " + path)
+		}
+	}
+	return pool, nil
+}

--- a/internal/http/certificate.go
+++ b/internal/http/certificate.go
@@ -6,8 +6,8 @@ import (
 	"os"
 )
 
-func LoadRootCAs(path string) (pool *x509.CertPool, err error) {
-	pool, err = x509.SystemCertPool()
+func LoadRootCAs(path string) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/certificate.go
+++ b/internal/http/certificate.go
@@ -6,19 +6,17 @@ import (
 	"os"
 )
 
-func LoadRootCAs(paths []string) (pool *x509.CertPool, err error) {
+func LoadRootCAs(path string) (pool *x509.CertPool, err error) {
 	pool, err = x509.SystemCertPool()
 	if err != nil {
 		return nil, err
 	}
-	for _, path := range paths {
-		pemBytes, err := os.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
-		if ok := pool.AppendCertsFromPEM(pemBytes); !ok {
-			return nil, errors.New("Failed to add certificate authority in file: " + path)
-		}
+	pemBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if ok := pool.AppendCertsFromPEM(pemBytes); !ok {
+		return nil, errors.New("Failed to add certificate authority in file: " + path)
 	}
 	return pool, nil
 }

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -3,6 +3,7 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"net/http"
 
 	"oras.land/oras-go/v2/registry/remote"
@@ -18,6 +19,7 @@ type ClientOptions struct {
 	CredentialStore *credential.Store
 	SkipTLSVerify   bool
 	Debug           bool
+	RootCAs         *x509.CertPool
 }
 
 func NewClient(opts ClientOptions) remote.Client {
@@ -26,6 +28,7 @@ func NewClient(opts ClientOptions) remote.Client {
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: opts.SkipTLSVerify,
+					RootCAs:            opts.RootCAs,
 				},
 			},
 		},

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -17,7 +17,6 @@ package http_test
 import (
 	"context"
 	"crypto/x509"
-	"encoding/pem"
 	"testing"
 
 	nhttp "net/http"
@@ -73,8 +72,7 @@ func Test_NewClient_CARoots(t *testing.T) {
 
 	// Test CA pool
 	pool := x509.NewCertPool()
-	c := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ts.Certificate().Raw})
-	pool.AppendCertsFromPEM(c)
+	pool.AddCert(ts.Certificate())
 	opts := http.ClientOptions{
 		RootCAs: pool,
 	}

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -35,7 +35,6 @@ func Test_NewClient_credential(t *testing.T) {
 		Credential: wanted,
 	}
 	client := http.NewClient(opts)
-
 	got, err := client.(*auth.Client).Credential(nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -53,7 +52,6 @@ func Test_NewClient_skipTlsVerify(t *testing.T) {
 
 	wanted := opts.SkipTLSVerify
 	client := http.NewClient(opts)
-
 	config := client.(*auth.Client).Client.Transport.(*nhttp.Transport).TLSClientConfig
 	got := config.InsecureSkipVerify
 	if got != wanted {


### PR DESCRIPTION
This PR enables configuring certificate authority files for registry client.

For now this was only used in `login` command but will also be applied to `pull` and `push` commands after revamping.

#217
