### PR TITLE
build: using cross compilation in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.20.2-alpine as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20.2-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras


### PR DESCRIPTION
**What this PR does / why we need it**:

The change follows https://docs.docker.com/build/guide/multi-platform/#build-using-cross-compilation to switch oras docker release build to cross-compilation. It boosts the build performance by ~7x.

[Existing using emulation](https://github.com/oras-project/oras/actions/runs/4467009705/jobs/7845927060): 12m 9s. 
[New using cross-compilation ](https://github.com/northtyphoon/oras/actions/runs/4832631679/jobs/8611648375): 1m 39s

**Please check the following list**:
- [X]  Does the affected code have corresponding tests, e.g. unit test, E2E test? Yes
- [X]  Does this change require a documentation update? No
- [X]  Does this introduce breaking changes that would require an announcement or bumping the major version? No
- [X]  Do all new files have an appropriate license header? N/A

