### PR TITLE
feat: show annotations in `oras discover` tree format output

### DIFF
--- a/cmd/oras/discover.go
+++ b/cmd/oras/discover.go
@@ -153,8 +153,7 @@ func fetchAllReferrers(ctx context.Context, repo *remote.Repository, desc ocispe
 		referrerNode := node.AddPath(r.ArtifactType, r.Digest)
 		if opts.Verbose {
 			for k, v := range r.Annotations {
-				v := map[string]string{k: v}
-				bytes, err := yaml.Marshal(v)
+				bytes, err := yaml.Marshal(map[string]string{k: v})
 				if err != nil {
 					return err
 				}

--- a/cmd/oras/discover.go
+++ b/cmd/oras/discover.go
@@ -150,6 +150,9 @@ func fetchAllReferrers(ctx context.Context, repo *remote.Repository, desc ocispe
 	for _, r := range results {
 		// Find all indirect referrers
 		referrerNode := node.AddPath(r.ArtifactType, r.Digest)
+		for a := range r.Annotations {
+			referrerNode.AddPathString(fmt.Sprintf("%s = %s", a, r.Annotations[a]))
+		}
 		err := fetchAllReferrers(
 			ctx, repo,
 			ocispec.Descriptor{

--- a/cmd/oras/discover.go
+++ b/cmd/oras/discover.go
@@ -152,8 +152,8 @@ func fetchAllReferrers(ctx context.Context, repo *remote.Repository, desc ocispe
 		// Find all indirect referrers
 		referrerNode := node.AddPath(r.ArtifactType, r.Digest)
 		if opts.Verbose {
-			for k := range r.Annotations {
-				v := map[string]string{k: r.Annotations[k]}
+			for k, v := range r.Annotations {
+				v := map[string]string{k: v}
 				bytes, err := yaml.Marshal(v)
 				if err != nil {
 					return err

--- a/cmd/oras/discover.go
+++ b/cmd/oras/discover.go
@@ -158,7 +158,7 @@ func fetchAllReferrers(ctx context.Context, repo *remote.Repository, desc ocispe
 				if err != nil {
 					return err
 				}
-				referrerNode.AddPathString(string(bytes))
+				referrerNode.AddPathString(strings.TrimSpace(string(bytes)))
 			}
 		}
 		err := fetchAllReferrers(

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.0.0-rc.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR enriches tree output of `oras discover`. Artifact annotations will be shown in yaml format if `--verbose` flag is set.

Resolves #631
```
$ IMAGE="localhost:5000/test:anno"
$ oras-demo push $IMAGE image
Uploading 254eddf15d95 image
Uploaded  254eddf15d95 image
Pushed localhost:5000/test:anno
Digest: sha256:93305aefab90f837c555e42afcce5a3d92e23180d5dc64e37363d78d65c93306
$ oras-demo attach $IMAGE sig -a "key: "="value ' " --artifact-type test.anno
Uploading 0a017e570e0b sig
Uploaded  0a017e570e0b sig
Attached to localhost:5000/test@sha256:93305aefab90f837c555e42afcce5a3d92e23180d5dc64e37363d78d65c93306
Digest: sha256:0f6ac3195806949d22ac6eaab804fa4fd5c25974acdfb003ddb4f24cc1b6da62
$ oras-demo attach $IMAGE -a "key"="value" --artifact-type test.anno
Uploading empty artifact
Attached to localhost:5000/test@sha256:93305aefab90f837c555e42afcce5a3d92e23180d5dc64e37363d78d65c93306
Digest: sha256:b9311291861ce206db11fdaf30a28492bac6a66b38b2183b17557cb49c7e18c2
$ oras-demo discover $IMAGE -o tree
localhost:5000/test:anno
└── test.anno
    ├── sha256:0f6ac3195806949d22ac6eaab804fa4fd5c25974acdfb003ddb4f24cc1b6da62
    └── sha256:b9311291861ce206db11fdaf30a28492bac6a66b38b2183b17557cb49c7e18c2
$ oras-demo discover $IMAGE -o tree -v
localhost:5000/test:anno
└── test.anno
    ├── sha256:0f6ac3195806949d22ac6eaab804fa4fd5c25974acdfb003ddb4f24cc1b6da62
    │   ├── 'key: ': 'value '' '
    │   └── org.opencontainers.image.created: "2023-01-09T02:24:17Z"
    └── sha256:b9311291861ce206db11fdaf30a28492bac6a66b38b2183b17557cb49c7e18c2
        ├── key: value
        └── org.opencontainers.image.created: "2023-01-09T02:24:37Z"
```
Signed-off-by: Billy Zha <jinzha1@microsoft.com>