### PR TITLE
bump: tag and release ORAS CLI v1.1.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.1.0-rc.2"
+	Version = "1.1.0"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes to tag `v1.1.0` and checkout `release-1.1` based on 7079c468a06fb5815c99395eb4aaf46dd459d3fa and release. At least 3 approvals are needed from the 5 owners.

Below is a summary of change notes since [v1.1.0-rc.2](https://github.com/oras-project/oras/releases/tag/v1.1.0-rc.2):
## Release Notes
### Other Changes
- Improve performance
  - Reduced auth requests for push and attach (#1084)
- Improve documentation
  - Updated security guide (#1017)
- Update dependencies
  - Bump oras-go to 2.3.0 
- Improve tests
  - Use ZOT in E2E tests (#1071)
  - Added E2E tests to cover spec update (#1092)

Detailed change logs:
## What's Changed
* bump: tag and release ORAS CLI v1.1.0-rc.2 by @qweeah in https://github.com/oras-project/oras/pull/1078
* test(e2e): add zot as a testing backend by @qweeah in https://github.com/oras-project/oras/pull/1072
* Add SECURITY.md file by @TerryHowe in https://github.com/oras-project/oras/pull/1082
* test(e2e): update e2e specs for `oras attach`  by @qweeah in https://github.com/oras-project/oras/pull/1081
* test(e2e): use ZOT as testing backend for `oras blob` specs by @qweeah in https://github.com/oras-project/oras/pull/1083
* test(e2e): fix logging when e2e test fails by @qweeah in https://github.com/oras-project/oras/pull/1090
* test(e2e): migrate `oras push` specs to ZOT  by @qweeah in https://github.com/oras-project/oras/pull/1085
* test(e2e): migrate `oras pull` specs to ZOT by @qweeah in https://github.com/oras-project/oras/pull/1086
* test(e2e): migrate `oras tag` specs to ZOT by @qweeah in https://github.com/oras-project/oras/pull/1087
* test(e2e): migrate `oras repo` specs to ZOT  by @qweeah in https://github.com/oras-project/oras/pull/1088
* test(e2e): migrate `oras manifest` specs to ZOT by @qweeah in https://github.com/oras-project/oras/pull/1089
* perf: save auth requests for push and attach by @Wwwsylvia in https://github.com/oras-project/oras/pull/1097
* test(e2e): re-bake test data by @qweeah in https://github.com/oras-project/oras/pull/1094
* test(e2e): migrate `oras cp` and `oras discover` specs to ZOT  by @qweeah in https://github.com/oras-project/oras/pull/1093
* test(e2e): cover pulling test for image spec 1.1.0-rc.2 artifact by @qweeah in https://github.com/oras-project/oras/pull/1098
* test(e2e): add tests to cover OCI spec v1.1.0-rc.4 and OCI distribution spec 1.1.0-rc3 by @qweeah in https://github.com/oras-project/oras/pull/1099
* test(e2e): add doc for ZOT test data by @qweeah in https://github.com/oras-project/oras/pull/1100
* build(deps): bump oras-go to v2.3.0 by @qweeah in https://github.com/oras-project/oras/pull/1101
* doc: update example for `oras push` by @qweeah in https://github.com/oras-project/oras/pull/1102


**Full Changelog**: https://github.com/oras-project/oras/compare/v1.1.0-rc.2...v1.1.0
