### PR TITLE
fix: Have make file fail with wrong go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CLI_PKG     = $(PROJECT_PKG)/cmd/oras
 GIT_COMMIT  = $(shell git rev-parse HEAD)
 GIT_TAG     = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 GIT_DIRTY   = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
+GO_EXE      = go
 
 TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz windows_amd64.zip
 
@@ -31,8 +32,8 @@ LDFLAGS += -X $(PROJECT_PKG)/internal/version.GitCommit=${GIT_COMMIT}
 LDFLAGS += -X $(PROJECT_PKG)/internal/version.GitTreeState=${GIT_DIRTY}
 
 .PHONY: test
-test: vendor check-encoding
-	go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+test: tidy vendor check-encoding
+	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: covhtml
 covhtml:
@@ -50,22 +51,22 @@ build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm-v7 build-linux-
 
 .PHONY: build-linux-amd64
 build-linux-amd64:
-	GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=amd64 CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/amd64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-linux-arm64
 build-linux-arm64:
-	GOARCH=arm64 CGO_ENABLED=0 GOOS=linux go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=arm64 CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/arm64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-linux-arm-v7
 build-linux-arm-v7:
-	GOARCH=arm CGO_ENABLED=0 GOOS=linux go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=arm CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/arm/v7/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-linux-s390x
 build-linux-s390x:
-	GOARCH=s390x CGO_ENABLED=0 GOOS=linux go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=s390x CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/s390x/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-mac
@@ -73,12 +74,12 @@ build-mac: build-mac-arm64 build-mac-amd64
 
 .PHONY: build-mac-amd64
 build-mac-amd64:
-	GOARCH=amd64 CGO_ENABLED=0 GOOS=darwin go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=amd64 CGO_ENABLED=0 GOOS=darwin $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/darwin/amd64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-mac-arm64
 build-mac-arm64:
-	GOARCH=arm64 CGO_ENABLED=0 GOOS=darwin go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=arm64 CGO_ENABLED=0 GOOS=darwin $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/darwin/arm64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-windows
@@ -86,12 +87,12 @@ build-windows: build-windows-amd64 build-windows-arm64
 
 .PHONY: build-windows-amd64
 build-windows-amd64:
-	GOARCH=amd64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=amd64 CGO_ENABLED=0 GOOS=windows $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/amd64/$(CLI_EXE).exe $(CLI_PKG)
 
 .PHONY: build-windows-arm64
 build-windows-arm64:
-	GOARCH=arm64 CGO_ENABLED=0 GOOS=windows go build -v --ldflags="$(LDFLAGS)" \
+	GOARCH=arm64 CGO_ENABLED=0 GOOS=windows $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/windows/arm64/$(CLI_EXE).exe $(CLI_PKG)
 
 .PHONY: check-encoding
@@ -102,9 +103,13 @@ check-encoding:
 fix-encoding:
 	find cmd internal -type f -name "*.go" -exec sed -i -e "s/\r//g" {} +
 
+.PHONY: tidy
+tidy:
+	GO111MODULE=on $(GO_EXE) mod tidy
+
 .PHONY: vendor
 vendor:
-	GO111MODULE=on go mod vendor
+	GO111MODULE=on $(GO_EXE) mod vendor
 
 .PHONY: fetch-dist
 fetch-dist:


### PR DESCRIPTION
Latest command `oras repository ls` requires go 1.20