### PR TITLE
fix: support binary target in `oras cp`

### DIFF
--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -66,7 +66,6 @@ func (opts *Remote) ApplyFlags(fs *pflag.FlagSet) {
 	opts.ApplyFlagsWithPrefix(fs, "", "")
 	fs.BoolVarP(&opts.PasswordFromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	fs.StringArrayVarP(&opts.headerFlags, "header", "H", nil, "add custom headers to requests")
-	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "customized DNS formatted in `host:port:address[:address_port]`")
 }
 
 func applyPrefix(prefix, description string) (flagPrefix, notePrefix string) {
@@ -98,6 +97,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.BoolVarP(&opts.Insecure, flagPrefix+"insecure", "", false, "allow connections to "+notePrefix+"SSL registry without certs")
 	fs.BoolVarP(&opts.PlainHTTP, flagPrefix+"plain-http", "", false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
+	fs.StringArrayVarP(&opts.resolveFlag, flagPrefix+"resolve", "", nil, "customized DNS for "+notePrefix+"registry, formatted in `host:port:address[:address_port]`")
 
 	if fs.Lookup("registry-config") == nil {
 		fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "`path` of the authentication file")

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -66,6 +66,7 @@ func (opts *Remote) ApplyFlags(fs *pflag.FlagSet) {
 	opts.ApplyFlagsWithPrefix(fs, "", "")
 	fs.BoolVarP(&opts.PasswordFromStdin, "password-stdin", "", false, "read password or identity token from stdin")
 	fs.StringArrayVarP(&opts.headerFlags, "header", "H", nil, "add custom headers to requests")
+	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "customized DNS formatted in `host:port:address[:address_port]`")
 }
 
 func applyPrefix(prefix, description string) (flagPrefix, notePrefix string) {
@@ -100,10 +101,6 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 
 	if fs.Lookup("registry-config") == nil {
 		fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "`path` of the authentication file")
-	}
-
-	if fs.Lookup("resolve") == nil {
-		fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "customized DNS formatted in `host:port:address[:address_port]`")
 	}
 }
 

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -194,12 +194,13 @@ func (opts *BinaryTarget) EnableDistributionSpecFlag() {
 func (opts *BinaryTarget) ApplyFlags(fs *pflag.FlagSet) {
 	opts.From.ApplyFlagsWithPrefix(fs, "from", "source")
 	opts.To.ApplyFlagsWithPrefix(fs, "to", "destination")
-	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "customized DNS formatted in `host:port:address[:address_port]`")
+	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "DNS rules formatted in `host:port:address[:address_port]`, can be overwritten by src or dest DNS rules")
 }
 
 // Parse parses user-provided flags and arguments into option struct.
 func (opts *BinaryTarget) Parse() error {
-	opts.From.resolveFlag = opts.resolveFlag
-	opts.To.resolveFlag = opts.resolveFlag
+	// resolve are parsed in array order, latter will overwrite former
+	opts.From.resolveFlag = append(opts.resolveFlag, opts.From.resolveFlag...)
+	opts.To.resolveFlag = append(opts.resolveFlag, opts.To.resolveFlag...)
 	return Parse(opts)
 }

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -179,8 +179,9 @@ func (opts *Target) EnsureReferenceNotEmpty() error {
 // BinaryTarget struct contains flags and arguments specifying two registries or
 // image layouts.
 type BinaryTarget struct {
-	From Target
-	To   Target
+	From        Target
+	To          Target
+	resolveFlag []string
 }
 
 // EnableDistributionSpecFlag set distribution specification flag as applicable.
@@ -193,9 +194,12 @@ func (opts *BinaryTarget) EnableDistributionSpecFlag() {
 func (opts *BinaryTarget) ApplyFlags(fs *pflag.FlagSet) {
 	opts.From.ApplyFlagsWithPrefix(fs, "from", "source")
 	opts.To.ApplyFlagsWithPrefix(fs, "to", "destination")
+	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "customized DNS formatted in `host:port:address[:address_port]`")
 }
 
 // Parse parses user-provided flags and arguments into option struct.
 func (opts *BinaryTarget) Parse() error {
+	opts.From.resolveFlag = opts.resolveFlag
+	opts.To.resolveFlag = opts.resolveFlag
 	return Parse(opts)
 }

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -194,7 +194,7 @@ func (opts *BinaryTarget) EnableDistributionSpecFlag() {
 func (opts *BinaryTarget) ApplyFlags(fs *pflag.FlagSet) {
 	opts.From.ApplyFlagsWithPrefix(fs, "from", "source")
 	opts.To.ApplyFlagsWithPrefix(fs, "to", "destination")
-	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "DNS rules formatted in `host:port:address[:address_port]`, can be overwritten by src or dest DNS rules")
+	fs.StringArrayVarP(&opts.resolveFlag, "resolve", "", nil, "base DNS rules formatted in `host:port:address[:address_port]` for --from-resolve and --to-resolve")
 }
 
 // Parse parses user-provided flags and arguments into option struct.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fix a bug in `oras cp`: when copying with `--resolve` provided for destination target, the provided value will be silently ignored.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #842 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
