### PR TITLE
feat: add s390x release and image to support s390x architecture

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: docker build
         run: |          
           docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ${{ steps.prepare.outputs.ref }} --push .
+          docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/s390x -t ${{ steps.prepare.outputs.ref }} --push .
       - name: clear
         if: always()
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,7 @@ builds:
   - amd64
   - arm64
   - arm
+  - s390x
   goarm:
   - '7'
   ignore:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GIT_COMMIT  = $(shell git rev-parse HEAD)
 GIT_TAG     = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 GIT_DIRTY   = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 
-TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz windows_amd64.zip
+TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz windows_amd64.zip
 
 LDFLAGS = -w
 ifdef VERSION
@@ -46,7 +46,7 @@ clean:
 build: build-linux build-mac build-windows
 
 .PHONY: build-linux
-build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm-v7
+build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm-v7 build-linux-s390x
 
 .PHONY: build-linux-amd64
 build-linux-amd64:
@@ -62,6 +62,11 @@ build-linux-arm64:
 build-linux-arm-v7:
 	GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/arm/v7/$(CLI_EXE) $(CLI_PKG)
+
+.PHONY: build-linux-s390x
+build-linux-s390x:
+	GOARCH=s390x CGO_ENABLED=0 GOOS=linux go build -v --ldflags="$(LDFLAGS)" \
+		-o bin/linux/s390x/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-mac
 build-mac: build-mac-arm64 build-mac-amd64


### PR DESCRIPTION
Resolves #731  

With this PR s390x release and image is added to oras. I build the binary and image for s390x and tested it on s390x architecture.

Binary:
```
[user@build oras]$ goreleaser build --snapshot
  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • building...                                    commit=09e997a40fdf09b262d9e7b8cd58ecc262926e07 latest tag=v0.0.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
      • DEPRECATED: `archives.rlcp` will be the default soon, check https://goreleaser.com/deprecations#archivesrlcp for more info
  • snapshotting
    • building snapshot...                           version=0.0.0-SNAPSHOT-09e997a
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/oras_darwin_arm64/oras
    • building                                       binary=dist/oras_darwin_amd64_v1/oras
    • building                                       binary=dist/oras_linux_amd64_v1/oras
    • building                                       binary=dist/oras_linux_arm64/oras
    • building                                       binary=dist/oras_linux_arm_7/oras
    • building                                       binary=dist/oras_linux_s390x/oras
    • building                                       binary=dist/oras_windows_amd64_v1/oras.exe
    • took: 3m43s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • your config is using deprecated properties, check logs above for details
  • build succeeded after 3m43s
[user@build oras]$ file dist/oras_linux_s390x/oras 
dist/oras_linux_s390x/oras: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, Go BuildID=yG4QVbt35EPXHWxRjOeK/p4YAbV8w75v-WxLDvCvq/_riPbUdJFM03kX7FOJcn/GfoRq8uhQrQu1jTuQLON, not stripped
```

```
[user@server ~]$ uname -a
Linux server 4.18.0-425.3.1.el8.s390x #1 SMP Fri Sep 30 11:35:32 EDT 2022 s390x s390x s390x GNU/Linux
[user@server ~]$ ./oras
Usage:
  oras [command]

Available Commands:
  attach      [Preview] Attach files to an existing artifact
  blob        [Preview] Blob operations
  completion  Generate the autocompletion script for the specified shell
  cp          [Preview] Copy artifacts from one target to another
  discover    [Preview] Discover referrers of a manifest in the remote registry
  help        Help about any command
  login       Log in to a remote registry
  logout      Log out from a remote registry
  manifest    [Preview] Manifest operations
  pull        Pull files from remote registry
  push        Push files to remote registry
  repo        [Preview] Repository operations
  tag         [Preview] Tag a manifest in the remote registry
  version     Show the oras version information

Flags:
  -h, --help   help for oras

Use "oras [command] --help" for more information about a command.
[user@server ~]$ ./oras version
Version:        0.0.0-SNAPSHOT-09e997a
Go version:     go1.18.8
Git commit:     09e997a40fdf09b262d9e7b8cd58ecc262926e07
Git tree state: clean
```

