### PR TITLE
build: license header check in workflows

### DIFF
--- a/.github/workflows/license-checker.yaml
+++ b/.github/workflows/license-checker.yaml
@@ -1,0 +1,27 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: license-header-check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-license-eye:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Check License Header
+      uses: apache/skywalking-eyes/header@main


### PR DESCRIPTION
check the license header for ORAS and its dependencies in Github workflows

Resolves: #435 
Signed-off-by: JasmineTang <jasminetang@microsoft.com>