### PR TITLE
chore: add triage labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -13,7 +13,7 @@
 
 name: Bug Report
 description: File a bug report
-labels: [bug]
+labels: [bug, triage]
 body:
   - type: markdown
     id: preface

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -13,7 +13,7 @@
 
 name: Feature Request
 description: File a feature request
-labels: [enhancement]
+labels: [enhancement, triage]
 body:
   - type: markdown
     id: preface


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a `triage` label to the ORAS issue templates. New issues will be labeled with `triage` so that we can quickly find the issues that need to be triaged. 
