### PR TITLE
refactor: use read only target to replace oras.Target for the target storage with caching

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -94,7 +94,7 @@ func runPull(opts pullOptions) error {
 	if repo.Reference.Reference == "" {
 		return errors.NewErrInvalidReference(repo.Reference)
 	}
-	var src oras.Target = repo
+	var src oras.ReadOnlyTarget = repo
 	if opts.cacheRoot != "" {
 		ociStore, err := oci.New(opts.cacheRoot)
 		if err != nil {

--- a/internal/cache/target.go
+++ b/internal/cache/target.go
@@ -34,15 +34,15 @@ func (fn closer) Close() error {
 
 // Cache target struct.
 type target struct {
-	oras.Target
+	oras.ReadOnlyTarget
 	cache content.Storage
 }
 
 // New generates a new target storage with caching.
-func New(source oras.Target, cache content.Storage) oras.Target {
+func New(source oras.ReadOnlyTarget, cache content.Storage) oras.ReadOnlyTarget {
 	t := &target{
-		Target: source,
-		cache:  cache,
+		ReadOnlyTarget: source,
+		cache:          cache,
 	}
 	if refFetcher, ok := source.(registry.ReferenceFetcher); ok {
 		return &referenceTarget{
@@ -61,7 +61,7 @@ func (t *target) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadC
 		return rc, nil
 	}
 
-	if rc, err = t.Target.Fetch(ctx, target); err != nil {
+	if rc, err = t.ReadOnlyTarget.Fetch(ctx, target); err != nil {
 		return nil, err
 	}
 
@@ -105,7 +105,7 @@ func (t *target) Exists(ctx context.Context, desc ocispec.Descriptor) (bool, err
 	if err == nil && exists {
 		return true, nil
 	}
-	return t.Target.Exists(ctx, desc)
+	return t.ReadOnlyTarget.Exists(ctx, desc)
 }
 
 // Cache referenceTarget struct.

--- a/internal/cas/fetch.go
+++ b/internal/cas/fetch.go
@@ -29,7 +29,7 @@ import (
 
 // FetchDescriptor fetches a minimal descriptor of reference from target.
 // If platform flag not empty, will fetch the specified platform.
-func FetchDescriptor(ctx context.Context, target oras.Target, reference string, p *ocispec.Platform) ([]byte, error) {
+func FetchDescriptor(ctx context.Context, target oras.ReadOnlyTarget, reference string, p *ocispec.Platform) ([]byte, error) {
 	desc, err := oras.Resolve(ctx, target, reference, oras.ResolveOptions{TargetPlatform: p})
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func FetchDescriptor(ctx context.Context, target oras.Target, reference string, 
 
 // FetchManifest fetches the manifest content of reference from target.
 // If platform flag not empty, will fetch the specified platform.
-func FetchManifest(ctx context.Context, target oras.Target, reference string, p *ocispec.Platform) ([]byte, error) {
+func FetchManifest(ctx context.Context, target oras.ReadOnlyTarget, reference string, p *ocispec.Platform) ([]byte, error) {
 	// TODO: improve implementation once oras-go#102 is resolved
 	if p == nil {
 		if rf, ok := target.(registry.ReferenceFetcher); ok {


### PR DESCRIPTION
Use `oras.ReadOnlyTarget` instead of `oras.Target` for the target storage with caching

Signed-off-by: Zoey Li <zoeyli@microsoft.com>