### PR TITLE
chore: update container build prepare job output in Github Actions

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -17,6 +17,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - releaser
 
 jobs:
   build:
@@ -35,8 +37,7 @@ jobs:
           if [[ "${VERSION}" == "${BRANCH_NAME}" ]]; then
             VERSION=$(git rev-parse --short HEAD)
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=ref::ghcr.io/${{ github.repository }}:${VERSION}
+          echo "ref=ghcr.io/${{ github.repository }}:${VERSION}" >> $GITHUB_OUTPUT
       - name: docker login
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -17,8 +17,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - releaser
 
 jobs:
   build:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the usage of `set-output` in Github Actions. Tested in my own fork and it works as expected: https://github.com/qweeah/oras/actions/runs/5521156830/jobs/10068846025

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1018 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
