### PR TITLE
chore: move ParseRepoPath to internal package

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,42 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package repository
+
+import (
+	"fmt"
+	"strings"
+
+	"oras.land/oras-go/v2/registry"
+)
+
+func ParseRepoPath(rawReference string) (hostname, namespace string, err error) {
+	rawReference = strings.TrimSuffix(rawReference, "/")
+	if strings.Contains(rawReference, "/") {
+		var ref registry.Reference
+		ref, err = registry.ParseReference(rawReference)
+		if err != nil {
+			return
+		}
+		if ref.Reference != "" {
+			err = fmt.Errorf("tags or digests should not be provided")
+			return
+		}
+		hostname = ref.Registry
+		namespace = ref.Repository + "/"
+	} else {
+		hostname = rawReference
+	}
+	return
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -21,6 +21,7 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+// ParserRepoPath extracts hostname and namespace from rawReference.
 func ParseRepoPath(rawReference string) (hostname, namespace string, err error) {
 	rawReference = strings.TrimSuffix(rawReference, "/")
 	if strings.Contains(rawReference, "/") {

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -28,7 +28,6 @@ func Test_ParseRepoPath(t *testing.T) {
 		wantNamespace string
 		wantErr       bool
 	}{
-		// TODO: Add test cases.
 		{
 			name:          "hostname only",
 			args:          args{"testregistry.example.io"},

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -17,71 +17,70 @@ package repository
 
 import "testing"
 
-func Test_parseRepoPath(t *testing.T) {
+func Test_ParseRepoPath(t *testing.T) {
 	type args struct {
-		opts *repositoryOptions
-		arg  string
+		rawReference string
 	}
-	var testOpts repositoryOptions
 	tests := []struct {
 		name          string
 		args          args
-		wantErr       bool
 		wantHostname  string
 		wantNamespace string
+		wantErr       bool
 	}{
+		// TODO: Add test cases.
 		{
 			name:          "hostname only",
-			args:          args{&testOpts, "testregistry.example.io"},
+			args:          args{"testregistry.example.io"},
 			wantErr:       false,
 			wantHostname:  "testregistry.example.io",
 			wantNamespace: "",
 		},
 		{
 			name:          "hostname with trailing slash",
-			args:          args{&testOpts, "testregistry.example.io/"},
+			args:          args{"testregistry.example.io/"},
 			wantErr:       false,
 			wantHostname:  "testregistry.example.io",
 			wantNamespace: "",
 		},
 		{
 			name:          "hostname and repo",
-			args:          args{&testOpts, "testregistry.example.io/showcase"},
+			args:          args{"testregistry.example.io/showcase"},
 			wantErr:       false,
 			wantHostname:  "testregistry.example.io",
 			wantNamespace: "showcase/",
 		},
 		{
 			name:          "hostname and repo in a sub-namespace",
-			args:          args{&testOpts, "testregistry.example.io/showcase/beta"},
+			args:          args{"testregistry.example.io/showcase/beta"},
 			wantErr:       false,
 			wantHostname:  "testregistry.example.io",
 			wantNamespace: "showcase/beta/",
 		},
 		{
 			name:          "hostname and repo in a sub-namespace with trailing slash",
-			args:          args{&testOpts, "testregistry.example.io/showcase/beta/"},
+			args:          args{"testregistry.example.io/showcase/beta/"},
 			wantErr:       false,
 			wantHostname:  "testregistry.example.io",
 			wantNamespace: "showcase/beta/",
 		},
 		{
 			name:          "error when a tag is provided",
-			args:          args{&testOpts, "testregistry.example.io/showcase:latest"},
+			args:          args{"testregistry.example.io/showcase:latest"},
 			wantErr:       true,
 			wantHostname:  "",
 			wantNamespace: "",
 		},
 		{
 			name:          "error when a digest is provided",
-			args:          args{&testOpts, "testregistry.example.io/showcase:sha256:2e0e0fe1fb3edbcdddad941c90d2b51e25a6bcd593e82545441a216de7bfa834"},
+			args:          args{"testregistry.example.io/showcase:sha256:2e0e0fe1fb3edbcdddad941c90d2b51e25a6bcd593e82545441a216de7bfa834"},
 			wantErr:       true,
 			wantHostname:  "",
 			wantNamespace: "",
 		},
 		{
 			name:          "error when a malformed path is provided",
-			args:          args{&testOpts, "testregistry.example.io///showcase/"},
+			args:          args{"testregistry.example.io///showcase/"},
 			wantErr:       true,
 			wantHostname:  "",
 			wantNamespace: "",
@@ -89,16 +88,17 @@ func Test_parseRepoPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := parseRepoPath(tt.args.opts, tt.args.arg)
+			gotHostname, gotNamespace, err := ParseRepoPath(tt.args.rawReference)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseRepoPath() error = %v, wantErr %v", err, tt.wantErr)
-			} else if testOpts.hostname != tt.wantHostname {
-				t.Errorf("got incorrect hostname = %v, want %v", testOpts.hostname, tt.wantHostname)
-			} else if testOpts.namespace != tt.wantNamespace {
-				t.Errorf("got incorrect hostname = %v, want %v", testOpts.namespace, tt.wantNamespace)
+				return
 			}
-			testOpts.hostname = ""
-			testOpts.namespace = ""
+			if gotHostname != tt.wantHostname {
+				t.Errorf("parseRepoPath() gotHostname = %v, want %v", gotHostname, tt.wantHostname)
+			}
+			if gotNamespace != tt.wantNamespace {
+				t.Errorf("parseRepoPath() gotNamespace = %v, want %v", gotNamespace, tt.wantNamespace)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Putting it in `cmd/oras/internal` will trigger code coverage scan on command declaration code, which effects our code coverage.