### PR TITLE
Bump to golang 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18]
+        go-version: [1.19]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: [1.18]
+        go-version: [1.19]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.1'
+          go-version: '1.19.0'
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.18.1-alpine as builder
+FROM docker.io/library/golang:1.19.0-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module oras.land/oras
 
-go 1.18
+go 1.19
 
 require (
 	github.com/docker/cli v20.10.17+incompatible


### PR DESCRIPTION
Signed-off-by: Sajay Antony <sajaya@microsoft.com>

Fixes #478 

Test build and release can be found here - 


[Bump to golang 1.19](https://github.com/sajayantony/oras/actions/runs/2836036330)
release-ghcr #10: Commit [3d7c282](https://github.com/sajayantony/oras/commit/3d7c28231864c608ae2680a1a43b2c17b3dba11a) pushed by [sajayantony](https://github.com/sajayantony)
[v2.0.0-alpha-go1.9](https://github.com/sajayantony/oras/tree/v2.0.0-alpha-go1.9)	
 4 minutes ago
 3m 25s
[Bump to golang 1.19](https://github.com/sajayantony/oras/actions/runs/2836036328)
release-github #10: Commit [3d7c282](https://github.com/sajayantony/oras/commit/3d7c28231864c608ae2680a1a43b2c17b3dba11a) pushed by [sajayantony](https://github.com/sajayantony)
[v2.0.0-alpha-go1.9](https://github.com/sajayantony/oras/tree/v2.0.0-alpha-go1.9)	
 4 minutes ago
 2m 13s