### PR TITLE
fix: capitalize the short and log doc for tag command

### DIFF
--- a/cmd/oras/tag/tag.go
+++ b/cmd/oras/tag/tag.go
@@ -36,8 +36,8 @@ func TagCmd() *cobra.Command {
 	var opts tagOptions
 	cmd := &cobra.Command{
 		Use:   "tag [flags] <name>{:<tag>|@<digest>} <new_tag> [...]",
-		Short: "[Preview] tag a manifest in the remote registry",
-		Long: `[Preview] tag a manifest in the remote registry
+		Short: "[Preview] Tag a manifest in the remote registry",
+		Long: `[Preview] Tag a manifest in the remote registry
 
 ** This command is in preview and under development. **
 


### PR DESCRIPTION
Signed-off-by: Billy Zha <jinzha1@microsoft.com>