### PR TITLE
fix!: support multiple config files in `oras cp`

### DIFF
--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -98,7 +98,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.BoolVarP(&opts.PlainHTTP, flagPrefix+"plain-http", "", false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
 	fs.StringArrayVarP(&opts.resolveFlag, flagPrefix+"resolve", "", nil, "customized DNS for "+notePrefix+"registry, formatted in `host:port:address[:address_port]`")
-	fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "`path` of the authentication file for "+notePrefix+"registry")
+	fs.StringArrayVarP(&opts.Configs, flagPrefix+"registry-config", "", nil, "`path` of the authentication file for "+notePrefix+"registry")
 }
 
 // Parse tries to read password with optional cmd prompt.

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -98,10 +98,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.BoolVarP(&opts.PlainHTTP, flagPrefix+"plain-http", "", false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
 	fs.StringArrayVarP(&opts.resolveFlag, flagPrefix+"resolve", "", nil, "customized DNS for "+notePrefix+"registry, formatted in `host:port:address[:address_port]`")
-
-	if fs.Lookup("registry-config") == nil {
-		fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "`path` of the authentication file")
-	}
+	fs.StringArrayVarP(&opts.Configs, "registry-config", "", nil, "`path` of the authentication file for "+notePrefix+"registry")
 }
 
 // Parse tries to read password with optional cmd prompt.

--- a/test/e2e/suite/auth/auth.go
+++ b/test/e2e/suite/auth/auth.go
@@ -30,7 +30,10 @@ var _ = Describe("Common registry user", Ordered, func() {
 
 		It("should run commands without logging in", func() {
 			RunWithoutLogin("attach", Host+"/repo:tag", "-a", "test=true", "--artifact-type", "doc/example")
-			RunWithoutLogin("copy", Host+"/repo:from", Host+"/repo:to")
+			ORAS("copy", Host+"/repo:from", Host+"/repo:to", "--from-registry-config", AuthConfigPath, "--to-registry-config", AuthConfigPath).
+				ExpectFailure().
+				MatchErrKeyWords("Error:", "credential required").
+				WithDescription("fail without logging in").Exec()
 			RunWithoutLogin("discover", Host+"/repo:tag")
 			RunWithoutLogin("push", "-a", "key=value", Host+"/repo:tag")
 			RunWithoutLogin("pull", Host+"/repo:tag")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in `oras cp`: Registry credential configuration file specified via `--registry-config` will not work for destination registry target. 

This pr introduces flags, `--from-registry-config` and `--to-registry-config`, for source and destination registry respectively when copying. Since docker config only supports storing one credential per config file, this feature will be useful when copying between repositories with different token scope requirement in the same registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #846 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [x]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
