### PR TITLE
fix: check if configPath is empty before writing to Annotations

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -111,24 +111,22 @@ func runPull(opts pullOptions) error {
 		}
 		var ret []ocispec.Descriptor
 		// Iterate all the successors to
-		// 1) Add name annotation if configPath is not empty
-		// 2) Skip fetching unamed leaf nodes
+		// 1) Add name annotation to config if configPath is not empty
+		// 2) Skip fetching unnamed leaf nodes
 		for i, s := range successors {
 			// Save the config when:
 			// 1) MediaType matches, or
 			// 2) MediaType not specified and current node is config.
 			// Note: For a manifest, the 0th indexed element is always a
 			// manifest config.
-			if s.MediaType == configMediaType || (configMediaType == "" && i == 0 && isManifestMediaType(desc.MediaType)) {
-				if configPath == "" {
-					continue
-				}
+			if (s.MediaType == configMediaType || (configMediaType == "" && i == 0 && isManifestMediaType(desc.MediaType))) && configPath != "" {
 				// Add annotation for manifest config
 				if s.Annotations == nil {
 					s.Annotations = make(map[string]string)
 				}
 				s.Annotations[ocispec.AnnotationTitle] = configPath
-			} else if s.Annotations[ocispec.AnnotationTitle] == "" {
+			}
+			if s.Annotations[ocispec.AnnotationTitle] == "" {
 				ss, err := content.Successors(ctx, fetcher, s)
 				if err != nil {
 					return nil, err

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -120,6 +120,9 @@ func runPull(opts pullOptions) error {
 			// Note: For a manifest, the 0th indexed element is always a
 			// manifest config.
 			if s.MediaType == configMediaType || (configMediaType == "" && i == 0 && isManifestMediaType(desc.MediaType)) {
+				if configPath == "" {
+					continue
+				}
 				// Add annotation for manifest config
 				if s.Annotations == nil {
 					s.Annotations = make(map[string]string)


### PR DESCRIPTION
This pr adds empty string check before writing configPath to Annotations, so that if a config only specifies the type but not name, oras cli should not fetch the content of this config.

Part of issue #415 
Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>