Image:
```
[user@build oras]$ docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/s390x -t private-registry/oras .
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
[+] Building 961.3s (55/55) FINISHED                                                                                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.1s
 => => transferring dockerfile: 1.11kB                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.1s
 => => transferring context: 2B                                                                                                                                                                               0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/alpine:3.15.4                                                                                                                                  0.8s
 => [linux/s390x internal] load metadata for docker.io/library/alpine:3.15.4                                                                                                                                  0.9s
 => [linux/arm/v7 internal] load metadata for docker.io/library/alpine:3.15.4                                                                                                                                 0.9s
 => [linux/s390x internal] load metadata for docker.io/library/golang:1.19.2-alpine                                                                                                                           1.0s
 => [linux/amd64 internal] load metadata for docker.io/library/alpine:3.15.4                                                                                                                                  1.0s
 => [linux/arm64 internal] load metadata for docker.io/library/golang:1.19.2-alpine                                                                                                                           1.0s
 => [linux/amd64 internal] load metadata for docker.io/library/golang:1.19.2-alpine                                                                                                                           0.9s
 => [linux/arm/v7 internal] load metadata for docker.io/library/golang:1.19.2-alpine                                                                                                                          0.9s
 => CACHED [linux/amd64 stage-1 1/5] FROM docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                             0.2s
 => => resolve docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                                                        0.2s
 => [linux/amd64 builder 1/6] FROM docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                            77.2s
 => => resolve docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                                                 0.3s
 => => sha256:861cc3991b26fba6073631f27a1dc32bb27761195d912d05ee2f14b86fdf923f 156B / 156B                                                                                                                    0.2s
 => => sha256:14bccb3a1cff3b5f09bf1f21ba9ecb17c96329fb82f96605d922cfa4c9a82032 122.25MB / 122.25MB                                                                                                           32.8s
 => => sha256:93c1e223e6f2123b855e0c95898eba50cb6a055881ba9023527c0a361761c1cf 153B / 153B                                                                                                                    0.3s
 => => sha256:4583459ba0371c715f926a9bbd37a9dae909234f4b898220160425131eb53bd4 284.73kB / 284.73kB                                                                                                            0.5s
 => => sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 2.81MB / 2.81MB                                                                                                                1.1s
 => => extracting sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49                                                                                                                     1.1s
 => => extracting sha256:4583459ba0371c715f926a9bbd37a9dae909234f4b898220160425131eb53bd4                                                                                                                     0.6s
 => => extracting sha256:93c1e223e6f2123b855e0c95898eba50cb6a055881ba9023527c0a361761c1cf                                                                                                                     0.1s
 => => extracting sha256:14bccb3a1cff3b5f09bf1f21ba9ecb17c96329fb82f96605d922cfa4c9a82032                                                                                                                    43.5s
 => => extracting sha256:861cc3991b26fba6073631f27a1dc32bb27761195d912d05ee2f14b86fdf923f                                                                                                                     0.3s
 => [internal] load build context                                                                                                                                                                             0.2s
 => => transferring context: 21.68kB                                                                                                                                                                          0.0s
 => [linux/arm/v7 builder 1/6] FROM docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                           80.7s
 => => resolve docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                                                 0.3s
 => => sha256:d533f790cdf46ba201e6ae0640634727e66d46ab09d7f56bcf66242bba4fd656 118.41MB / 118.41MB                                                                                                           43.9s
 => => sha256:f62601eba0f2135ba01bd7632b6cd5858fd87c654ebbd7aa446022efda221518 153B / 153B                                                                                                                    0.4s
 => => sha256:1bb4eb882dd734293a28e32a55182efac09a590954d1c7e0ac4e9afd668b950f 283.75kB / 283.75kB                                                                                                            0.6s
 => => sha256:c6556b3b6858c6fa1e328377cc2c4becdc9cd1bc3e7302aa7299936522cf93ba 2.42MB / 2.42MB                                                                                                                1.4s
 => => extracting sha256:c6556b3b6858c6fa1e328377cc2c4becdc9cd1bc3e7302aa7299936522cf93ba                                                                                                                     0.7s
 => => sha256:1c61e62f2b709ff977a2267df5d4696983ae815ab58342ed609147a12cea999a 125B / 125B                                                                                                                    0.4s
 => => extracting sha256:1bb4eb882dd734293a28e32a55182efac09a590954d1c7e0ac4e9afd668b950f                                                                                                                     0.6s
 => => extracting sha256:f62601eba0f2135ba01bd7632b6cd5858fd87c654ebbd7aa446022efda221518                                                                                                                     0.2s
 => => extracting sha256:d533f790cdf46ba201e6ae0640634727e66d46ab09d7f56bcf66242bba4fd656                                                                                                                    35.4s
 => => extracting sha256:1c61e62f2b709ff977a2267df5d4696983ae815ab58342ed609147a12cea999a                                                                                                                     0.2s
 => CACHED [linux/arm/v7 stage-1 1/5] FROM docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                            0.4s
 => => resolve docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                                                        0.3s
 => [linux/s390x builder 1/6] FROM docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                            81.4s
 => => resolve docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                                                 0.3s
 => => sha256:e365613c053faa0517c5a9a3a8561d8dc4efe2d2d1159866dae02b07eb9f38d3 155B / 155B                                                                                                                    0.3s
 => => sha256:d3229342a30d3f1b9300228f7e3414e521024d8294398cc78d68c228dc8d1c40 120.73MB / 120.73MB                                                                                                           39.0s
 => => sha256:b2788e533105e3c00ed84523a8f99d7947c0bb8b12932018a3081ecc29964605 154B / 154B                                                                                                                    1.1s
 => => sha256:99d31ae2e1f77c70a25e9cbeea435b4ab68149a4e17f9d4668768da8dd5ac68a 284.95kB / 284.95kB                                                                                                            0.9s
 => => sha256:790c84f1f3409eab952345157df7fa804ba6b5f06d4ceb6f2dfa3c6de2064397 2.59MB / 2.59MB                                                                                                                1.8s
 => => extracting sha256:790c84f1f3409eab952345157df7fa804ba6b5f06d4ceb6f2dfa3c6de2064397                                                                                                                     1.6s
 => => extracting sha256:99d31ae2e1f77c70a25e9cbeea435b4ab68149a4e17f9d4668768da8dd5ac68a                                                                                                                     1.5s
 => => extracting sha256:b2788e533105e3c00ed84523a8f99d7947c0bb8b12932018a3081ecc29964605                                                                                                                     0.2s
 => => extracting sha256:d3229342a30d3f1b9300228f7e3414e521024d8294398cc78d68c228dc8d1c40                                                                                                                    37.2s
 => => extracting sha256:e365613c053faa0517c5a9a3a8561d8dc4efe2d2d1159866dae02b07eb9f38d3                                                                                                                     0.1s
 => CACHED [linux/s390x stage-1 1/5] FROM docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                             0.4s
 => => resolve docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                                                        0.3s
 => [linux/arm64 builder 1/6] FROM docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                            79.2s
 => => resolve docker.io/library/golang:1.19.2-alpine@sha256:e4dcdac3ed37d8c2b3b8bcef2909573b2ad9c2ab53ba53c608909e8b89ccee36                                                                                 0.3s
 => => extracting sha256:9b18e9b68314027565b90ff6189d65942c0f7986da80df008b8431276885218e                                                                                                                     1.1s
 => => sha256:2835e8a4bb0ee851e16f1fa0345de53422948c82255c6d9c268d8393a61af5c7 116.83MB / 116.83MB                                                                                                           40.6s
 => => extracting sha256:35d82f9e3411d2eff49049d09ae871e53b96a0cc7dd335883f1fec28c43f9c86                                                                                                                     0.6s
 => => extracting sha256:e169736571560c1a3278f9971532d55ddc4abfaef12e8c54c05f4644445d5520                                                                                                                     0.2s
 => => extracting sha256:2835e8a4bb0ee851e16f1fa0345de53422948c82255c6d9c268d8393a61af5c7                                                                                                                    37.4s
 => => extracting sha256:c77bffb5b3d35cc58420bfab1e257ae1719aa061ddce01f06f28661f69d580bf                                                                                                                     0.1s
 => CACHED [linux/arm64 stage-1 1/5] FROM docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                             0.4s
 => => resolve docker.io/library/alpine:3.15.4@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454                                                                                        0.3s
 => [linux/amd64 stage-1 2/5] RUN apk --update add ca-certificates                                                                                                                                            9.1s
 => [linux/arm64 stage-1 2/5] RUN apk --update add ca-certificates                                                                                                                                           37.4s
 => [linux/s390x stage-1 2/5] RUN apk --update add ca-certificates                                                                                                                                           40.3s
 => [linux/arm/v7 stage-1 2/5] RUN apk --update add ca-certificates                                                                                                                                          47.4s
 => [linux/amd64 builder 2/6] RUN apk add git make                                                                                                                                                            5.8s
 => [linux/arm64 builder 2/6] RUN apk add git make                                                                                                                                                           19.3s
 => [linux/arm/v7 builder 2/6] RUN apk add git make                                                                                                                                                          18.6s
 => [linux/s390x builder 2/6] RUN apk add git make                                                                                                                                                           21.8s
 => [linux/amd64 builder 3/6] ADD . /oras                                                                                                                                                                     0.4s
 => [linux/amd64 builder 4/6] WORKDIR /oras                                                                                                                                                                   0.2s
 => [linux/amd64 builder 5/6] RUN make "build-$(echo linux/amd64 | tr / -)"                                                                                                                                  88.2s
 => [linux/arm64 builder 3/6] ADD . /oras                                                                                                                                                                     0.3s
 => [linux/arm64 builder 4/6] WORKDIR /oras                                                                                                                                                                   0.2s
 => [linux/arm64 builder 5/6] RUN make "build-$(echo linux/arm64 | tr / -)"                                                                                                                                 854.8s
 => [linux/arm/v7 builder 3/6] ADD . /oras                                                                                                                                                                    0.4s
 => [linux/arm/v7 builder 4/6] WORKDIR /oras                                                                                                                                                                  0.2s
 => [linux/arm/v7 builder 5/6] RUN make "build-$(echo linux/arm/v7 | tr / -)"                                                                                                                               842.3s
 => [linux/s390x builder 3/6] ADD . /oras                                                                                                                                                                     0.6s
 => [linux/s390x builder 4/6] WORKDIR /oras                                                                                                                                                                   0.3s
 => [linux/s390x builder 5/6] RUN make "build-$(echo linux/s390x | tr / -)"                                                                                                                                 854.6s
 => [linux/amd64 builder 6/6] RUN mv /oras/bin/linux/amd64/oras /go/bin/oras                                                                                                                                  0.6s
 => [linux/amd64 stage-1 3/5] COPY --from=builder /go/bin/oras /bin/oras                                                                                                                                      0.2s
 => [linux/amd64 stage-1 4/5] RUN mkdir /workspace                                                                                                                                                            0.4s
 => [linux/amd64 stage-1 5/5] WORKDIR /workspace                                                                                                                                                              0.2s
 => [linux/arm/v7 builder 6/6] RUN mv /oras/bin/linux/arm/v7/oras /go/bin/oras                                                                                                                                0.8s
 => [linux/arm/v7 stage-1 3/5] COPY --from=builder /go/bin/oras /bin/oras                                                                                                                                     0.3s
 => [linux/arm/v7 stage-1 4/5] RUN mkdir /workspace                                                                                                                                                           0.7s
 => [linux/arm/v7 stage-1 5/5] WORKDIR /workspace                                                                                                                                                             0.3s
 => [linux/arm64 builder 6/6] RUN mv /oras/bin/linux/arm64/oras /go/bin/oras                                                                                                                                  0.5s
 => [linux/arm64 stage-1 3/5] COPY --from=builder /go/bin/oras /bin/oras                                                                                                                                      0.2s
 => [linux/arm64 stage-1 4/5] RUN mkdir /workspace                                                                                                                                                            0.5s
 => [linux/arm64 stage-1 5/5] WORKDIR /workspace                                                                                                                                                              0.2s
 => [linux/s390x builder 6/6] RUN mv /oras/bin/linux/s390x/oras /go/bin/oras                                                                                                                                  0.4s
 => [linux/s390x stage-1 3/5] COPY --from=builder /go/bin/oras /bin/oras                                                                                                                                      0.1s
 => [linux/s390x stage-1 4/5] RUN mkdir /workspace                                                                                                                                                            0.3s
 => [linux/s390x stage-1 5/5] WORKDIR /workspace
[user@build oras]$ docker push private-registry/oras:latest
The push refers to repository [private-registry/oras]
5f70bf18a086: Pushed 
6b07e616b9b1: Pushed 
bce454c7bcf8: Pushed 
9a4cf0b00b45: Pushed 
ef842a515ae1: Pushed 
latest: digest: sha256:a0381e38a3db523f62b1cf258c88158e12d9f037cc439896f88a62f66ee70013 size: 1363
```

```
[user@server ~]$ uname -a
Linux server 4.18.0-425.3.1.el8.s390x #1 SMP Fri Sep 30 11:35:32 EDT 2022 s390x s390x s390x GNU/Linux
[user@server ~]$ podman run -it private-registry/oras:latest
Usage:
  oras [command]

Available Commands:
  attach      [Preview] Attach files to an existing artifact
  blob        [Preview] Blob operations
  completion  Generate the autocompletion script for the specified shell
  cp          [Preview] Copy artifacts from one target to another
  discover    [Preview] Discover referrers of a manifest in the remote registry
  help        Help about any command
  login       Log in to a remote registry
  logout      Log out from a remote registry
  manifest    [Preview] Manifest operations
  pull        Pull files from remote registry
  push        Push files to remote registry
  repo        [Preview] Repository operations
  tag         [Preview] Tag a manifest in the remote registry
  version     Show the oras version information

Flags:
  -h, --help   help for oras

Use "oras [command] --help" for more information about a command.

[user@server ~]$ podman run -it private-registry/oras:latest version
Version:        0.16.0+unreleased
Go version:     go1.19.2
Git commit:     09e997a40fdf09b262d9e7b8cd58ecc262926e07
Git tree state: dirty
```