### PR TITLE
test: make e2e coverage data in action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Run E2E Tests
         run: |
           bash $GITHUB_WORKSPACE/test/e2e/scripts/e2e.sh $GITHUB_WORKSPACE --clean
+          make e2e-covdata
         env:
           ORAS_PATH: bin/linux/amd64/oras
           COVERAGE_DUMP_ROOT: .cover

--- a/test/e2e/scripts/e2e.sh
+++ b/test/e2e/scripts/e2e.sh
@@ -69,14 +69,7 @@ if ! [ -z ${COVERAGE_DUMP_ROOT} ]; then
 fi
 
 echo " === run tests === "
-ginkgo -r -p --succinct suite || fail=true
-
-if ! [ -z ${COVERAGE_DUMP_ROOT} ]; then
-  echo " === generating code cov report === "
-  make -C ${repo_root} e2e-covdata || true
-fi
-
-if [ "${fail}" = 'true' ]; then
+if ! ginkgo -r -p --succinct suite; then 
   echo " === retriving registry error logs === "
   echo '-------- oras distribution trace -------------'
   docker logs -t --tail 200 $oras_container_name

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -113,6 +113,12 @@ var _ = Describe("Common registry users:", func() {
 				Exec()
 		})
 
+		It("should discover all referrers of a subject via referrers API", func() {
+			ORAS("discover", subjectRef, "-o", format, "--distribution-spec", "v1.1-referrers-api").
+				MatchKeyWords(append(discoverKeyWords(false, referrers...), RegistryRef(Host, ArtifactRepo, foobar.Digest))...).
+				Exec()
+		})
+
 		It("should discover all referrers of a subject with annotations", func() {
 			ORAS("discover", subjectRef, "-o", format, "-v").
 				MatchKeyWords(append(discoverKeyWords(true, referrers...), RegistryRef(Host, ArtifactRepo, foobar.Digest))...).
@@ -170,9 +176,17 @@ var _ = Describe("Fallback registry users:", func() {
 				MatchKeyWords(append(discoverKeyWords(true, referrers...), RegistryRef(FallbackHost, ArtifactRepo, foobar.Digest))...).
 				Exec()
 		})
-		It("should all referrers of a subject via table output", func() {
+
+		It("should discover direct referrers of a subject via table output", func() {
 			referrers := []ocispec.Descriptor{foobar.FallbackSBOMImageReferrer}
 			ORAS("discover", subjectRef, "-o", "table").
+				MatchKeyWords(append(discoverKeyWords(false, referrers...), foobar.Digest)...).
+				Exec()
+		})
+
+		It("should discover direct referrers explicitly via tag scheme", func() {
+			referrers := []ocispec.Descriptor{foobar.FallbackSBOMImageReferrer}
+			ORAS("discover", subjectRef, "-o", "table", "--distribution-spec", "v1.1-referrers-tag").
 				MatchKeyWords(append(discoverKeyWords(false, referrers...), foobar.Digest)...).
 				Exec()
 		})

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -136,10 +136,16 @@ var _ = Describe("ORAS beginners:", func() {
 					Exec()
 			})
 
-			It("should fail if no blob reference provided", func() {
+			It("should fail if no manifest reference provided", func() {
 				dstRepo := fmt.Sprintf(repoFmt, "delete", "no-reference")
 				prepare(RegistryRef(Host, ImageRepo, foobar.Tag), RegistryRef(Host, dstRepo, tempTag))
 				ORAS("manifest", "delete").ExpectFailure().Exec()
+			})
+
+			It("should fail if no digest provided", func() {
+				dstRepo := fmt.Sprintf(repoFmt, "delete", "no-reference")
+				prepare(RegistryRef(Host, ImageRepo, foobar.Tag), RegistryRef(Host, dstRepo, ""))
+				ORAS("manifest", "delete", RegistryRef(Host, dstRepo, "")).ExpectFailure().MatchErrKeyWords("name@digest").Exec()
 			})
 		})
 		When("running `manifest fetch-config`", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
As a follow-up of #924, this PR moves the action of coverage data generation out of e2e run script.
Also added some e2e specs to validate the changes.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
