### PR TITLE
refactor: reuse print status func

### DIFF
--- a/cmd/oras/internal/display/print.go
+++ b/cmd/oras/internal/display/print.go
@@ -37,14 +37,7 @@ func Print(a ...any) error {
 // StatusPrinter returns a tracking function for transfer status.
 func StatusPrinter(status string, verbose bool) func(context.Context, ocispec.Descriptor) error {
 	return func(ctx context.Context, desc ocispec.Descriptor) error {
-		name, ok := desc.Annotations[ocispec.AnnotationTitle]
-		if !ok {
-			if !verbose {
-				return nil
-			}
-			name = desc.MediaType
-		}
-		return Print(status, ShortDigest(desc), name)
+		return PrintStatus(desc, status, verbose)
 	}
 }
 


### PR DESCRIPTION
This PR cleans up duplicated code for status printing

Signed-off-by: Billy Zha <jinzha1@microsoft.com>