### PR TITLE
chore: align naming of pack option to oras-go

### DIFF
--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -29,17 +29,17 @@ const (
 
 // ImageSpec option struct.
 type ImageSpec struct {
-	flag     string
-	PackType oras.PackManifestVersion
+	flag        string
+	PackVersion oras.PackManifestVersion
 }
 
 // Parse parses flags into the option.
 func (opts *ImageSpec) Parse() error {
 	switch opts.flag {
 	case ImageSpecV1_1:
-		opts.PackType = oras.PackManifestVersion1_1_RC4
+		opts.PackVersion = oras.PackManifestVersion1_1_RC4
 	case ImageSpecV1_0:
-		opts.PackType = oras.PackManifestVersion1_0
+		opts.PackVersion = oras.PackManifestVersion1_0
 	default:
 		return fmt.Errorf("unknown image specification flag: %q", opts.flag)
 	}

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -101,7 +101,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 			if err := option.Parse(&opts); err != nil {
 				return err
 			}
-			switch opts.PackType {
+			switch opts.PackVersion {
 			case oras.PackManifestVersion1_0:
 				if opts.manifestConfigRef != "" && opts.artifactType != "" {
 					return errors.New("--artifact-type and --config cannot both be provided for 1.0 OCI image")
@@ -161,7 +161,7 @@ func runPush(ctx context.Context, opts pushOptions) error {
 	packOpts.Layers = descs
 	memoryStore := memory.New()
 	pack := func() (ocispec.Descriptor, error) {
-		root, err := oras.PackManifest(ctx, memoryStore, opts.PackType, opts.artifactType, packOpts)
+		root, err := oras.PackManifest(ctx, memoryStore, opts.PackVersion, opts.artifactType, packOpts)
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}


### PR DESCRIPTION
This PR updates the pack option of image spec from `PackType` to `PackVersion`