### PR TITLE
docs: add doc comments for the loop of successors

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -110,6 +110,7 @@ func runPull(opts pullOptions) error {
 			return nil, err
 		}
 		var ret []ocispec.Descriptor
+		// For each successor s, save its config to Annotations and skip unnamed content.
 		for i, s := range successors {
 			// Save the config when:
 			// 1) MediaType matches, or
@@ -127,6 +128,7 @@ func runPull(opts pullOptions) error {
 				if err != nil {
 					return nil, err
 				}
+				// Skip s if s is unnamed and has no successors.
 				if len(ss) == 0 {
 					continue
 				}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -110,7 +110,9 @@ func runPull(opts pullOptions) error {
 			return nil, err
 		}
 		var ret []ocispec.Descriptor
-		// For each successor s, save its config to Annotations and skip unnamed content.
+		// Iterate all the successors to
+		// 1) Add name annotation if configPath is not empty
+		// 2) Skip fetching unamed leaf nodes
 		for i, s := range successors {
 			// Save the config when:
 			// 1) MediaType matches, or


### PR DESCRIPTION
Note that there are comments in line 115-119.
This pr adds additional comments before and inside the loop of successors to describe what the loop does.

Part of issue #415 

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>