### PR TITLE
bump: upgrade golang and alpine versions

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.19.2-alpine as builder
+FROM docker.io/library/golang:1.19.5-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR ${ORASPKG}
 RUN make "build-$(echo $TARGETPLATFORM | tr / -)"
 RUN mv ${ORASPKG}/bin/${TARGETPLATFORM}/oras /go/bin/oras
 
-FROM docker.io/library/alpine:3.15.4
+FROM docker.io/library/alpine:3.17.1
 RUN apk --update add ca-certificates
 COPY --from=builder /go/bin/oras /bin/oras
 RUN mkdir /workspace


### PR DESCRIPTION
1. Updated golang version to `1.19.5` for GitHub action
2. Updated golang version to `1.19.5` in dockerfile 
3. Updated alpine version to `3.17.1` in dockerfile

Signed-off-by: Sylvia Lei <lixlei@microsoft.com>