### PR TITLE
add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+ARG VARIANT="1.18"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "1.18"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": { 
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go"
+			},
+			
+			"extensions": [
+				"golang.Go"
+			]
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	"remoteUser": "vscode",
+	"features": {
+		"docker-in-docker": "latest"
+	}
+}


### PR DESCRIPTION
Adds a standard dev container configuration, setting up this repo for a great experience with VS Code Remote Containers, GitHub Codespaces, and any other implementor of the [dev container specification](https://containers.dev).

Configures a container with:
 - Go 1.18 installed with the appropriate flags
 - Docker running (inside the container, thus "docker-in-docker")

Additionally, if the user opens this dev container in VS Code, the official Go extension will be automatically installed.