### PR TITLE
fix: fix flag name parsing error for oras blob push

### DIFF
--- a/cmd/oras/blob/push.go
+++ b/cmd/oras/blob/push.go
@@ -89,7 +89,7 @@ Example - Push blob without TLS:
 	}
 
 	cmd.Flags().Int64VarP(&opts.size, "size", "", -1, "provide the blob size")
-	cmd.Flags().StringVarP(&opts.mediaType, "media-type", "", ocispec.MediaTypeImageLayer, "specify the returned media type in the descriptor if `--descriptor` is used")
+	cmd.Flags().StringVarP(&opts.mediaType, "media-type", "", ocispec.MediaTypeImageLayer, "specify the returned media type in the descriptor if --descriptor is used")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return cmd
 }


### PR DESCRIPTION
From:
![image](https://user-images.githubusercontent.com/108315938/191907570-0e21fd1f-d4b5-47aa-b0d4-34e6f9817d55.png)
to:
![image](https://user-images.githubusercontent.com/108315938/191907606-d4af6784-a50f-4c38-9812-d71de259bf90.png)


Resolves: https://github.com/oras-project/oras/issues/613
Signed-off-by: Zoey Li <zoeyli@microsoft.com>