### PR TITLE
fix!: allow colon and back slash in unix file name

### DIFF
--- a/cmd/oras/internal/fileref/unix.go
+++ b/cmd/oras/internal/fileref/unix.go
@@ -43,7 +43,6 @@ func Parse(reference string, defaultMediaType string) (filePath, mediaType strin
 	return filePath, mediaType, nil
 }
 
-// isEscaped returns if the character in path with offset is escaped by '\'.
 func isEscaped(path string, offset int) bool {
 	cnt := 0
 	for i := offset - 1; i >= 0; i-- {

--- a/cmd/oras/internal/fileref/unix.go
+++ b/cmd/oras/internal/fileref/unix.go
@@ -24,14 +24,50 @@ import (
 
 // Parse parses file reference on unix.
 func Parse(reference string, defaultMediaType string) (filePath, mediaType string, err error) {
-	i := strings.LastIndex(reference, ":")
-	if i < 0 {
-		filePath, mediaType = reference, defaultMediaType
+	i := len(reference)
+	for {
+		// found the right most colon which is not escaped
+		i = strings.LastIndex(reference[:i], ":")
+		if i < 0 || !isEscaped(reference, i) {
+			break
+		}
+	}
+	if i < 0 || isEscaped(reference, i) {
+		filePath, mediaType = unescape(reference), defaultMediaType
 	} else {
-		filePath, mediaType = reference[:i], reference[i+1:]
+		filePath, mediaType = unescape(reference[:i]), reference[i+1:]
 	}
 	if filePath == "" {
 		return "", "", fmt.Errorf("found empty file path in %q", reference)
 	}
 	return filePath, mediaType, nil
+}
+
+// isEscaped returns if the character in path with offset is escaped by '\'.
+func isEscaped(path string, offset int) bool {
+	cnt := 0
+	for i := offset - 1; i >= 0; i-- {
+		if path[i] != '\\' {
+			break
+		}
+	}
+	return cnt%2 != 0
+}
+
+func unescape(path string) string {
+	len := len(path)
+	ret := ""
+	i := 0
+	for i < len {
+		if path[i] == '\\' {
+			if i < len-1 {
+				ret += string(path[i+1])
+			}
+			i += 2
+		} else {
+			ret += string(path[i])
+			i += 1
+		}
+	}
+	return ret
 }

--- a/cmd/oras/internal/fileref/unix.go
+++ b/cmd/oras/internal/fileref/unix.go
@@ -49,6 +49,7 @@ func isEscaped(path string, offset int) bool {
 		if path[i] != '\\' {
 			break
 		}
+		cnt++
 	}
 	return cnt%2 != 0
 }

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,7 +36,8 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
-		{"colon file name with backslash and media type with backslash", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
+		{"colon file name with backslash and media type", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
+		{"colon file name with backslash", args{`az\\\\:b`, "c"}, `az\\`, `b`},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
 		{"colon-prefix file name and media type", args{":az:b:c", "d"}, ":az:b", "c"},
 

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,7 +36,7 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
-		{"colon file name with escape char and media type", args{`az\\\:b:c`, "d"}, `az\:b`, "c"},
+		{"colon file name with backslash and media type with backslash", args{`az\\\:b:c\\d`, "d"}, `az\:b`, "c\d"},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
 		{"colon-prefix file name and media type", args{":az:b:c", "d"}, ":az:b", "c"},
 
@@ -98,8 +98,8 @@ func Test_unescape(t *testing.T) {
 		want  string
 	}{
 		{"empty string", "", ""},
-		{"only escape char", "\\", ""},
-		{"double escape char", `\\`, `\`},
+		{"only backslash", "\\", ""},
+		{"double backslash", `\\`, `\`},
 		{"escaping t", `\t\t`, "tt"},
 		{"not escaping 1st t", `\\t\t`, `\tt`},
 		{"not escaping 2nd t", `\t\\t`, `t\t`},

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,6 +36,7 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
+		{"colon file name and default media type", args{`az\:`, "b"}, "az:", ""},
 		{"colon file name with backslash and media type1", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
 		{"colon file name with backslash and media type2", args{`az\\\\:b`, "c"}, `az\\`, `b`},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
@@ -108,7 +109,7 @@ func Test_unescape(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := unescape(tt.input)
 			if got != tt.want {
-				t.Errorf("Parse() gotFilePath = %v, want %v", got, tt.want)
+				t.Errorf("unescape() gotFilePath = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -19,7 +19,7 @@ package fileref
 
 import "testing"
 
-func Test_ParseFileReference(t *testing.T) {
+func Test_Parse_fileReference(t *testing.T) {
 	type args struct {
 		reference string
 		mediaType string
@@ -35,7 +35,8 @@ func Test_ParseFileReference(t *testing.T) {
 		{"file name and default media type", args{"az", "c"}, "az", "c"},
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
-		{"colon file name and media type", args{"az:b:c", "d"}, "az:b", "c"},
+		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
+		{"colon file name with escape char and media type", args{`az\\\:b:c`, "d"}, `az\:b`, "c"},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
 		{"colon-prefix file name and media type", args{":az:b:c", "d"}, ":az:b", "c"},
 
@@ -55,7 +56,7 @@ func Test_ParseFileReference(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
+func Test_Parse_err(t *testing.T) {
 	type args struct {
 		reference string
 		mediaType string
@@ -88,3 +89,28 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+
+func Test_unescape(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty string", "", ""},
+		{"only escape char", "\\", ""},
+		{"double escape char", `\\`, `\`},
+		{"escaping t", `\t\t`, "tt"},
+		{"not escaping 1st t", `\\t\t`, `\tt`},
+		{"not escaping 2nd t", `\t\\t`, `t\t`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unescape(tt.input)
+			if got != tt.want {
+				t.Errorf("Parse() gotFilePath = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,7 +36,7 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
-		{"colon file name with backslash and media type with backslash", args{`az\\\:b:c\\d`, "d"}, `az\:b`, "c\d"},
+		{"colon file name with backslash and media type with backslash", args{`az\\\:b:c\\d`, "d"}, `az\:b`, `c\d`},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
 		{"colon-prefix file name and media type", args{":az:b:c", "d"}, ":az:b", "c"},
 

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,8 +36,8 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
-		{"colon file name with backslash and media type", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
-		{"colon file name with backslash", args{`az\\\\:b`, "c"}, `az\\`, `b`},
+		{"colon file name with backslash and media type1", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
+		{"colon file name with backslash and media type2", args{`az\\\\:b`, "c"}, `az\\`, `b`},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
 		{"colon-prefix file name and media type", args{":az:b:c", "d"}, ":az:b", "c"},
 
@@ -91,7 +91,6 @@ func Test_Parse_err(t *testing.T) {
 	}
 }
 
-
 func Test_unescape(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -114,4 +113,3 @@ func Test_unescape(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,7 +36,7 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
-		{"colon file name with backslash and media type with backslash", args{`az\\\:b:c\\d`, "d"}, `az\:b`, `c\d`},
+		{"colon file name with backslash and media type with backslash", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},
 		{"colon-prefix file name and media type", args{":az:b:c", "d"}, ":az:b", "c"},
 

--- a/cmd/oras/internal/fileref/unix_test.go
+++ b/cmd/oras/internal/fileref/unix_test.go
@@ -36,7 +36,7 @@ func Test_Parse_fileReference(t *testing.T) {
 		{"file name and media type, default type ignored", args{"az:b", "c"}, "az", "b"},
 		{"file name and empty media type, default type ignored", args{"az:", "c"}, "az", ""},
 		{"colon file name and media type", args{`az\:b:c`, "d"}, "az:b", "c"},
-		{"colon file name and default media type", args{`az\:`, "b"}, "az:", ""},
+		{"colon file name and default media type", args{`az\:`, "b"}, "az:", "b"},
 		{"colon file name with backslash and media type1", args{`az\\\:b:c`, "d"}, `az\:b`, `c`},
 		{"colon file name with backslash and media type2", args{`az\\\\:b`, "c"}, `az\\`, `b`},
 		{"colon file name and empty media type", args{"az:b:", "c"}, "az:b", ""},


### PR DESCRIPTION
Resolves #695

To provide a file name with colon(`:`) and media-type at the same time, we can use backslash(`\`) to escape the colon in the file name, taking `oras push` as an example:
```
oras push some.reg/repo:tag "my\:file:my.media.type" # will push a file named `my:file` with mediatype `my.media.type`
```

Backslash can be used to escape itself:

```
oras push some.reg/repo:tag "my\\file:my.media.type" # will push a file named `my\file` with mediatype `my.media.type`
```

The old workaround still works after this change:
```
oras push some.reg/repo:tag my:file:my.media.type: # will push a file named `my:file` with mediatype `my.media.type`
```

Signed-off-by: Billy Zha <jinzha1@microsoft.com>