### PR TITLE
chore: use golangci lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,41 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: golangci-lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.20']
+      fail-fast: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+        check-latest: true
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
**What this PR does / why we need it**:
The following are the places that's giving some errors as of now according to the linter. 
<details><summary> output of running golangci locally </summary>
<p>

```bash
$ golangci-lint run
cmd/oras/root/attach.go:94:22: Error return value of `cmd.MarkFlagRequired` is not checked (errcheck)
        cmd.MarkFlagRequired("artifact-type")
                            ^
cmd/oras/root/discover.go:191:13: Error return value is not checked (errcheck)
                        printJSON(ref)
                                 ^
cmd/oras/internal/display/print.go:119:9: Error return value is not checked (errcheck)
                        Print("Tagging", ref)
                             ^
cmd/oras/internal/display/print.go:139:9: Error return value is not checked (errcheck)
                        Print("Tagging", ref)
                             ^
cmd/oras/internal/option/packer_test.go:73:14: Error return value of `os.WriteFile` is not checked (errcheck)
        os.WriteFile(testFile, []byte(testContent), fs.ModePerm)
                    ^
cmd/oras/internal/option/remote.go:276:30: Error return value of `repo.SetReferrersCapability` is not checked (errcheck)
                repo.SetReferrersCapability(*opts.distributionSpec.referrersAPI)
                                           ^
cmd/oras/internal/option/remote_test.go:54:29: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                        json.NewEncoder(w).Encode(testTagList)
                                                 ^
cmd/oras/internal/option/remote_test.go:236:28: Error return value of `(*encoding/json.Encoder).Encode` is not checked (errcheck)
                json.NewEncoder(w).Encode(testTagList)
                                         ^
internal/cache/target_test.go:180:12: Error return value of `w.Write` is not checked (errcheck)
                                w.Write(blob)
                                       ^
internal/graph/graph_test.go:142:14: Error return value of `memory.Push` is not checked (errcheck)
                memory.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
                           ^
internal/graph/graph_test.go:258:14: Error return value of `memory.Push` is not checked (errcheck)
                memory.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
                           ^
internal/graph/graph_test.go:356:14: Error return value of `memory.Push` is not checked (errcheck)
                memory.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
```

</p>
</details> 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #981 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
