### PR TITLE
chore: upgrade oras-go

### DIFF
--- a/cmd/oras/manifest/fetch.go
+++ b/cmd/oras/manifest/fetch.go
@@ -18,12 +18,10 @@ package manifest
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
-	"oras.land/oras-go/v2/errdef"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/cas"
@@ -104,9 +102,6 @@ func fetchManifest(opts fetchOptions) error {
 		content, err = cas.FetchManifest(ctx, repo, opts.targetRef, targetPlatform)
 	}
 	if err != nil {
-		if targetPlatform != nil && errors.Is(err, errdef.ErrNotFound) {
-			return fmt.Errorf("no manifest with platform %s was found", opts.Platform.Platform)
-		}
 		return err
 	}
 	if opts.pretty {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
-	oras.land/oras-go/v2 v2.0.0-rc.2
+	oras.land/oras-go/v2 v2.0.0-rc.2.0.20220905143834-e413b922a410
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -67,5 +67,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-oras.land/oras-go/v2 v2.0.0-rc.2 h1:dks9BxPg6HQOxn5+jVNuTFl45FuYvHfLQ6wcP7hVRdE=
-oras.land/oras-go/v2 v2.0.0-rc.2/go.mod h1:IZRIoIJqkAH6x0pL3tVnpyPUyZgthjSyPcH2kgJvBMo=
+oras.land/oras-go/v2 v2.0.0-rc.2.0.20220905143834-e413b922a410 h1:spKPANrlfnsDqnrdvv9MhI2/gN6e+SuqCs1ttTn5MhA=
+oras.land/oras-go/v2 v2.0.0-rc.2.0.20220905143834-e413b922a410/go.mod h1:PrY+cCglzK/DrQoJUtxbYVbL94ZHecVS3eJR01RglpE=


### PR DESCRIPTION
Bump oras-go from rc2 to latest code
Remove error message on platform mismatch in fetch.go since https://github.com/oras-project/oras-go/pull/292 has already improve error message on platform mismatch in order to distinguish platform not found and manifest not found.

Signed-off-by: Zoey Li <zoeyli@microsoft.com>