### PR TITLE
refactor: add pre-defined annotation keys into option.Packer

### DIFF
--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -81,7 +81,7 @@ func runAttach(opts attachOptions) error {
 	if err != nil {
 		return err
 	}
-	if len(opts.FileRefs) == 0 && len(annotations[annotationManifest]) == 0 {
+	if len(opts.FileRefs) == 0 && len(annotations[option.AnnotationManifest]) == 0 {
 		return errors.New("no blob or manifest annotation are provided")
 	}
 

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	annotationManifest = "$manifest"
+	AnnotationManifest = "$manifest"
+	AnnotationConfig   = "$config"
 )
 
 var (
@@ -110,6 +111,6 @@ func parseAnnotationFlags(flags []string, annotations map[string]map[string]stri
 		}
 		manifestAnnotations[key] = val
 	}
-	annotations[annotationManifest] = manifestAnnotations
+	annotations[AnnotationManifest] = manifestAnnotations
 	return nil
 }

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -28,7 +28,7 @@ import (
 	"oras.land/oras-go/v2/content"
 )
 
-// Pre-Defined Annotation Keys
+// pre-defined annotation Keys
 const (
 	AnnotationManifest = "$manifest"
 	AnnotationConfig   = "$config"

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -28,6 +28,7 @@ import (
 	"oras.land/oras-go/v2/content"
 )
 
+// Pre-Defined Annotation Keys
 const (
 	AnnotationManifest = "$manifest"
 	AnnotationConfig   = "$config"

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -28,7 +28,7 @@ import (
 	"oras.land/oras-go/v2/content"
 )
 
-// pre-defined annotation Keys
+// Pre-defined annotation keys for annotation file
 const (
 	AnnotationManifest = "$manifest"
 	AnnotationConfig   = "$config"

--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -30,9 +30,7 @@ import (
 )
 
 const (
-	annotationConfig   = "$config"
-	annotationManifest = "$manifest"
-	tagStaged          = "staged"
+	tagStaged = "staged"
 )
 
 type pushOptions struct {
@@ -74,10 +72,10 @@ Example - Push file to the HTTP registry:
   oras push localhost:5000/hello:latest hi.txt --plain-http
 
 Example - Push repository with manifest annotations
-  oras push localhost:5000/hello:latest --annotaion "key=val"
+  oras push localhost:5000/hello:latest --annotation "key=val"
 
 Example - Push repository with manifest annotation file
-  oras push localhost:5000/hello:latest --annotaion-file annotation.json
+  oras push localhost:5000/hello:latest --annotation-file annotation.json
   `,
 		Args: cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -155,15 +153,15 @@ func runPush(opts pushOptions) error {
 
 func packManifest(ctx context.Context, store *file.Store, annotations map[string]map[string]string, opts *pushOptions) (ocispec.Descriptor, error) {
 	var packOpts oras.PackOptions
-	packOpts.ConfigAnnotations = annotations[annotationConfig]
-	packOpts.ManifestAnnotations = annotations[annotationManifest]
+	packOpts.ConfigAnnotations = annotations[option.AnnotationConfig]
+	packOpts.ManifestAnnotations = annotations[option.AnnotationManifest]
 
 	if opts.artifactType != "" {
 		packOpts.ConfigMediaType = opts.artifactType
 	}
 	if opts.manifestConfigRef != "" {
 		path, mediatype := parseFileReference(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
-		desc, err := store.Add(ctx, annotationConfig, mediatype, path)
+		desc, err := store.Add(ctx, option.AnnotationConfig, mediatype, path)
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}


### PR DESCRIPTION
Defined pre-defined annotation keys in `option.Packer`, and replaced other const defined with the same value.

Updated annotation related example description.