### PR TITLE
refactor!: rename the --manifest-config to --config

### DIFF
--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -72,8 +72,8 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.BoolVarP(&opts.PlainHTTP, flagPrefix+"plain-http", "", false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
 
-	if fs.Lookup("config") != nil {
-		fs.StringArrayVarP(&opts.Configs, "config", "c", nil, "auth config path")
+	if fs.Lookup("registry-config") != nil {
+		fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "auth config path")
 	}
 }
 

--- a/cmd/oras/logout.go
+++ b/cmd/oras/logout.go
@@ -46,7 +46,7 @@ Example - Logout:
 	}
 
 	cmd.Flags().BoolVarP(&opts.debug, "debug", "d", false, "debug mode")
-	cmd.Flags().StringArrayVarP(&opts.configs, "config", "c", nil, "auth config path")
+	cmd.Flags().StringArrayVarP(&opts.configs, "registry-config", "", nil, "auth config path")
 	return cmd
 }
 

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -79,7 +79,7 @@ Example - Pull files with local cache:
 	cmd.Flags().BoolVarP(&opts.KeepOldFiles, "keep-old-files", "k", false, "do not replace existing files when pulling, treat them as errors")
 	cmd.Flags().BoolVarP(&opts.PathTraversal, "allow-path-traversal", "T", false, "allow storing files out of the output directory")
 	cmd.Flags().StringVarP(&opts.Output, "output", "o", ".", "output directory")
-	cmd.Flags().StringVarP(&opts.ManifestConfigRef, "manifest-config", "", "", "output manifest config file")
+	cmd.Flags().StringVarP(&opts.ManifestConfigRef, "config", "", "", "output manifest config file")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return cmd
 }


### PR DESCRIPTION
- Rename current `-c/--config` option to `--registry-config`
- Rename `--manifest-config` to `--config`

Resolves: https://github.com/oras-project/oras/issues/495
Signed-off-by: Zoey Li <zoeyli@microsoft.com>