### PR TITLE
bump: update golang from 1.20.2 to 1.20.5

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20.2'
+          go-version: '1.20.5'
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20.2-alpine as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20.5-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras


### PR DESCRIPTION
This PR updates the version of Golang for binary build and GHCR container build.