### PR TITLE
Remove push mandate on `subject`

### DIFF
--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -124,13 +124,14 @@ func runPush(opts pushOptions) error {
 
 	// bake artifact
 	var pushOpts []oras.PushOpt
-	if opts.artifactType != "" {
+	if opts.artifactType != "" && opts.artifactRefs != "" {
 		resolver, err = orasDocker.WithDiscover(opts.artifactRefs, resolver, orasDocker.NewOpts(ropts))
 		if err != nil {
 			return err
 		}
 
-		manifest, err := loadReference(ctx, resolver, opts.artifactRefs)
+		var manifest ocispec.Descriptor
+		manifest, err = loadReference(ctx, resolver, opts.artifactRefs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #361

Does NOT fix oras-project/oras-go#206; since this client does not use the go library.
