### PR TITLE
fix: add get alias for oras blob fetch command

### DIFF
--- a/cmd/oras/blob/fetch.go
+++ b/cmd/oras/blob/fetch.go
@@ -78,6 +78,7 @@ Example - Fetch blob from the insecure registry:
 			opts.cacheRoot = os.Getenv("ORAS_CACHE")
 			return opts.ReadPassword()
 		},
+		Aliases: []string{"get"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.targetRef = args[0]
 			return fetchBlob(opts)


### PR DESCRIPTION
Add `oras blob get` alias for `oras blob fetch` command

Resolves: https://github.com/oras-project/oras/issues/550
Signed-off-by: Zoey Li <zoeyli@microsoft.com>