### PR TITLE
feat!: disable auto type conversion for manifests

### DIFF
--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -160,26 +160,6 @@ func runAttach(opts attachOptions) error {
 			}
 			return content.Successors(ctx, fetcher, node)
 		}
-
-		if content.Equal(node, root) {
-			
-		}
-		if root.MediaType == ocispec.MediaTypeArtifactManifest {
-			graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-				if content.Equal(node, root) {
-					// skip subject
-					return descs, nil
-				}
-				return content.Successors(ctx, fetcher, node)
-			}
-		} else if root.MediaType == ocispec.MediaTypeImageManifest {
-			graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-				if content.Equal(node, root) {
-					// skip subject
-					return append(descs, 
-				return content.Successors(ctx, fetcher, node)
-			}
-		}
 		return oras.CopyGraph(ctx, store, dst, root, graphCopyOptions)
 	}
 

--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -152,6 +152,19 @@ func runAttach(opts attachOptions) error {
 				}
 				return content.Successors(ctx, fetcher, node)
 			}
+		} else if root.MediaType == ocispec.MediaTypeImageManifest {
+			graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				if content.Equal(node, root) {
+					// skip subject
+					// scratch config blob with content of `{}` (size of 2)
+					return append(descs, ocispec.Descriptor{
+						MediaType: "application/vnd.oci.example+json",
+						Digest:    `sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`,
+						Size:      2,
+						Data:      []byte(`{}`)}), nil
+				}
+				return content.Successors(ctx, fetcher, node)
+			}
 		}
 		return oras.CopyGraph(ctx, store, dst, root, graphCopyOptions)
 	}

