### PR TITLE
bump: update go to 1.20.1

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20.0'
+          go-version: '1.20.1'
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.20.0-alpine as builder
+FROM docker.io/library/golang:1.20.1-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the go version of binary build and container build.

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
