### PR TITLE
fix: mandates empty referrer to empty array

### DIFF
--- a/cmd/oras/discover.go
+++ b/cmd/oras/discover.go
@@ -130,7 +130,7 @@ func runDiscover(opts discoverOptions) error {
 }
 
 func fetchReferrers(ctx context.Context, repo *remote.Repository, desc ocispec.Descriptor, artifactType string) ([]ocispec.Descriptor, error) {
-	var results []ocispec.Descriptor
+	results := []ocispec.Descriptor{}
 	err := repo.Referrers(ctx, desc, artifactType, func(referrers []ocispec.Descriptor) error {
 		results = append(results, referrers...)
 		return nil


### PR DESCRIPTION
Resolves: #728 

Signed-off-by: Billy Zha <jinzha1@microsoft.com>