### PR TITLE
chore: add Terry Howe as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @deitch @jdolitsky @sajayantony @shizhMSFT @stevelasker @qweeah
+* @deitch @jdolitsky @sajayantony @shizhMSFT @stevelasker @qweeah @TerryHowe

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,5 +2,6 @@
 
 Maintainers:
 - Billy Zha (@qweeah)
+- Terry Howe (@TerryHowe)
 
 [Owners](Owners.md) are also maintainers.


### PR DESCRIPTION
Nominate Terry Howe (@TerryHowe) as a maintainer of the `oras` repository.

Terry opened 8 issues and 8 PRs (2 merged) in the past 2 months. Terry is also active in other open issues.