--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -144,6 +144,26 @@ func runAttach(opts attachOptions) error {
 	graphCopyOptions.Concurrency = opts.concurrency
 	updateDisplayOption(&graphCopyOptions, store, opts.Verbose)
 	copy := func(root ocispec.Descriptor) error {
+		graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			if content.Equal(node, root) {
+				// skip duplicated Resolve on subject
+				successors := descs
+				if root.MediaType == ocispec.MediaTypeImageManifest {
+					successors = append(successors, ocispec.Descriptor{
+						// scratch config blob with content of `{}` (size of 2)
+						MediaType: "application/vnd.oci.example+json",
+						Digest:    `sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`,
+						Size:      2,
+						Data:      []byte(`{}`)})
+				}
+				return successors, nil
+			}
+			return content.Successors(ctx, fetcher, node)
+		}
+
+		if content.Equal(node, root) {
+			
+		}
 		if root.MediaType == ocispec.MediaTypeArtifactManifest {
 			graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 				if content.Equal(node, root) {
@@ -156,13 +176,7 @@ func runAttach(opts attachOptions) error {
 			graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 				if content.Equal(node, root) {
 					// skip subject
-					return append(descs, ocispec.Descriptor{
-						// scratch config blob with content of `{}` (size of 2)
-						MediaType: "application/vnd.oci.example+json",
-						Digest:    `sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`,
-						Size:      2,
-						Data:      []byte(`{}`)}), nil
-				}
+					return append(descs, 
 				return content.Successors(ctx, fetcher, node)
 			}
 		}

--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -156,8 +156,8 @@ func runAttach(opts attachOptions) error {
 			graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 				if content.Equal(node, root) {
 					// skip subject
-					// scratch config blob with content of `{}` (size of 2)
 					return append(descs, ocispec.Descriptor{
+						// scratch config blob with content of `{}` (size of 2)
 						MediaType: "application/vnd.oci.example+json",
 						Digest:    `sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a`,
 						Size:      2,

--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -156,7 +156,7 @@ func runAttach(opts attachOptions) error {
 		return oras.CopyGraph(ctx, store, dst, root, graphCopyOptions)
 	}
 
-	root, err := pushArtifact(dst, pack, &packOpts, copy, &graphCopyOptions, opts.ManifestMediaType == "", opts.Verbose)
+	root, err := pushArtifact(dst, pack, copy)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -148,7 +148,7 @@ func runAttach(opts attachOptions) error {
 		graphCopyOptions.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			if content.Equal(node, root) {
 				// skip duplicated Resolve on subject
-				successors, _, config, err := graph.Successors(ctx, fetcher, root)
+				successors, _, config, err := graph.Successors(ctx, fetcher, node)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -34,7 +34,7 @@ type ImageSpec struct {
 // Parse parses flags into the option.
 func (opts *ImageSpec) Parse() error {
 	switch opts.specFlag {
-	case "":
+	case "v1.1-auto":
 		opts.ManifestMediaType = ""
 	case "v1.1-image":
 		opts.ManifestMediaType = ocispec.MediaTypeImageManifest
@@ -48,7 +48,7 @@ func (opts *ImageSpec) Parse() error {
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&opts.specFlag, "image-spec", "", "specify manifest type for building artifact. options: v1.1-image, v1.1-artifact")
+	fs.StringVar(&opts.specFlag, "image-spec", "v1.1-artifact", "specify manifest type for building artifact. options: v1.1-image, v1.1-artifact, v1.1-auto")
 }
 
 // distributionSpec option struct.

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -48,7 +48,7 @@ func (opts *ImageSpec) Parse() error {
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&opts.specFlag, "image-spec", "v1.1-artifact", "specify manifest type for building artifact. options: v1.1-image, v1.1-artifact, v1.1-auto")
+	fs.StringVar(&opts.specFlag, "image-spec", "v1.1-image", "specify manifest type for building artifact. options: v1.1-image, v1.1-artifact, v1.1-auto")
 }
 
 // distributionSpec option struct.

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -34,8 +34,6 @@ type ImageSpec struct {
 // Parse parses flags into the option.
 func (opts *ImageSpec) Parse() error {
 	switch opts.specFlag {
-	case "v1.1-auto":
-		opts.ManifestMediaType = ""
 	case "v1.1-image":
 		opts.ManifestMediaType = ocispec.MediaTypeImageManifest
 	case "v1.1-artifact":
@@ -48,7 +46,7 @@ func (opts *ImageSpec) Parse() error {
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&opts.specFlag, "image-spec", "v1.1-image", "specify manifest type for building artifact. options: v1.1-image, v1.1-artifact, v1.1-auto")
+	fs.StringVar(&opts.specFlag, "image-spec", "v1.1-image", "specify manifest type for building artifact. options: v1.1-image, v1.1-artifact")
 }
 
 // distributionSpec option struct.

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -67,12 +67,12 @@ var _ = Describe("Remote registry users:", func() {
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
-			Binary("jq", ".blobs[]", "--compact-output").
+			Binary("jq", ".layers[]", "--compact-output").
 				MatchTrimmedContent(fmt.Sprintf(layerDescriptorTemplate, ocispec.MediaTypeImageLayer)).
 				WithInput(fetched).Exec()
 
 			fetched = ORAS("manifest", "fetch", Reference(Host, repo, extraTag)).Exec().Out
-			Binary("jq", ".blobs[]", "--compact-output").
+			Binary("jq", ".layers[]", "--compact-output").
 				MatchTrimmedContent(fmt.Sprintf(layerDescriptorTemplate, ocispec.MediaTypeImageLayer)).
 				WithInput(fetched).Exec()
 		})

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -50,7 +50,7 @@ var _ = Describe("Remote registry users:", func() {
 			}
 
 			ORAS("push", Reference(Host, repo, tag), files[1], "-v").
-				MatchStatus(statusKeys, true, 1).
+				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
 			Binary("jq", ".blobs[]", "--compact-output").
@@ -84,7 +84,6 @@ var _ = Describe("Remote registry users:", func() {
 			if err := CopyTestData(tempDir); err != nil {
 				panic(err)
 			}
-
 			ORAS("push", Reference(Host, repo, tag), files[1]+":"+layerType, "-v").
 				MatchStatus(statusKeys, true, 1).
 				WithWorkDir(tempDir).Exec()
@@ -104,7 +103,7 @@ var _ = Describe("Remote registry users:", func() {
 
 			exportPath := "packed.json"
 			ORAS("push", Reference(Host, repo, tag), files[1]+":"+layerType, "-v", "--export-manifest", exportPath).
-				MatchStatus(statusKeys, true, 1).
+				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out.Contents()
 			MatchFile(filepath.Join(tempDir, exportPath), string(fetched), DefaultTimeout)
@@ -159,7 +158,7 @@ var _ = Describe("Remote registry users:", func() {
 			}
 
 			ORAS("push", Reference(Host, repo, tag), files[1], "-v", "--annotation", fmt.Sprintf("%s=%s", key, value)).
-				MatchStatus(statusKeys, true, 1).
+				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
 

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	. "oras.land/oras/test/e2e/internal/utils"
 	"oras.land/oras/test/e2e/internal/utils/match"
@@ -54,7 +53,7 @@ var _ = Describe("Remote registry users:", func() {
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
 			Binary("jq", ".blobs[]", "--compact-output").
-				MatchTrimmedContent(fmt.Sprintf(layerDescriptorTemplate, ocispec.MediaTypeImageLayer)).
+				MatchTrimmedContent(fmt.Sprintf(layerDescriptorTemplate, "application/vnd.oci.image.layer.v1.tar")).
 				WithInput(fetched).Exec()
 		})
 
@@ -85,7 +84,7 @@ var _ = Describe("Remote registry users:", func() {
 				panic(err)
 			}
 			ORAS("push", Reference(Host, repo, tag), files[1]+":"+layerType, "-v").
-				MatchStatus(statusKeys, true, 1).
+				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
 			Binary("jq", ".blobs[]", "--compact-output").
@@ -162,7 +161,7 @@ var _ = Describe("Remote registry users:", func() {
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
 
-			Binary("jq", `.annotations|del(.["org.opencontainers.artifact.created"])`, "--compact-output").
+			Binary("jq", `.annotations|del(.["org.opencontainers.image.created"])`, "--compact-output").
 				MatchTrimmedContent(fmt.Sprintf(`{"%s":"%s"}`, key, value)).
 				WithInput(fetched).Exec()
 		})

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	. "oras.land/oras/test/e2e/internal/utils"
 	"oras.land/oras/test/e2e/internal/utils/match"

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -52,7 +52,7 @@ var _ = Describe("Remote registry users:", func() {
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
-			Binary("jq", ".blobs[]", "--compact-output").
+			Binary("jq", ".layers[]", "--compact-output").
 				MatchTrimmedContent(fmt.Sprintf(layerDescriptorTemplate, "application/vnd.oci.image.layer.v1.tar")).
 				WithInput(fetched).Exec()
 		})
@@ -87,7 +87,7 @@ var _ = Describe("Remote registry users:", func() {
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
-			Binary("jq", ".blobs[]", "--compact-output").
+			Binary("jq", ".layers[]", "--compact-output").
 				MatchTrimmedContent(fmt.Sprintf(layerDescriptorTemplate, layerType)).
 				WithInput(fetched).Exec()
 		})

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -64,7 +64,7 @@ var _ = Describe("Remote registry users:", func() {
 			extraTag := "2e2"
 
 			ORAS("push", fmt.Sprintf("%s,%s", Reference(Host, repo, tag), extraTag), files[1], "-v").
-				MatchStatus(statusKeys, true, 1).
+				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			fetched := ORAS("manifest", "fetch", Reference(Host, repo, tag)).Exec().Out
 			Binary("jq", ".blobs[]", "--compact-output").


### PR DESCRIPTION
This PR changes the default media type of `oras push` and `oras attach` by removing the auto-conversion of the manifest type.

Resolves #782 

Signed-off-by: Billy Zha <jinzha1@microsoft.com>