### PR TITLE
Refine release pipeline

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -25,10 +25,11 @@ jobs:
         run: |
           docker build -t ${{ steps.prepare.outputs.ref }} .
       - name: docker login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: docker push
         run: |
           docker push ${{ steps.prepare.outputs.ref }}

--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -28,8 +28,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.RELEASE_GHCR_USER_NAME }}
-          password: ${{ secrets.RELEASE_GHCR_USER_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: docker push
         run: |
           docker push ${{ steps.prepare.outputs.ref }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -21,4 +21,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use Github token instead of personal access token for releasing.


Related to #377 