### PR TITLE
feat!: support OCI image fallback for `oras push` and `oras attach`

### DIFF
--- a/cmd/oras/push.go
+++ b/cmd/oras/push.go
@@ -17,8 +17,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -27,12 +29,10 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/errcode"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/option"
-)
-
-const (
-	tagStaged = "staged"
 )
 
 type pushOptions struct {
@@ -120,64 +120,19 @@ func runPush(opts pushOptions) error {
 		return err
 	}
 
-	// Prepare manifest
+	// prepare pack
+	packOpts := oras.PackOptions{
+		ConfigAnnotations:   annotations[option.AnnotationConfig],
+		ManifestAnnotations: annotations[option.AnnotationManifest],
+	}
 	store := file.New("")
 	defer store.Close()
 	store.AllowPathTraversalOnWrite = opts.PathValidationDisabled
-
-	// Ready to push
-	copyOptions := oras.DefaultCopyOptions
-	copyOptions.Concurrency = opts.concurrency
-	updateDisplayOption(&copyOptions.CopyGraphOptions, store, opts.Verbose)
-	desc, err := packManifest(ctx, store, annotations, &opts)
-	if err != nil {
-		return err
-	}
-
-	// Push
-	dst, err := opts.NewRepository(opts.targetRef, opts.Common)
-	if err != nil {
-		return err
-	}
-	if tag := dst.Reference.Reference; tag == "" {
-		err = oras.CopyGraph(ctx, store, dst, desc, copyOptions.CopyGraphOptions)
-	} else {
-		desc, err = oras.Copy(ctx, store, tagStaged, dst, tag, copyOptions)
-	}
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Pushed", opts.targetRef)
-
-	if len(opts.extraRefs) != 0 {
-		contentBytes, err := content.FetchAll(ctx, store, desc)
-		if err != nil {
-			return err
-		}
-		tagBytesNOpts := oras.DefaultTagBytesNOptions
-		tagBytesNOpts.Concurrency = opts.concurrency
-		if _, err = oras.TagBytesN(ctx, &display.TagManifestStatusPrinter{Repository: dst}, desc.MediaType, contentBytes, opts.extraRefs, tagBytesNOpts); err != nil {
-			return err
-		}
-	}
-
-	fmt.Println("Digest:", desc.Digest)
-
-	// Export manifest
-	return opts.ExportManifest(ctx, store, desc)
-}
-
-func packManifest(ctx context.Context, store *file.Store, annotations map[string]map[string]string, opts *pushOptions) (ocispec.Descriptor, error) {
-	var packOpts oras.PackOptions
-	packOpts.ConfigAnnotations = annotations[option.AnnotationConfig]
-	packOpts.ManifestAnnotations = annotations[option.AnnotationManifest]
-
 	if opts.manifestConfigRef != "" {
-		path, mediatype := parseFileReference(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
-		desc, err := store.Add(ctx, option.AnnotationConfig, mediatype, path)
+		path, cfgMediaType := parseFileReference(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
+		desc, err := store.Add(ctx, option.AnnotationConfig, cfgMediaType, path)
 		if err != nil {
-			return ocispec.Descriptor{}, err
+			return err
 		}
 		desc.Annotations = packOpts.ConfigAnnotations
 		packOpts.ConfigDescriptor = &desc
@@ -185,19 +140,59 @@ func packManifest(ctx context.Context, store *file.Store, annotations map[string
 	}
 	descs, err := loadFiles(ctx, store, annotations, opts.FileRefs, opts.Verbose)
 	if err != nil {
-		return ocispec.Descriptor{}, err
+		return err
+	}
+	pack := func() (ocispec.Descriptor, error) {
+		root, err := oras.Pack(ctx, store, opts.artifactType, descs, packOpts)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		if err = store.Tag(ctx, root, root.Digest.String()); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		return root, nil
 	}
 
-	// pack artifact
-	manifestDesc, err := oras.Pack(ctx, store, opts.artifactType, descs, packOpts)
+	// prepare push
+	dst, err := opts.NewRepository(opts.targetRef, opts.Common)
 	if err != nil {
-		return ocispec.Descriptor{}, err
+		return err
+	}
+	copyOptions := oras.DefaultCopyOptions
+	copyOptions.Concurrency = opts.concurrency
+	updateDisplayOption(&copyOptions.CopyGraphOptions, store, opts.Verbose)
+	copy := func(root ocispec.Descriptor) error {
+		if tag := dst.Reference.Reference; tag == "" {
+			err = oras.CopyGraph(ctx, store, dst, root, copyOptions.CopyGraphOptions)
+		} else {
+			_, err = oras.Copy(ctx, store, root.Digest.String(), dst, tag, copyOptions)
+		}
+		return err
 	}
 
-	if err = store.Tag(ctx, manifestDesc, tagStaged); err != nil {
-		return ocispec.Descriptor{}, err
+	// Push
+	root, err := pushArtifact(dst, pack, &packOpts, copy, &copyOptions.CopyGraphOptions, opts.Verbose)
+	if err != nil {
+		return err
 	}
-	return manifestDesc, nil
+	fmt.Println("Pushed", opts.targetRef)
+
+	if len(opts.extraRefs) != 0 {
+		contentBytes, err := content.FetchAll(ctx, store, root)
+		if err != nil {
+			return err
+		}
+		tagBytesNOpts := oras.DefaultTagBytesNOptions
+		tagBytesNOpts.Concurrency = opts.concurrency
+		if _, err = oras.TagBytesN(ctx, &display.TagManifestStatusPrinter{Repository: dst}, root.MediaType, contentBytes, opts.extraRefs, tagBytesNOpts); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Digest:", root.Digest)
+
+	// Export manifest
+	return opts.ExportManifest(ctx, store, root)
 }
 
 func updateDisplayOption(opts *oras.CopyGraphOptions, store content.Fetcher, verbose bool) {
@@ -214,4 +209,85 @@ func updateDisplayOption(opts *oras.CopyGraphOptions, store content.Fetcher, ver
 		}
 		return display.PrintStatus(desc, "Uploaded ", verbose)
 	}
+}
+
+type packFunc func() (ocispec.Descriptor, error)
+type copyFunc func(desc ocispec.Descriptor) error
+
+func pushArtifact(dst *remote.Repository, pack packFunc, packOpts *oras.PackOptions, copy copyFunc, copyOpts *oras.CopyGraphOptions, verbose bool) (ocispec.Descriptor, error) {
+	root, err := pack()
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	copyRootAttempted := false
+	preCopy := copyOpts.PreCopy
+	copyOpts.PreCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
+		if content.Equal(root, desc) {
+			copyRootAttempted = true
+		}
+		return preCopy(ctx, desc)
+	}
+
+	// push
+	if err = copy(root); err == nil {
+		return root, nil
+	}
+
+	if !copyRootAttempted || !isArtifactUnsupported(err) {
+		return ocispec.Descriptor{}, err
+	}
+
+	if err := display.PrintStatus(root, "Fallback ", verbose); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	dst.SetReferrersCapability(false)
+	packOpts.PackImageManifest = true
+	root, err = pack()
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if content.Equal(node, root) {
+			// skip non-config
+			content, err := content.FetchAll(ctx, fetcher, root)
+			if err != nil {
+				return nil, err
+			}
+			var manifest ocispec.Manifest
+			if err := json.Unmarshal(content, &manifest); err != nil {
+				return nil, err
+			}
+			return []ocispec.Descriptor{manifest.Config}, nil
+		}
+
+		// config has no successors
+		return nil, nil
+	}
+	err = copy(root)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return root, nil
+}
+
+func isArtifactUnsupported(err error) bool {
+	var errResp *errcode.ErrorResponse
+	if !errors.As(err, &errResp) || errResp.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	var errCode errcode.Error
+	if !errors.As(errResp, &errCode) {
+		return false
+	}
+
+	// As of November 2022, ECR is known to return UNSUPPORTED error when
+	// putting an OCI artifact manifest.
+	switch errCode.Code {
+	case errcode.ErrorCodeManifestInvalid, errcode.ErrorCodeUnsupported:
+		return true
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
-	oras.land/oras-go/v2 v2.0.0-rc.3.0.20221018111647-1969551cc3c7
+	oras.land/oras-go/v2 v2.0.0-rc.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -63,5 +63,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-oras.land/oras-go/v2 v2.0.0-rc.3.0.20221018111647-1969551cc3c7 h1:5ikyoiiYKWxQCxitZ+ZQ6KdxknZj1MdG+CX3iPGBrvw=
-oras.land/oras-go/v2 v2.0.0-rc.3.0.20221018111647-1969551cc3c7/go.mod h1:YGHvWBGuqRlZgUyXUIoKsR3lcuCOb3DAtG0SEsEw1iY=
+oras.land/oras-go/v2 v2.0.0-rc.4 h1:hg/R2znUQ1+qd43gRmL16VeX1GIZ8hQlLalBjYhhKSk=
+oras.land/oras-go/v2 v2.0.0-rc.4/go.mod h1:YGHvWBGuqRlZgUyXUIoKsR3lcuCOb3DAtG0SEsEw1iY=


### PR DESCRIPTION
Since oras-go will take care of fallback with tag schema if referrer API not supported, this PR provides OCI Image fallback when-and-only-when OCI artifact is not supported.

Resolves: #654 