### PR TITLE
fix: lazy close file store

### DIFF
--- a/cmd/oras/pull.go
+++ b/cmd/oras/pull.go
@@ -199,6 +199,7 @@ func runPull(opts pullOptions) error {
 	if err != nil {
 		return err
 	}
+	defer dst.Close()
 	dst.AllowPathTraversalOnWrite = opts.PathTraversal
 	dst.DisableOverwrite = opts.KeepOldFiles
 


### PR DESCRIPTION
Fixes #815 
We should delete the temp file after pulling the image to reduce storage usage