### PR TITLE
docs: Add development environment section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 Documentation for the ORAS CLI is located on
 the project website: [oras.land/cli](https://oras.land/cli/)
 
+## Development Environment Setup
+
+Refer to the [development guide](https://oras.land/cli/5_developer_guide/) to get started [contributing to ORAS](https://oras.land/contributing/).
+
 ## Code of Conduct
 
 This project has adopted the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for further details.


### PR DESCRIPTION
Each ORAS sub-project should have a section in the README.md about setting up a development environment, since each sub-project is unique.