### PR TITLE
chore: make error returned by `oras tag` more readable

### DIFF
--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/option"
 )
@@ -58,6 +59,9 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 		Args: cobra.MinimumNArgs(2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
+			if _, err := registry.ParseReference(opts.RawReference); err != nil {
+				return fmt.Errorf("unable to add tag for '%s': %w", opts.RawReference, err)
+			}
 			opts.targetRefs = args[1:]
 			return option.Parse(&opts)
 		},

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -33,7 +33,11 @@ var _ = Describe("ORAS beginners:", func() {
 		})
 
 		It("should fail when provided manifest reference is not found", func() {
-			ORAS("tag", RegistryRef(Host, ImageRepo, "i-dont-think-this-tag-exists")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
+			ORAS("tag", RegistryRef(Host, ImageRepo, "i-dont-think-this-tag-exists"), "tagged").ExpectFailure().MatchErrKeyWords("Error:").Exec()
+		})
+
+		It("should fail when provided invalid reference", func() {
+			ORAS("tag", "list", "tagged").ExpectFailure().MatchErrKeyWords("Error:", "'list'").Exec()
 		})
 	})
 })


### PR DESCRIPTION
This PR improves the readability of error info when an invalid reference is provided:
```console
$ oras tag list test
Error: unable to add tag for 'list': invalid reference: missing repository
```