### PR TITLE
fix: fix bugs related to the spec `--distribution-spec`

### DIFF
--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -92,6 +92,7 @@ Example - Attach file to the manifest tagged 'v1' in an OCI layout folder 'layou
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
 	cmd.MarkFlagRequired("artifact-type")
+	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())
 	return cmd
 }

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -105,7 +105,10 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 
 // Parse tries to read password with optional cmd prompt.
 func (opts *Remote) Parse() error {
-	return opts.readPassword()
+	if err := opts.readPassword(); err != nil {
+		return err
+	}
+	return opts.distributionSpec.Parse()
 }
 
 // readPassword tries to read password with optional cmd prompt.

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -17,7 +17,6 @@ package option
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -84,9 +83,6 @@ func (opts *Target) Parse() error {
 	switch {
 	case opts.isOCILayout:
 		opts.Type = TargetTypeOCILayout
-		if opts.Remote.distributionSpec.referrersAPI != nil {
-			return errors.New("cannot enforce referrers API for image layout target")
-		}
 		return nil
 	default:
 		opts.Type = TargetTypeRemote

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -87,10 +87,11 @@ func (opts *Target) Parse() error {
 		if opts.Remote.distributionSpec.referrersAPI != nil {
 			return errors.New("cannot enforce referrers API for image layout target")
 		}
+		return nil
 	default:
 		opts.Type = TargetTypeRemote
+		return opts.Remote.Parse()
 	}
-	return nil
 }
 
 // parseOCILayoutReference parses the raw in format of <path>[:<tag>|@<digest>]


### PR DESCRIPTION
1. Fix flags `--from-distribution-spec` and `--to-distribution-spec` for `oras copy`
2. Fix the flag `--distribution-spec` for `oras attach`

This PR removes the check when specifying `--distribution-spec` for OCI layout.

Fixes: #770, #771 