### PR TITLE
Push canary image on each commit, sign images

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -2,6 +2,8 @@ name: release-ghcr
 
 on:
   push:
+    branches:
+      - main
     tags:
       - v*
 
@@ -11,16 +13,17 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: prepare
         id: prepare
         run: |
+          # If not a tagged release, override image tag to "canary"
           VERSION=${GITHUB_REF#refs/*/}
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          if [[ "${VERSION}" == "${BRANCH_NAME}" ]]; then
-            VERSION=$(git rev-parse --short HEAD)
+          if [[ $GITHUB_REF != refs/tags/* ]]; then
+            VERSION=canary
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=ref::ghcr.io/${{ github.repository }}:${VERSION}
@@ -34,6 +37,13 @@ jobs:
         run: |          
           docker buildx create --use
           docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${{ steps.prepare.outputs.ref }} --push .
+      - name: install cosign
+        uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2
+        with:
+          cosign-release: 'v1.9.0'
+      - name: sign image
+        run: |
+          COSIGN_EXPERIMENTAL=1 cosign sign -y -f ${{ steps.prepare.outputs.ref }}
       - name: clear
         if: always()
         run: |

--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -43,7 +43,7 @@ jobs:
           cosign-release: 'v1.9.0'
       - name: sign image
         run: |
-          COSIGN_EXPERIMENTAL=1 cosign sign -y -f ${{ steps.prepare.outputs.ref }}
+          COSIGN_EXPERIMENTAL=1 cosign sign -r -y -f ${{ steps.prepare.outputs.ref }}
       - name: clear
         if: always()
         run: |


### PR DESCRIPTION
Release a canary image on each commit and sign it "keyless" using the GitHub Actions provided OIDC token