### PR TITLE
feat: Add ability query tags for `oras repo tags` command

### DIFF
--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -56,7 +56,7 @@ Example - Show tags of the target OCI layout folder 'layout-dir':
 Example - Show tags of the target OCI layout archive 'layout.tar':
   oras repo tags --oci-layout layout.tar
 
-Example - Show tags also associated with a particular tagged resource:
+Example - Show tags associated with a particular tagged resource:
   oras repo tags localhost:5000/hello:latest
 
 Example - Show tags associated with a digest:
@@ -104,14 +104,15 @@ func showTags(opts showTagsOptions) error {
 				continue
 			}
 			if filter != "" {
+				if tag == opts.Reference {
+					fmt.Println(tag)
+					continue
+				}
 				desc, err := finder.Resolve(ctx, tag)
 				if err != nil {
 					return err
 				}
 				if desc.Digest.String() != filter {
-					continue
-				}
-				if tag == opts.Reference {
 					continue
 				}
 			}

--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -55,6 +55,12 @@ Example - Show tags of the target OCI layout folder 'layout-dir':
 
 Example - Show tags of the target OCI layout archive 'layout.tar':
   oras repo tags --oci-layout layout.tar
+
+Example - Show tags also associated with a particular tagged resource:
+  oras repo tags localhost:5000/hello:latest
+
+Example - Show tags associated with a digest:
+  oras repo tags localhost:5000/hello@sha256:c551125a624189
 `,
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"show-tags"},

--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -17,7 +17,6 @@ package repository
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/opencontainers/go-digest"
@@ -80,7 +79,7 @@ Example - Show tags associated with a digest:
 }
 
 func showTags(opts showTagsOptions) error {
-	ctx, _ := opts.SetLoggerLevel()
+	ctx, logger := opts.SetLoggerLevel()
 	finder, err := opts.NewReadonlyTarget(ctx, opts.Common)
 	if err != nil {
 		return err
@@ -97,7 +96,7 @@ func showTags(opts showTagsOptions) error {
 			}
 			filter = desc.Digest.String()
 		}
-		fmt.Fprintln(os.Stderr, "Tag query by reference may take a while")
+		logger.Infof("[Preview] Querying tags associated to %s, it may take a while.\n", filter)
 	}
 	return finder.Tags(ctx, opts.last, func(tags []string) error {
 		for _, tag := range tags {

--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -80,7 +80,8 @@ func showTags(opts showTagsOptions) error {
 	}
 	filter := ""
 	if opts.Reference != "" {
-		if isDigestTag(opts.Reference) {
+		_, err := digest.Parse(opts.Reference)
+		if err == nil {
 			filter = opts.Reference
 		} else {
 			desc, err := finder.Resolve(ctx, opts.Reference)
@@ -88,7 +89,6 @@ func showTags(opts showTagsOptions) error {
 				return err
 			}
 			filter = desc.Digest.String()
-			fmt.Println(filter)
 		}
 	}
 	return finder.Tags(ctx, opts.last, func(tags []string) error {

--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -61,7 +61,7 @@ Example - Show tags also associated with a particular tagged resource:
   oras repo tags localhost:5000/hello:latest
 
 Example - Show tags associated with a digest:
-  oras repo tags localhost:5000/hello@sha256:c551125a624189
+  oras repo tags localhost:5000/hello@sha256:c551125a624189cece9135981621f3f3144564ddabe14b523507bf74c2281d9b
 `,
 		Args:    cobra.ExactArgs(1),
 		Aliases: []string{"show-tags"},

--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -17,6 +17,7 @@ package repository
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/opencontainers/go-digest"
@@ -96,6 +97,7 @@ func showTags(opts showTagsOptions) error {
 			}
 			filter = desc.Digest.String()
 		}
+		fmt.Fprintln(os.Stderr, "Tag query by reference may take a while")
 	}
 	return finder.Tags(ctx, opts.last, func(tags []string) error {
 		for _, tag := range tags {

--- a/cmd/oras/repository/tags.go
+++ b/cmd/oras/repository/tags.go
@@ -29,6 +29,7 @@ type showTagsOptions struct {
 	option.Target
 
 	last             string
+	filter           string
 	excludeDigestTag bool
 }
 
@@ -68,6 +69,7 @@ Example - Show tags of the target OCI layout archive 'layout.tar':
 	}
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the tag specified by `last`")
 	cmd.Flags().BoolVar(&opts.excludeDigestTag, "exclude-digest-tags", false, "exclude all digest-like tags such as 'sha256-aaaa...'")
+	cmd.Flags().StringVar(&opts.filter, "filter", "", "get tags associated with specified tag or digest")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return cmd
 }
@@ -85,6 +87,15 @@ func showTags(opts showTagsOptions) error {
 		for _, tag := range tags {
 			if opts.excludeDigestTag && isDigestTag(tag) {
 				continue
+			}
+			if opts.filter != "" {
+				desc, err := finder.Resolve(ctx, tag)
+				if err != nil {
+					return err
+				}
+				if desc.Digest.String() != opts.filter {
+					continue
+				}
 			}
 			fmt.Println(tag)
 		}


### PR DESCRIPTION
Add a ability for the `oras repo tags` command to get the tags associated with a specified digest or tag. Given a tag, it will return the digest. Given a digest, it will return the tag.

Closes: https://github.com/oras-project/oras/issues/799

Signed-off-by: Terry Howe <tlhowe@amazon.com>