### PR TITLE
fix: fix the lookup check for registry-config option

### DIFF
--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -72,7 +72,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.BoolVarP(&opts.PlainHTTP, flagPrefix+"plain-http", "", false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
 
-	if fs.Lookup("registry-config") != nil {
+	if fs.Lookup("registry-config") == nil {
 		fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "auth config path")
 	}
 }


### PR DESCRIPTION
This bug was introduced in PR https://github.com/oras-project/oras/pull/432.
`fs.Lookup("config") != nil` was intended to check whether there was an existing config to avoid repeatedly setting the config value. However, we are not able to set the config value if `fs.Lookup("config")` returns nil.
This PR changed the check to `if fs.Lookup("config") == nil {}`

Signed-off-by: Zoey Li <zoeyli@microsoft.com>