### PR TITLE
bump: tag and release ORAS CLI v1.1.0-rc.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.1.0-rc.1"
+	Version = "1.1.0-rc.2"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes to tag for oras CLI based on 443242e41d469a911af6fa68f3338fcfb2f5f268 and release.  The new tag will be named as `v1.1.0-rc.2` for releasing. At least 3 approvals are needed from the 5 owners.

Below is a summary of change notes since [v1.1.0-rc.1](https://github.com/oras-project/oras/releases/tag/v1.1.0-rc.1):
## Release Notes
### New Features
- Pack OCI image compliant to [OCI image spec v1.1.0-rc4](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/manifest.md#oci-image-manifest-specification) (#1043, #1009)
   - `oras attach` and `oras push` no longer build manifests with manifest type `application/vnd.oci.artifact.manifest.v1+json`
   - Remove the experimental flag `--image-spec` from `oras attach`
   - `oras push` builds artifact manifest following [this decision tree](https://oras.land/docs/concepts/artifact#determining-the-artifact-type)
     - Remove options `v1.1-image` and `v1.1-artifact` from the flag `--image-spec`, add new options `v1.0` and `v1.1` to this flag
     - `artifactType` is used to denote the artifact type field
     - [Empty descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/manifest.md#guidance-for-an-empty-descriptor) will be used if the flag `--config` not specified
   - `oras cp` supports index with subject
- Output OCI distribution warning headers (#898)

### Other Changes
- Revert feature
  - Remove the flag `--skip-delete-referrers` to skip garbage collection of obsolete referrers index  (#1041)
- Improve UX
  - Make error logs more readable (#1021)
- Improve documentation
  - Fix broken links in project readme (#1017)
- Update dependencies
- Update to golang `1.21`
- Improve tests
  - Add unit tests for cred store (#972)
  - Fix E2E false positive result (#1022)
- Improve workflow
  - Add linter action (#986)
  - Add stale action
  - Upgrade container release action (#1018)

Detailed change logs:
## What's Changed
* bump: tag and release ORAS CLI v1.1.0-rc.1 by @qweeah in https://github.com/oras-project/oras/pull/1016
* chore: fix lint warning by @kranurag7 in https://github.com/oras-project/oras/pull/1001
* chore: fix the links in project readme by @amands98 in https://github.com/oras-project/oras/pull/1012
* chore: update container build prepare job output in Github Actions by @qweeah in https://github.com/oras-project/oras/pull/1019
* test: add unit test for error scenario in `internal/credential/store.go` by @enraiha0307 in https://github.com/oras-project/oras/pull/982
* chore: use golangci lint by @kranurag7 in https://github.com/oras-project/oras/pull/986
* fix: correct e2e specs and CI check configuration by @qweeah in https://github.com/oras-project/oras/pull/1023
* workflow: add github stale action by @sajayantony in https://github.com/oras-project/oras/pull/1024
* fix: move stale into .github/workflows by @sajayantony in https://github.com/oras-project/oras/pull/1031
* build(deps): bump github.com/onsi/gomega from 1.27.8 to 1.27.10 in /test/e2e by @dependabot in https://github.com/oras-project/oras/pull/1037
* chore: improving error log for `oras push` and `oras attach` when the annotation file is invalid by @1Shubham7 in https://github.com/oras-project/oras/pull/1026
* chore: exempt stale if milestone is set by @qweeah in https://github.com/oras-project/oras/pull/1036
* chore: add triage labels by @FeynmanZhou in https://github.com/oras-project/oras/pull/1055
* chore: make error returned by `oras tag` more readable by @qweeah in https://github.com/oras-project/oras/pull/1058
* revert: "feat: add flag to skip deleting obsolete referrers index" by @qweeah in https://github.com/oras-project/oras/pull/1060
* feat: disable referrers index GC by default by @qweeah in https://github.com/oras-project/oras/pull/1059
* build(deps): bump golang.org/x/term from 0.10.0 to 0.11.0 by @dependabot in https://github.com/oras-project/oras/pull/1051
* feat: pack OCI image spec v1.1 manifests by @qweeah in https://github.com/oras-project/oras/pull/1054
* bump: use new packing function in oras-go by @qweeah in https://github.com/oras-project/oras/pull/1070
* feat: support warning in remote targets by @qweeah in https://github.com/oras-project/oras/pull/1057
* chore: align naming of pack option to oras-go by @qweeah in https://github.com/oras-project/oras/pull/1073
* bump: update golang to 1.21 by @qweeah in https://github.com/oras-project/oras/pull/1074
* build(deps): bump github.com/onsi/ginkgo/v2 from 2.11.0 to 2.12.0 in /test/e2e by @dependabot in https://github.com/oras-project/oras/pull/1075