### PR TITLE
fix: enforce path validation for push/attach and improve path traversal failure message for pull

### DIFF
--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -86,7 +86,7 @@ func (opts *Packer) Parse() error {
 			}
 		}
 		if len(failedPaths) > 0 {
-			return fmt.Errorf("%v: %v currentDir :%v", errPathValidation, strings.Join(failedPaths, ", "), currentDir)
+			return fmt.Errorf("%w: %v", errPathValidation, strings.Join(failedPaths, ", "))
 		}
 	}
 	return nil

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -40,7 +40,7 @@ var (
 	errAnnotationConflict    = errors.New("`--annotation` and `--annotation-file` cannot be both specified")
 	errAnnotationFormat      = errors.New("missing key in `--annotation` flag")
 	errAnnotationDuplication = errors.New("duplicate annotation key")
-	errPathValidation        = errors.New("one or more files are not in the current directory.If it's intentional use --disable-path-validation flag to skip this check")
+	errPathValidation        = errors.New("absolute file path detected. If it's intentional use --disable-path-validation flag to skip this check")
 )
 
 // Packer option struct.

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -40,7 +40,7 @@ var (
 	errAnnotationConflict    = errors.New("`--annotation` and `--annotation-file` cannot be both specified")
 	errAnnotationFormat      = errors.New("missing key in `--annotation` flag")
 	errAnnotationDuplication = errors.New("duplicate annotation key")
-	errPathValidation        = errors.New("absolute file path detected. If it's intentional use --disable-path-validation flag to skip this check")
+	errPathValidation        = errors.New("absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check")
 )
 
 // Packer option struct.

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -72,8 +72,8 @@ func (opts *Packer) ExportManifest(ctx context.Context, fetcher content.Fetcher,
 	return os.WriteFile(opts.ManifestExportPath, manifestBytes, 0666)
 }
 func (opts *Packer) Parse() error {
-	currentDir, err := os.Getwd()
 	var failedPaths []string
+	currentDir, err := os.Getwd()
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -74,7 +74,7 @@ func (opts *Packer) ExportManifest(ctx context.Context, fetcher content.Fetcher,
 }
 func (opts *Packer) Parse() error {
 	var failedPaths []string
-	if !opts.PathValidationDisabled && len(opts.FileRefs) != 0 {
+	if !opts.PathValidationDisabled {
 		for _, path := range opts.FileRefs {
 			//Remove the type if specified in the path <file>[:<type>] format
 			path, _, err = fileref.Parse(path, "")

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -73,8 +73,8 @@ func (opts *Packer) ExportManifest(ctx context.Context, fetcher content.Fetcher,
 	return os.WriteFile(opts.ManifestExportPath, manifestBytes, 0666)
 }
 func (opts *Packer) Parse() error {
-	var failedPaths []string
 	if !opts.PathValidationDisabled {
+		var failedPaths []string
 		for _, path := range opts.FileRefs {
 			// Remove the type if specified in the path <file>[:<type>] format
 			path, _, err := fileref.Parse(path, "")

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -94,8 +94,7 @@ func (opts *Packer) Parse() error {
 			}
 		}
 		if len(failedPaths) > 0 {
-			errorMsg := fmt.Sprintf("%v: %v currentDir :%v", errPathValidation, strings.Join(failedPaths, ", "), currentDir)
-			return errors.New(errorMsg)
+			return fmt.Errorf("%v: %v currentDir :%v", errPathValidation, strings.Join(failedPaths, ", "), currentDir)
 		}
 	}
 	return nil

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -76,7 +76,7 @@ func (opts *Packer) Parse() error {
 	var failedPaths []string
 	if !opts.PathValidationDisabled {
 		for _, path := range opts.FileRefs {
-			//Remove the type if specified in the path <file>[:<type>] format
+			// Remove the type if specified in the path <file>[:<type>] format
 			path, _, err = fileref.Parse(path, "")
 			if err != nil {
 				return err

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -27,6 +27,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/pflag"
 	"oras.land/oras-go/v2/content"
+	"oras.land/oras/cmd/oras/internal/fileref"
 )
 
 // Pre-defined annotation keys for annotation file
@@ -80,17 +81,12 @@ func (opts *Packer) Parse() error {
 	if !opts.PathValidationDisabled && len(opts.FileRefs) != 0 {
 		for _, path := range opts.FileRefs {
 			//Remove the type if specified in the path <file>[:<type>] format
-			lastIndex := strings.LastIndex(path, ":")
-			if lastIndex != -1 {
-				path = path[:lastIndex]
-			}
-			absPath, err := filepath.Abs(path)
-			dirPath := filepath.Dir(absPath)
+			path, _, err = fileref.Parse(path, "")
 			if err != nil {
 				return err
 			}
-			if dirPath != currentDir {
-				failedPaths = append(failedPaths, absPath)
+			if filepath.IsAbs(path) {
+				failedPaths = append(failedPaths, path)
 			}
 		}
 		if len(failedPaths) > 0 {

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -74,10 +74,6 @@ func (opts *Packer) ExportManifest(ctx context.Context, fetcher content.Fetcher,
 }
 func (opts *Packer) Parse() error {
 	var failedPaths []string
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
 	if !opts.PathValidationDisabled && len(opts.FileRefs) != 0 {
 		for _, path := range opts.FileRefs {
 			//Remove the type if specified in the path <file>[:<type>] format

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -77,7 +77,7 @@ func (opts *Packer) Parse() error {
 	if !opts.PathValidationDisabled {
 		for _, path := range opts.FileRefs {
 			// Remove the type if specified in the path <file>[:<type>] format
-			path, _, err = fileref.Parse(path, "")
+			path, _, err := fileref.Parse(path, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -113,7 +113,6 @@ func runAttach(ctx context.Context, opts attachOptions) error {
 		return err
 	}
 	defer store.Close()
-	store.AllowPathTraversalOnWrite = opts.PathValidationDisabled
 
 	dst, err := opts.NewTarget(opts.Common)
 	if err != nil {

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -239,9 +238,8 @@ func runPull(ctx context.Context, opts pullOptions) error {
 	// Copy
 	desc, err := oras.Copy(ctx, src, opts.Reference, dst, opts.Reference, copyOptions)
 	if err != nil {
-		if strings.Contains(err.Error(), "path traversal disallowed") {
-			errorMsg := fmt.Sprintf("%v: %w ", "to enable path traversal use --allow-path-traversal flag", err)
-			return errors.New(errorMsg)
+		if errors.Is(err, file.ErrPathTraversalDisallowed) {
+			err = fmt.Errorf("%s: %w", "use option -T/allow-path-traversal to allow pulling outside of working directory", err)
 		}
 		return err
 	}

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -240,7 +240,7 @@ func runPull(ctx context.Context, opts pullOptions) error {
 	desc, err := oras.Copy(ctx, src, opts.Reference, dst, opts.Reference, copyOptions)
 	if err != nil {
 		if strings.Contains(err.Error(), "path traversal disallowed") {
-			errorMsg := fmt.Sprintf("%v: %v ", err, "To enable path traversal use --allow-path-traversal flag")
+			errorMsg := fmt.Sprintf("%v: %w ", "to enable path traversal use --allow-path-traversal flag", err)
 			return errors.New(errorMsg)
 		}
 		return err

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -17,8 +17,10 @@ package root
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -237,6 +239,10 @@ func runPull(ctx context.Context, opts pullOptions) error {
 	// Copy
 	desc, err := oras.Copy(ctx, src, opts.Reference, dst, opts.Reference, copyOptions)
 	if err != nil {
+		if strings.Contains(err.Error(), "path traversal disallowed") {
+			errorMsg := fmt.Sprintf("%v: %v ", err, "To enable path traversal use --allow-path-traversal flag")
+			return errors.New(errorMsg)
+		}
 		return err
 	}
 	if pulledEmpty {

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -239,7 +239,7 @@ func runPull(ctx context.Context, opts pullOptions) error {
 	desc, err := oras.Copy(ctx, src, opts.Reference, dst, opts.Reference, copyOptions)
 	if err != nil {
 		if errors.Is(err, file.ErrPathTraversalDisallowed) {
-			err = fmt.Errorf("%s: %w", "use option -T/allow-path-traversal to allow pulling outside of working directory", err)
+			err = fmt.Errorf("%s: %w", "use flag -T/allow-path-traversal to allow pulling files outside of working directory", err)
 		}
 		return err
 	}

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -239,7 +239,7 @@ func runPull(ctx context.Context, opts pullOptions) error {
 	desc, err := oras.Copy(ctx, src, opts.Reference, dst, opts.Reference, copyOptions)
 	if err != nil {
 		if errors.Is(err, file.ErrPathTraversalDisallowed) {
-			err = fmt.Errorf("%s: %w", "use flag -T/allow-path-traversal to allow pulling files outside of working directory", err)
+			err = fmt.Errorf("%s: %w", "use flag --allow-path-traversal to allow insecurely pulling files outside of working directory", err)
 		}
 		return err
 	}

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -139,7 +139,6 @@ func runPush(ctx context.Context, opts pushOptions) error {
 		return err
 	}
 	defer store.Close()
-	store.AllowPathTraversalOnWrite = opts.PathValidationDisabled
 	if opts.manifestConfigRef != "" {
 		path, cfgMediaType, err := fileref.Parse(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
 I just tried to push an artifact file from linux environment from a absolute path or from different directory. The path is implicitly taken by the oras cli or oras sdk when I pushed it. Like the file was in a directory /home/vts/1/a.exe. and I pushed from /home/test. I am ok if the push fails stating me that the file is not in the current directory and for security reasons you have to be in same working directory. But the push passes and pull fails . So disallow is a much better option. I am sure when I used ORAS python SDK it did fail with error stating as here https://github.com/oras-project/oras-py/blob/209c9b98043a00d1b04789cc2967ca7021dc5b2e/oras/provider.py#L651 . The CLI should have same behaviour as SDK. Then push and pull are coherent. It can be a bad experience when push is ok and pull fails and when different people do it can be hard for people to understand why it fails and also cross platform can fail if it is not intentional

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#980 
#983 
#978 
**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

Screenshot showing the scenarios tested

<img width="1335" alt="Screenshot 2023-06-26 at 10 13 47 pm" src="https://github.com/oras-project/oras/assets/5260185/acfb92c3-e9a5-4905-8b3c-2f994359724d">
