### PR TITLE
feat!: show subject digest in oras discover

### DIFF
--- a/cmd/oras/attach.go
+++ b/cmd/oras/attach.go
@@ -26,7 +26,6 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -164,14 +163,7 @@ func runAttach(opts attachOptions) error {
 
 	digest := subject.Digest.String()
 	if !strings.HasSuffix(opts.RawReference, digest) {
-		// Reassemble a reference with subject digest
-		if repo, ok := dst.(*remote.Repository); ok {
-			ref := repo.Reference
-			ref.Reference = subject.Digest.String()
-			opts.RawReference = ref.String()
-		} else if opts.Type == option.TargetTypeOCILayout {
-			opts.RawReference = fmt.Sprintf("%s@%s", opts.Path, subject.Digest)
-		}
+		opts.RawReference = fmt.Sprintf("%s@%s", opts.Path, subject.Digest)
 	}
 	fmt.Println("Attached to", opts.AnnotatedReference())
 	fmt.Println("Digest:", root.Digest)

--- a/cmd/oras/discover.go
+++ b/cmd/oras/discover.go
@@ -109,7 +109,7 @@ func runDiscover(opts discoverOptions) error {
 	}
 
 	if opts.outputType == "tree" {
-		root := tree.New(opts.Reference)
+		root := tree.New(fmt.Sprintf("%s@%s", opts.Path, desc.Digest))
 		err = fetchAllReferrers(ctx, repo, desc, opts.artifactType, root, &opts)
 		if err != nil {
 			return err

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -159,6 +159,9 @@ func (opts *Target) NewReadonlyTarget(ctx context.Context, common Common) (ReadO
 		if err != nil {
 			return nil, err
 		}
+		tmp := repo.Reference
+		tmp.Reference = ""
+		opts.Path = tmp.String()
 		opts.Reference = repo.Reference.Reference
 		return repo, nil
 	}

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -41,7 +41,7 @@ type Target struct {
 	RawReference string
 	Type         string
 	Reference    string //contains tag or digest
-	// contains
+	// Path contains
 	//  - path to the OCI image layout target, or
 	//  - registry and repository for the remote target
 	Path string

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -41,7 +41,10 @@ type Target struct {
 	RawReference string
 	Type         string
 	Reference    string //contains tag or digest
-	Path         string
+	// contains
+	//  - path to the OCI image layout target, or
+	//  - registry and repository for the remote target
+	Path string
 
 	isOCILayout bool
 }
@@ -118,6 +121,9 @@ func (opts *Target) NewTarget(common Common) (oras.GraphTarget, error) {
 		if err != nil {
 			return nil, err
 		}
+		tmp := repo.Reference
+		tmp.Reference = ""
+		opts.Path = tmp.String()
 		opts.Reference = repo.Reference.Reference
 		return repo, nil
 	}


### PR DESCRIPTION
Changes in this PR prints resolved digest for root node of tree-view output in `oras discover`.

Resolves #789

Signed-off-by: Billy Zha <jinzha1@microsoft.com>