### PR TITLE
fix: allow HTTPS for localhost

### DIFF
--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -43,7 +43,6 @@ import (
 // Remote options struct.
 type Remote struct {
 	CACertFilePath    string
-	GetPlainHTTP      func() *bool
 	Insecure          bool
 	Configs           []string
 	Username          string
@@ -56,6 +55,7 @@ type Remote struct {
 	headerFlags           []string
 	headers               http.Header
 	warned                map[string]*sync.Map
+	getPlainHTTP          func() *bool
 }
 
 // EnableDistributionSpecFlag set distribution specification flag as applicable.
@@ -101,7 +101,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	plainHTTPFlagName := flagPrefix + "plain-http"
 	plainHTTP := false
 	fs.BoolVar(&plainHTTP, plainHTTPFlagName, plainHTTP, "allow insecure connections to "+notePrefix+"registry without SSL check")
-	opts.GetPlainHTTP = func() *bool {
+	opts.getPlainHTTP = func() *bool {
 		if !fs.Changed(plainHTTPFlagName) {
 			return nil
 		}
@@ -313,7 +313,7 @@ func (opts *Remote) NewRepository(reference string, common Common, logger logrus
 
 // isPlainHttp returns the plain http flag for a given registry.
 func (opts *Remote) isPlainHttp(registry string) bool {
-	if plainHTTP := opts.GetPlainHTTP(); plainHTTP != nil {
+	if plainHTTP := opts.getPlainHTTP(); plainHTTP != nil {
 		return *plainHTTP
 	}
 	host, _, _ := net.SplitHostPort(registry)

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -55,7 +55,7 @@ type Remote struct {
 	headerFlags           []string
 	headers               http.Header
 	warned                map[string]*sync.Map
-	plainHTTP             func() (plainHTTP bool, fromFlag bool)
+	plainHTTP             func() (plainHTTP bool, enforced bool)
 }
 
 // EnableDistributionSpecFlag set distribution specification flag as applicable.
@@ -309,7 +309,7 @@ func (opts *Remote) NewRepository(reference string, common Common, logger logrus
 
 // isPlainHttp returns the plain http flag for a given registry.
 func (opts *Remote) isPlainHttp(registry string) bool {
-	if plainHTTP, specified := opts.plainHTTP(); specified {
+	if plainHTTP, enforced := opts.plainHTTP(); enforced {
 		return plainHTTP
 	}
 

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -99,8 +99,8 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.StringVarP(&opts.Password, flagPrefix+"password", shortPassword, "", notePrefix+"registry password or identity token")
 	fs.BoolVarP(&opts.Insecure, flagPrefix+"insecure", "", false, "allow connections to "+notePrefix+"SSL registry without certs")
 	plainHTTPFlagName := flagPrefix + "plain-http"
-	var plainHTTP bool
-	fs.BoolVarP(&plainHTTP, plainHTTPFlagName, "", false, "allow insecure connections to "+notePrefix+"registry without SSL check")
+	plainHTTP := false
+	fs.BoolVar(&plainHTTP, plainHTTPFlagName, plainHTTP, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	opts.GetPlainHTTP = func() *bool {
 		if !fs.Changed(plainHTTPFlagName) {
 			return nil

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -99,8 +99,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.StringVarP(&opts.Password, flagPrefix+"password", shortPassword, "", notePrefix+"registry password or identity token")
 	fs.BoolVarP(&opts.Insecure, flagPrefix+"insecure", "", false, "allow connections to "+notePrefix+"SSL registry without certs")
 	plainHTTPFlagName := flagPrefix + "plain-http"
-	plainHTTP := false
-	fs.BoolVar(&plainHTTP, plainHTTPFlagName, plainHTTP, "allow insecure connections to "+notePrefix+"registry without SSL check")
+	plainHTTP := *fs.Bool(plainHTTPFlagName, false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	opts.plainHTTP = func() (bool, bool) {
 		if !fs.Changed(plainHTTPFlagName) {
 			return plainHTTP, false

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -309,11 +309,14 @@ func (opts *Remote) NewRepository(reference string, common Common, logger logrus
 
 // isPlainHttp returns the plain http flag for a given registry.
 func (opts *Remote) isPlainHttp(registry string) bool {
-	if plainHTTP, enforced := opts.plainHTTP(); enforced {
+	plainHTTP, enforced := opts.plainHTTP()
+	if enforced {
 		return plainHTTP
 	}
-
-	// not specified, defaults to plain http for localhost
 	host, _, _ := net.SplitHostPort(registry)
-	return host == "localhost" || registry == "localhost"
+	if host == "localhost" || registry == "localhost" {
+		// not specified, defaults to plain http for localhost
+		return true
+	}
+	return plainHTTP
 }

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -99,9 +99,9 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	fs.StringVarP(&opts.Password, flagPrefix+"password", shortPassword, "", notePrefix+"registry password or identity token")
 	fs.BoolVarP(&opts.Insecure, flagPrefix+"insecure", "", false, "allow connections to "+notePrefix+"SSL registry without certs")
 	plainHTTPFlagName := flagPrefix + "plain-http"
-	plainHTTP := *fs.Bool(plainHTTPFlagName, false, "allow insecure connections to "+notePrefix+"registry without SSL check")
+	plainHTTP := fs.Bool(plainHTTPFlagName, false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	opts.plainHTTP = func() (bool, bool) {
-		return plainHTTP, fs.Changed(plainHTTPFlagName)
+		return *plainHTTP, fs.Changed(plainHTTPFlagName)
 	}
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
 	fs.StringArrayVarP(&opts.resolveFlag, flagPrefix+"resolve", "", nil, "customized DNS for "+notePrefix+"registry, formatted in `host:port:address[:address_port]`")

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -101,10 +101,7 @@ func (opts *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 	plainHTTPFlagName := flagPrefix + "plain-http"
 	plainHTTP := *fs.Bool(plainHTTPFlagName, false, "allow insecure connections to "+notePrefix+"registry without SSL check")
 	opts.plainHTTP = func() (bool, bool) {
-		if !fs.Changed(plainHTTPFlagName) {
-			return plainHTTP, false
-		}
-		return plainHTTP, true
+		return plainHTTP, fs.Changed(plainHTTPFlagName)
 	}
 	fs.StringVarP(&opts.CACertFilePath, flagPrefix+"ca-file", "", "", "server certificate authority file for the remote "+notePrefix+"registry")
 	fs.StringArrayVarP(&opts.resolveFlag, flagPrefix+"resolve", "", nil, "customized DNS for "+notePrefix+"registry, formatted in `host:port:address[:address_port]`")

--- a/cmd/oras/internal/option/remote_test.go
+++ b/cmd/oras/internal/option/remote_test.go
@@ -277,7 +277,9 @@ func TestRemote_NewRepository_Retry(t *testing.T) {
 }
 
 func TestRemote_isPlainHttp_localhost(t *testing.T) {
-	opts := Remote{PlainHTTP: false}
+	opts := Remote{GetPlainHTTP: func() *bool {
+		return new(bool)
+	}}
 	got := opts.isPlainHttp("localhost")
 	if got != true {
 		t.Fatalf("tls should be disabled when domain is localhost")

--- a/cmd/oras/internal/option/remote_test.go
+++ b/cmd/oras/internal/option/remote_test.go
@@ -277,7 +277,7 @@ func TestRemote_NewRepository_Retry(t *testing.T) {
 }
 
 func TestRemote_isPlainHttp_localhost(t *testing.T) {
-	opts := Remote{GetPlainHTTP: func() *bool {
+	opts := Remote{getPlainHTTP: func() *bool {
 		return new(bool)
 	}}
 	got := opts.isPlainHttp("localhost")

--- a/cmd/oras/internal/option/remote_test.go
+++ b/cmd/oras/internal/option/remote_test.go
@@ -162,15 +162,14 @@ func TestRemote_authClient_resolve(t *testing.T) {
 	}
 }
 
-func plainHTTPEnabled() *bool {
-	t := true
-	return &t
+func plainHTTPEnabled() (plainHTTP bool, fromFlag bool) {
+	return true, true
 }
-func HTTPSEnabled() *bool {
-	return new(bool)
+func HTTPSEnabled() (plainHTTP bool, fromFlag bool) {
+	return false, true
 }
-func plainHTTPNotSpecified() *bool {
-	return nil
+func plainHTTPNotSpecified() (plainHTTP bool, fromFlag bool) {
+	return false, false
 }
 
 func TestRemote_NewRegistry(t *testing.T) {
@@ -185,7 +184,7 @@ func TestRemote_NewRegistry(t *testing.T) {
 	}{
 		Remote{
 			CACertFilePath: caPath,
-			getPlainHTTP:   plainHTTPNotSpecified,
+			plainHTTP:      plainHTTPNotSpecified,
 		},
 		Common{},
 	}
@@ -213,7 +212,7 @@ func TestRemote_NewRepository(t *testing.T) {
 	}{
 		Remote{
 			CACertFilePath: caPath,
-			getPlainHTTP:   plainHTTPNotSpecified,
+			plainHTTP:      plainHTTPNotSpecified,
 		},
 		Common{},
 	}
@@ -261,7 +260,7 @@ func TestRemote_NewRepository_Retry(t *testing.T) {
 	}{
 		Remote{
 			CACertFilePath: caPath,
-			getPlainHTTP:   plainHTTPNotSpecified,
+			plainHTTP:      plainHTTPNotSpecified,
 		},
 		Common{},
 	}
@@ -291,7 +290,7 @@ func TestRemote_NewRepository_Retry(t *testing.T) {
 }
 
 func TestRemote_default_localhost(t *testing.T) {
-	opts := Remote{getPlainHTTP: plainHTTPNotSpecified}
+	opts := Remote{plainHTTP: plainHTTPNotSpecified}
 	got := opts.isPlainHttp("localhost")
 	if got != true {
 		t.Fatalf("tls should be disabled when domain is localhost")
@@ -306,7 +305,7 @@ func TestRemote_default_localhost(t *testing.T) {
 }
 
 func TestRemote_isPlainHTTP_localhost(t *testing.T) {
-	opts := Remote{getPlainHTTP: plainHTTPEnabled}
+	opts := Remote{plainHTTP: plainHTTPEnabled}
 	isplainHTTP := opts.isPlainHttp("localhost")
 	if isplainHTTP != true {
 		t.Fatalf("tls should be disabled when domain is localhost and --plain-http is used")
@@ -321,7 +320,7 @@ func TestRemote_isPlainHTTP_localhost(t *testing.T) {
 }
 
 func TestRemote_isHTTPS_localhost(t *testing.T) {
-	opts := Remote{getPlainHTTP: HTTPSEnabled}
+	opts := Remote{plainHTTP: HTTPSEnabled}
 	got := opts.isPlainHttp("localhost")
 	if got != false {
 		t.Fatalf("tls should be enabled when domain is localhost and --plain-http=false is used")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows user to specify `--plain-http=false` for a registry named `localhost`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1106 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
