### PR TITLE
bump: upgrade golang to 1.19.2

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.0'
+          go-version: '1.19.2'
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.19.0-alpine as builder
+FROM docker.io/library/golang:1.19.2-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras


### PR DESCRIPTION
This PR bumps golang version used by go releaser and buildx.

Resolves: #647
Signed-off-by: Billy Zha <jinzha1@microsoft.com>