### PR TITLE
feat: print digest and media type when content is skipped using sync.Map

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
@@ -85,6 +86,7 @@ Example - Pull files with local cache:
 }
 
 func runPull(opts pullOptions) error {
+	printed := &sync.Map{}
 	repo, err := opts.NewRepository(opts.targetRef, opts.Common)
 	if err != nil {
 		return err
@@ -133,6 +135,13 @@ func runPull(opts pullOptions) error {
 				}
 				// Skip s if s is unnamed and has no successors.
 				if len(ss) == 0 {
+					if _, exists := printed.Load(s.Digest.String()); !exists {
+						err = display.PrintStatus(s, "Skipped    ", opts.Verbose)
+						if err != nil {
+							return nil, err
+						}
+						printed.Store(s.Digest.String(), true)
+					}
 					continue
 				}
 			}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -86,7 +86,7 @@ Example - Pull files with local cache:
 }
 
 func runPull(opts pullOptions) error {
-	printed := &sync.Map{}
+	var printed sync.Map
 	repo, err := opts.NewRepository(opts.targetRef, opts.Common)
 	if err != nil {
 		return err
@@ -136,8 +136,7 @@ func runPull(opts pullOptions) error {
 				// Skip s if s is unnamed and has no successors.
 				if len(ss) == 0 {
 					if _, loaded := printed.LoadOrStore(s.Digest.String(), true); !loaded {
-						err = display.PrintStatus(s, "Skipped    ", opts.Verbose)
-						if err != nil {
+						if err = display.PrintStatus(s, "Skipped    ", opts.Verbose); err != nil {
 							return nil, err
 						}
 					}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -135,12 +135,11 @@ func runPull(opts pullOptions) error {
 				}
 				// Skip s if s is unnamed and has no successors.
 				if len(ss) == 0 {
-					if _, exists := printed.Load(s.Digest.String()); !exists {
+					if _, loaded := printed.LoadOrStore(s.Digest.String(), true); !loaded {
 						err = display.PrintStatus(s, "Skipped    ", opts.Verbose)
 						if err != nil {
 							return nil, err
 						}
-						printed.Store(s.Digest.String(), true)
 					}
 					continue
 				}


### PR DESCRIPTION
Print digest and media type when content is skipped, and use sync.Map to ensure skipped content is printed only once.

Part of issue #415 
Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>