### PR TITLE
chore: e2e test code clean

### DIFF
--- a/test/e2e/internal/utils/match/keywords.go
+++ b/test/e2e/internal/utils/match/keywords.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gbytes"
 )
 
@@ -45,6 +46,6 @@ func (want keywordMatcher) Match(got *gbytes.Buffer) {
 
 	if len(missed) != 0 {
 		fmt.Printf("Keywords missed: %v\n", missed)
-		panic("failed to match all keywords")
+		ginkgo.Fail("failed to match all keywords")
 	}
 }

--- a/test/e2e/internal/utils/match/request.go
+++ b/test/e2e/internal/utils/match/request.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 )
@@ -54,7 +55,7 @@ func (r requestHeaderMatcher) Match(got *gbytes.Buffer) {
 
 	if len(missed) != 0 {
 		fmt.Printf("Headers missed: %v\n", missed)
-		panic("failed to match all headers")
+		ginkgo.Fail("failed to match all headers")
 	}
 }
 

--- a/test/e2e/internal/utils/match/status.go
+++ b/test/e2e/internal/utils/match/status.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 )
@@ -76,7 +77,7 @@ func newStateMachine(cmd string) *stateMachine {
 		sm.addPath("Skipped")
 		sm.addPath("Exists")
 	default:
-		panic("Unrecognized cmd name " + cmd)
+		ginkgo.Fail("Unrecognized cmd name " + cmd)
 	}
 	return sm
 }

--- a/test/e2e/suite/command/custom_header.go
+++ b/test/e2e/suite/command/custom_header.go
@@ -64,10 +64,7 @@ var _ = Describe("Common registry users:", func() {
 		})
 		It("push", func() {
 			repo := headerTestRepo("push")
-			tempDir := GinkgoT().TempDir()
-			if err := CopyTestFiles(tempDir); err != nil {
-				panic(err)
-			}
+			tempDir := PrepareTempFiles()
 			ORAS("push", "-d", "-H", FoobarHeaderInput, "-H", AbHeaderInput,
 				RegistryRef(Host, repo, "latest"), "foobar/bar").
 				WithWorkDir(tempDir).MatchRequestHeaders(FoobarHeader, AbHeader).Exec()

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -51,11 +51,8 @@ var _ = Describe("Remote registry users:", func() {
 		}
 		It("should push files without customized media types", func() {
 			repo := fmt.Sprintf("%s/%s", repoPrefix, "no-mediatype")
-			tempDir := GinkgoT().TempDir()
+			tempDir := PrepareTempFiles()
 			ref := RegistryRef(Host, repo, tag)
-			if err := CopyTestFiles(tempDir); err != nil {
-				panic(err)
-			}
 
 			ORAS("push", ref, foobar.FileBarName, "-v").
 				MatchStatus(statusKeys, true, len(statusKeys)).

--- a/test/e2e/suite/scenario/oci_artifact.go
+++ b/test/e2e/suite/scenario/oci_artifact.go
@@ -31,10 +31,7 @@ var _ = Describe("Common OCI artifact users:", Ordered, func() {
 		tag := "artifact"
 		var tempDir string
 		BeforeAll(func() {
-			tempDir = GinkgoT().TempDir()
-			if err := CopyTestFiles(tempDir); err != nil {
-				panic(err)
-			}
+			tempDir = PrepareTempFiles()
 		})
 
 		pulledManifest := "packed.json"

--- a/test/e2e/suite/scenario/oci_image.go
+++ b/test/e2e/suite/scenario/oci_image.go
@@ -31,7 +31,7 @@ var _ = Describe("OCI image user:", Ordered, func() {
 		tag := "image"
 		var tempDir string
 		BeforeAll(func() {
-			PrepareTempFiles()
+			tempDir = PrepareTempFiles()
 		})
 
 		It("should push and pull an image", func() {

--- a/test/e2e/suite/scenario/oci_image.go
+++ b/test/e2e/suite/scenario/oci_image.go
@@ -31,10 +31,7 @@ var _ = Describe("OCI image user:", Ordered, func() {
 		tag := "image"
 		var tempDir string
 		BeforeAll(func() {
-			tempDir = GinkgoT().TempDir()
-			if err := CopyTestFiles(tempDir); err != nil {
-				panic(err)
-			}
+			PrepareTempFiles()
 		})
 
 		It("should push and pull an image", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does below cleanup works on e2e tests.
 - Use `ginkgo.Fail` instead of `panic` in test result matching.
 - Make test folder preparation code more nit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
