### PR TITLE
Release v1.1.0 rc1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.1.0-rc.1"
+	Version = "1.1.0-rc1"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.1.0-rc1"
+	Version = "1.1.0-rc1+dev"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
Draft PR to show version bumps so the release can be PR driven. 

The proposal here is to tag 32bfb875d3e288f0c5133b81af2c742d257cbc9b as v1.1.0-rc1

Basically move voting to the PR rather than an issue - https://github.com/oras-project/oras/issues/1002