### PR TITLE
fix: print post-copy logs for unnamed content in verbose mode

### DIFF
--- a/cmd/oras/internal/display/print.go
+++ b/cmd/oras/internal/display/print.go
@@ -45,6 +45,7 @@ func StatusPrinter(status string, verbose bool) func(context.Context, ocispec.De
 func PrintStatus(desc ocispec.Descriptor, status string, verbose bool) error {
 	name, ok := desc.Annotations[ocispec.AnnotationTitle]
 	if !ok {
+		// no status for unnamed content
 		if !verbose {
 			return nil
 		}

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -153,9 +153,14 @@ func runPull(opts pullOptions) error {
 	copyOptions.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		name := desc.Annotations[ocispec.AnnotationTitle]
 		if name == "" {
-			return nil
+			if !opts.Verbose {
+				return nil
+			}
+			name = desc.MediaType
+		} else {
+			// named content downloaded
+			pulledEmpty = false
 		}
-		pulledEmpty = false
 		return display.Print("Downloaded ", display.ShortDigest(desc), name)
 	}
 

--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -151,8 +151,8 @@ func runPull(opts pullOptions) error {
 	pulledEmpty := true
 	copyOptions.PreCopy = display.StatusPrinter("Downloading", opts.Verbose)
 	copyOptions.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
-		name := desc.Annotations[ocispec.AnnotationTitle]
-		if name == "" {
+		name, ok := desc.Annotations[ocispec.AnnotationTitle]
+		if !ok {
 			if !opts.Verbose {
 				return nil
 			}


### PR DESCRIPTION
The verbose flag should work properly when unnamed content is skipped or downloaded. It currently does not. Example: this "downloading" is not paired with a "downloaded".

<img width="716" alt="Screen Shot 2022-08-19 at 12 02 50" src="https://user-images.githubusercontent.com/103478229/185543513-da7aaf0f-54f8-4418-bd86-ae4aeb2779cc.png">


Part of issue #415 

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>