### PR TITLE
build: release ppc64le/riscv64 and improve reproducibility 

### DIFF
--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -45,7 +45,7 @@ jobs:
       - name: docker build
         run: |          
           docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/s390x -t ${{ steps.prepare.outputs.ref }} --push .
+          docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/s390x,linux/ppc64le -t ${{ steps.prepare.outputs.ref }} --push .
       - name: clear
         if: always()
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,7 @@ builds:
   - arm
   - s390x
   - ppc64le
+  - riscv64
   goarm:
   - '7'
   ignore:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,7 @@ builds:
   - arm64
   - arm
   - s390x
+  - ppc64le
   goarm:
   - '7'
   ignore:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
   binary: ./oras
   env:
   - CGO_ENABLED=0
+  flags:
+  - -trimpath
   goos:
   - darwin
   - linux
@@ -42,7 +44,8 @@ builds:
   ldflags:
   # one-line ldflags to bypass the goreleaser bugs
   # the git tree state is guaranteed to be clean by goreleaser
-  - -w -X oras.land/oras/internal/version.Version={{.Version}} -X oras.land/oras/internal/version.GitCommit={{.FullCommit}} -X oras.land/oras/internal/version.BuildMetadata= -X oras.land/oras/internal/version.GitTreeState=clean
+  - -w -s -buildid= -X oras.land/oras/internal/version.Version={{.Version}} -X oras.land/oras/internal/version.GitCommit={{.FullCommit}} -X oras.land/oras/internal/version.BuildMetadata= -X oras.land/oras/internal/version.GitTreeState=clean
+  mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GIT_TAG     = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 GIT_DIRTY   = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 GO_EXE      = go
 
-TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz windows_amd64.zip
+TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz windows_amd64.zip
 
 LDFLAGS = -w
 ifdef VERSION
@@ -50,8 +50,11 @@ clean:  ## clean up build
 .PHONY: build
 build: build-linux build-mac build-windows  ## build for all targets
 
+.PHONY: build-linux-all
+build-linux-all: build-linux-amd64 build-linux-arm64 build-linux-arm-v7 build-linux-s390x build-linux-ppc64le ## build all linux architectures
+
 .PHONY: build-linux
-build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm-v7 build-linux-s390x  ## build all linux architectures
+build-linux: build-linux-amd64 build-linux-arm64
 
 .PHONY: build-linux-amd64
 build-linux-amd64:  ## build for linux amd64
@@ -72,6 +75,11 @@ build-linux-arm-v7:  ## build for linux arm v7
 build-linux-s390x:  ## build for linux s390x
 	GOARCH=s390x CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/s390x/$(CLI_EXE) $(CLI_PKG)
+
+.PHONY: build-linux-ppc64le
+build-linux-ppc64le:  ## build for linux ppc64le
+	GOARCH=ppc64le CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
+		-o bin/linux/ppc64le/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-mac
 build-mac: build-mac-arm64 build-mac-amd64  ## build all mac architectures

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GIT_TAG     = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 GIT_DIRTY   = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 GO_EXE      = go
 
-TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz windows_amd64.zip
+TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz linux_riscv64.tar.gz windows_amd64.zip
 
 LDFLAGS = -w
 ifdef VERSION
@@ -51,7 +51,7 @@ clean:  ## clean up build
 build: build-linux build-mac build-windows  ## build for all targets
 
 .PHONY: build-linux-all
-build-linux-all: build-linux-amd64 build-linux-arm64 build-linux-arm-v7 build-linux-s390x build-linux-ppc64le ## build all linux architectures
+build-linux-all: build-linux-amd64 build-linux-arm64 build-linux-arm-v7 build-linux-s390x build-linux-ppc64le build-linux-riscv64 ## build all linux architectures
 
 .PHONY: build-linux
 build-linux: build-linux-amd64 build-linux-arm64
@@ -80,6 +80,11 @@ build-linux-s390x:  ## build for linux s390x
 build-linux-ppc64le:  ## build for linux ppc64le
 	GOARCH=ppc64le CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
 		-o bin/linux/ppc64le/$(CLI_EXE) $(CLI_PKG)
+
+.PHONY: build-linux-riscv64
+build-linux-riscv64:  ## build for linux riscv64
+	GOARCH=riscv64 CGO_ENABLED=0 GOOS=linux $(GO_EXE) build -v --ldflags="$(LDFLAGS)" \
+		-o bin/linux/riscv64/$(CLI_EXE) $(CLI_PKG)
 
 .PHONY: build-mac
 build-mac: build-mac-arm64 build-mac-amd64  ## build all mac architectures


### PR DESCRIPTION
**What this PR does / why we need it**:

Release for more architectures, as oras is getting more popular :tada: and some use cases require more exotic architectures.

Also improving the reproducibility of release artifacts by
- trimming paths (making the build independent from the current directory)
- set build ID to empty string
- set binary timestamp to commit timestamp
- strip binary (reduces size from 9.2MB to 8.5MB)

**Which issue(s) this PR fixes**:
Fixes #1111

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test? **does not apply**
- [x]  Does this change require a documentation update? **no**
- [x]  Does this introduce breaking changes that would require an announcement or bumping the major version? **no**
- [x]  Do all new files have an appropriate license header? **does not apply**

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
