### PR TITLE
feat: Support pulling arbitrary manifest config

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -109,11 +109,11 @@ func runPull(opts pullOptions) error {
 		}
 		var ret []ocispec.Descriptor
 		for i, s := range successors {
-			// Check whether the node's MediaType matches the specified MediaType.
-			// If the mediaType is not specified, check whether the parent node
-			// is a manifest.
-			// Note: For a manifest, the 0th indexed element is always a manifest
-			// config.
+			// Save the config when:
+			// 1) MediaType matches, or
+			// 2) MediaType not specified and current node is config.
+			// Note: For a manifest, the 0th indexed element is always a
+			// manifest config.
 			if s.MediaType == configMediaType || (configMediaType == "" && i == 0 &&
 				(desc.MediaType == "application/vnd.docker.distribution.manifest.v2+json" ||
 					desc.MediaType == ocispec.MediaTypeImageManifest)) {

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/cache"
+	"oras.land/oras/internal/docker"
 )
 
 type pullOptions struct {
@@ -114,9 +115,7 @@ func runPull(opts pullOptions) error {
 			// 2) MediaType not specified and current node is config.
 			// Note: For a manifest, the 0th indexed element is always a
 			// manifest config.
-			if s.MediaType == configMediaType || (configMediaType == "" && i == 0 &&
-				(desc.MediaType == "application/vnd.docker.distribution.manifest.v2+json" ||
-					desc.MediaType == ocispec.MediaTypeImageManifest)) {
+			if s.MediaType == configMediaType || (configMediaType == "" && i == 0 && isManifestMediaType(desc.MediaType)) {
 				// Add annotation for manifest config
 				if s.Annotations == nil {
 					s.Annotations = make(map[string]string)
@@ -163,4 +162,8 @@ func runPull(opts pullOptions) error {
 	fmt.Println("Pulled", opts.targetRef)
 	fmt.Println("Digest:", desc.Digest)
 	return nil
+}
+
+func isManifestMediaType(mediaType string) bool {
+	return mediaType == docker.MediaTypeManifest || mediaType == ocispec.MediaTypeImageManifest
 }

--- a/internal/docker/mediatype.go
+++ b/internal/docker/mediatype.go
@@ -1,0 +1,21 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+// docker media types
+const (
+	MediaTypeManifest = "application/vnd.docker.distribution.manifest.v2+json"
+)


### PR DESCRIPTION
#274 enables the CLI to pull manifest config. However, the user must provide the desired media type of the config or use the default. This PR allows pulling arbitrary manifest config.

If the user does not specify the desired media type, the code will get the 0th indexed node as the manifest config if its parent node is a manifest.
Note: For a manifest, the 0th indexed element is always a manifest config. ref: https://github.com/oras-project/oras-go/blob/6a09a65fcc0b96c3448e988c1727ed154c2388ea/content/graph.go#L58

Examples:
```
$ oras pull --manifest-config config.json localhost:5000/hello:latest
Downloaded  3ad08644ab5a artifact.txt
Downloaded  98df5c495df6 config.json
Pulled localhost:5000/hello:latest
Digest: sha256:8627dfe823698a566e105d961045eafcaa9115b6faf1f625edd85df558421bd5
```

Resolves: #275 
Signed-off-by: Zoey Li <zoeyli@microsoft.com>