### PR TITLE
fix: print digest and media type when unnamed content is skipped

### DIFF
--- a/cmd/oras/internal/display/print.go
+++ b/cmd/oras/internal/display/print.go
@@ -37,8 +37,8 @@ func Print(a ...any) error {
 // StatusPrinter returns a tracking function for transfer status.
 func StatusPrinter(status string, verbose bool) func(context.Context, ocispec.Descriptor) error {
 	return func(ctx context.Context, desc ocispec.Descriptor) error {
-		name, ok := desc.Annotations[ocispec.AnnotationTitle]
-		if !ok {
+		name := desc.Annotations[ocispec.AnnotationTitle]
+		if name == "" {
 			if !verbose {
 				return nil
 			}

--- a/cmd/oras/internal/display/print.go
+++ b/cmd/oras/internal/display/print.go
@@ -40,6 +40,7 @@ func StatusPrinter(status string, verbose bool) func(context.Context, ocispec.De
 		name := desc.Annotations[ocispec.AnnotationTitle]
 		if name == "" {
 			if !verbose {
+				// no status for unamed content
 				return nil
 			}
 			name = desc.MediaType

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -33,6 +33,8 @@ import (
 	"oras.land/oras/internal/docker"
 )
 
+type void struct{}
+
 type pullOptions struct {
 	option.Common
 	option.Remote
@@ -85,6 +87,8 @@ Example - Pull files with local cache:
 }
 
 func runPull(opts pullOptions) error {
+	set := make(map[string]void)
+	var printed void
 	repo, err := opts.NewRepository(opts.targetRef, opts.Common)
 	if err != nil {
 		return err
@@ -129,9 +133,12 @@ func runPull(opts pullOptions) error {
 					return nil, err
 				}
 				if len(ss) == 0 {
-					err = display.StatusPrinter("Skipped    ", opts.Verbose)(ctx, s)
-					if err != nil {
-						return nil, err
+					if _, exists := set[string(s.Digest)]; !exists {
+						err = display.StatusPrinter("Skipped    ", opts.Verbose)(ctx, s)
+						if err != nil {
+							return nil, err
+						}
+						set[string(s.Digest)] = printed
 					}
 					continue
 				}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -122,13 +122,17 @@ func runPull(opts pullOptions) error {
 					s.Annotations = make(map[string]string)
 				}
 				s.Annotations[ocispec.AnnotationTitle] = configPath
-			} else if s.Annotations[ocispec.AnnotationTitle] == "" {
+			}
+			if s.Annotations[ocispec.AnnotationTitle] == "" {
 				ss, err := content.Successors(ctx, fetcher, s)
 				if err != nil {
 					return nil, err
 				}
 				if len(ss) == 0 {
-					display.StatusPrinter("Skipped", opts.Verbose)
+					err = display.StatusPrinter("Skipped    ", opts.Verbose)(ctx, s)
+					if err != nil {
+						return nil, err
+					}
 					continue
 				}
 			}
@@ -141,10 +145,10 @@ func runPull(opts pullOptions) error {
 	copyOptions.PreCopy = display.StatusPrinter("Downloading", opts.Verbose)
 	copyOptions.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		name := desc.Annotations[ocispec.AnnotationTitle]
-		if name == "" {
+		pulledEmpty = name == ""
+		if name == "" && !opts.Verbose {
 			return nil
 		}
-		pulledEmpty = false
 		return display.Print("Downloaded ", display.ShortDigest(desc), name)
 	}
 

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -128,6 +128,7 @@ func runPull(opts pullOptions) error {
 					return nil, err
 				}
 				if len(ss) == 0 {
+					display.Print("Skipped ", display.ShortDigest(desc), s.MediaType)
 					continue
 				}
 			}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -125,6 +125,7 @@ func runPull(opts pullOptions) error {
 				s.Annotations[ocispec.AnnotationTitle] = configPath
 			}
 			if s.Annotations[ocispec.AnnotationTitle] == "" {
+				// skip fetching unamed leaf nodes
 				ss, err := content.Successors(ctx, fetcher, s)
 				if err != nil {
 					return nil, err
@@ -155,6 +156,7 @@ func runPull(opts pullOptions) error {
 			}
 			name = desc.MediaType
 		} else {
+			// no named content pulled
 			pulledEmpty = false
 		}
 		return display.Print("Downloaded ", display.ShortDigest(desc), name)

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -156,7 +156,7 @@ func runPull(opts pullOptions) error {
 			}
 			name = desc.MediaType
 		} else {
-			// no named content pulled
+			// named content downloaded
 			pulledEmpty = false
 		}
 		return display.Print("Downloaded ", display.ShortDigest(desc), name)

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -128,7 +128,7 @@ func runPull(opts pullOptions) error {
 					return nil, err
 				}
 				if len(ss) == 0 {
-					display.Print("Skipped ", display.ShortDigest(s), s.MediaType)
+					display.StatusPrinter("Skipped", opts.Verbose)
 					continue
 				}
 			}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -33,8 +33,6 @@ import (
 	"oras.land/oras/internal/docker"
 )
 
-type void struct{}
-
 type pullOptions struct {
 	option.Common
 	option.Remote
@@ -87,8 +85,7 @@ Example - Pull files with local cache:
 }
 
 func runPull(opts pullOptions) error {
-	set := make(map[string]void)
-	var printed void
+	printed := make(map[string]bool)
 	repo, err := opts.NewRepository(opts.targetRef, opts.Common)
 	if err != nil {
 		return err
@@ -133,12 +130,12 @@ func runPull(opts pullOptions) error {
 					return nil, err
 				}
 				if len(ss) == 0 {
-					if _, exists := set[string(s.Digest)]; !exists {
+					if !printed[s.Digest.String()] {
 						err = display.StatusPrinter("Skipped    ", opts.Verbose)(ctx, s)
 						if err != nil {
 							return nil, err
 						}
-						set[string(s.Digest)] = printed
+						printed[s.Digest.String()] = true
 					}
 					continue
 				}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -128,7 +128,7 @@ func runPull(opts pullOptions) error {
 					return nil, err
 				}
 				if len(ss) == 0 {
-					display.Print("Skipped ", display.ShortDigest(desc), s.MediaType)
+					display.Print("Skipped ", display.ShortDigest(s), s.MediaType)
 					continue
 				}
 			}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -145,9 +145,13 @@ func runPull(opts pullOptions) error {
 	copyOptions.PreCopy = display.StatusPrinter("Downloading", opts.Verbose)
 	copyOptions.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		name := desc.Annotations[ocispec.AnnotationTitle]
-		pulledEmpty = name == ""
-		if name == "" && !opts.Verbose {
-			return nil
+		if name == "" {
+			if !opts.Verbose {
+				return nil
+			}
+			name = desc.MediaType
+		} else {
+			pulledEmpty = false
 		}
 		return display.Print("Downloaded ", display.ShortDigest(desc), name)
 	}


### PR DESCRIPTION
Add a print statement when unnamed content is skipped for downloading. Short digest and media type will be printed.

Resolves #415 
Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>
