### PR TITLE
feat: add the job to publish new releases for `winget`

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -37,3 +37,12 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-to-winget:
+    needs: [ build ]
+    runs-on: windows-latest
+    steps:
+      - name: Release to Winget
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: ORASProject.ORAS
+          token: ${{ secrets.WINGET_GITHUB_TOKEN }}


### PR DESCRIPTION
Description - 

The github workflows have been updated to make it easier to publish new versions of our application to the Windows Package manager.

Required - 

- [ ] Create a classic PAT with public_repo scope (WINGET_GITHUB_TOKEN)
- [ ] Fork the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository under the same account/organization.

The details can be found [here](https://github.com/vedantmgoyal2009/winget-releaser#getting-started-).

Fixes #939 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
