### PR TITLE
Adding support for windows-arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,16 @@ build-mac-arm64:
 		-o bin/darwin/arm64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-windows
-build-windows:
+build-windows: build-windows-amd64 build-windows-arm64
+
+.PHONY: build-windows-amd64:
 	GOARCH=amd64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/amd64/$(CLI_EXE).exe $(CLI_PKG)
+
+.PHONY: build-windows-arm64
+build-windows:
+	GOARCH=arm64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
+		-o bin/windows/arm64/$(CLI_EXE).exe $(CLI_PKG)
 
 .PHONY: check-encoding
 check-encoding:

--- a/Makefile
+++ b/Makefile
@@ -65,16 +65,14 @@ build-mac-arm64:
 
 .PHONY: build-windows
 build-windows: build-windows-amd64 build-windows-arm64
-
 .PHONY: build-windows-amd64
+build-windows-amd64:
 	GOARCH=amd64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/amd64/$(CLI_EXE).exe $(CLI_PKG)
-
 .PHONY: build-windows-arm64
-build-windows:
+build-windows-arm64:
 	GOARCH=arm64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/arm64/$(CLI_EXE).exe $(CLI_PKG)
-
 .PHONY: check-encoding
 check-encoding:
 	! find cmd internal -name "*.go" -type f -exec file "{}" ";" | grep CRLF

--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,17 @@ build-mac-arm64:
 
 .PHONY: build-windows
 build-windows: build-windows-amd64 build-windows-arm64
+
 .PHONY: build-windows-amd64
 build-windows-amd64:
 	GOARCH=amd64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/amd64/$(CLI_EXE).exe $(CLI_PKG)
+
 .PHONY: build-windows-arm64
 build-windows-arm64:
 	GOARCH=arm64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/arm64/$(CLI_EXE).exe $(CLI_PKG)
+
 .PHONY: check-encoding
 check-encoding:
 	! find cmd internal -name "*.go" -type f -exec file "{}" ";" | grep CRLF

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build-mac-arm64:
 .PHONY: build-windows
 build-windows: build-windows-amd64 build-windows-arm64
 
-.PHONY: build-windows-amd64:
+.PHONY: build-windows-amd64
 	GOARCH=amd64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/amd64/$(CLI_EXE).exe $(CLI_PKG)
 


### PR DESCRIPTION
This PR adds changes to support ORAS CLI on windows 64 Architecture.

Signed-off-by: Koushik Dey <57134947+koushdey@users.noreply.github.com>