### PR TITLE
bump: tag and release ORAS CLI v1.0.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.0.0"
+	Version = "1.0.1"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes to tag oras CLI v1.0.1 based on https://github.com/oras-project/oras/pull/1048/commits/acf147b7564f44f8637dc59937d6167e5427e612 and release. This merged commit in branch release 1.0 will be tagged as v1.0.1 for releasing. At least 3 approvals are needed from the 5 owners.

Below is a summary of change notes since [v1.0.0](https://github.com/oras-project/oras/releases/tag/v1.0.0):
## Issue Notes
### Bug Fixes
- `oras push` and `oras attach` generates unwanted manifest file (#995)
- Path validation not enforced for `oras attach` and `oras push` (#983, #980, #973)
- Wrong error information when `--distribution-spec` is provided with invalid value (#897)  
- Tree view print bug in `oras discover` (#1003)

### Other Changes
- Improve UX
  - `oras pull` prints better error msg when path traversal is required (#978)
  - Mention OCI support in help doc (#904)
  - Mark filtered tag listing as experimental (#993)
- Improve Documentation
  - Fix link in contribute doc (#950)
- Update dependencies
  - Remove dependencies on docker CLI (#414)
  - Update dependency from `github.com/moby/term` to `golang.org/x/term` (#908)
- Update to golang `1.20.7`
- Improve tests
  - Generate code coverage for E2E tests (#900)
  - Added more tests (#904, #901, #972, #1022)
- Workflow
  - add Github actions to lint go code (#981)
  - update Github actions output configuration (#1018)
  - add Github stale actions