### PR TITLE
 feat: add workflow to bump homebrew formula

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   build:
+    name: "Oras build & release"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -31,9 +32,21 @@ jobs:
         with:
           go-version: '1.20.5'
       - name: run goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract version
+        id: extract-version
+        run: |
+          printf "::set-output name=%s::%s\n" tag-name "${GITHUB_REF#refs/tags/}"
+      - name: bump homebrew formula
+        uses: mislav/bump-homebrew-formula-action@v2
+        with: 
+          formula-name: oras
+          formula-path: Formula/oras.rb
+          download-url: https://github.com/oras-project/oras/archive/${{  steps.extract-version.outputs.tag-name  }}.tar.gz
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Description - 

The github workflows have been updated to make it easier to publish new versions of our application to the homebrew.

Required - 
- [ ]  personal access token should have "repo" & "workflow" scopes (COMMITTER_TOKEN)

Fixes #1025

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
