### PR TITLE
Upgrades to oras-go v2.0.0-alpha

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
-	oras.land/oras-go/v2 v2.0.0-20220622093312-9fc00616c490
+	oras.land/oras-go/v2 v2.0.0-alpha
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -62,5 +62,5 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-oras.land/oras-go/v2 v2.0.0-20220622093312-9fc00616c490 h1:25gVyqUJeNaPYtgxuBKNaN/nWsSYgQeHc4m4XQyd39A=
-oras.land/oras-go/v2 v2.0.0-20220622093312-9fc00616c490/go.mod h1:0IQiLwHUJuMs0+QYGavaeQWw5FD4ABD/RP5YamXT/sc=
+oras.land/oras-go/v2 v2.0.0-alpha h1:Uwso3p1KMTmm7YheWBkGNjf8xqXZ2AYxMfxu1DoQiH0=
+oras.land/oras-go/v2 v2.0.0-alpha/go.mod h1:0IQiLwHUJuMs0+QYGavaeQWw5FD4ABD/RP5YamXT/sc=


### PR DESCRIPTION
This PR upgrades the underlying oras-go to v2.0.0-alpha

Signed-off-by: Billy Zha <jinzha1@microsoft.com>