### PR TITLE
fix: add new line to prettify manifest fetch result 

### DIFF
--- a/cmd/oras/manifest/fetch.go
+++ b/cmd/oras/manifest/fetch.go
@@ -109,8 +109,9 @@ func fetchManifest(opts fetchOptions) error {
 		if err = json.Indent(buf, content, "", "  "); err != nil {
 			return fmt.Errorf("failed to prettify: %w", err)
 		}
-		content = buf.Bytes()
+
 		buf.WriteByte('\n')
+		content = buf.Bytes()
 	}
 	_, err = os.Stdout.Write(content)
 	return err

--- a/cmd/oras/manifest/fetch.go
+++ b/cmd/oras/manifest/fetch.go
@@ -109,7 +109,6 @@ func fetchManifest(opts fetchOptions) error {
 		if err = json.Indent(buf, content, "", "  "); err != nil {
 			return fmt.Errorf("failed to prettify: %w", err)
 		}
-
 		buf.WriteByte('\n')
 		content = buf.Bytes()
 	}

--- a/cmd/oras/manifest/fetch.go
+++ b/cmd/oras/manifest/fetch.go
@@ -110,6 +110,7 @@ func fetchManifest(opts fetchOptions) error {
 			return fmt.Errorf("failed to prettify: %w", err)
 		}
 		content = buf.Bytes()
+		buf.WriteByte('\n')
 	}
 	_, err = os.Stdout.Write(content)
 	return err


### PR DESCRIPTION
So linux prompt will not be shown right after the prettified result.