### PR TITLE
fix: resolve duplicated debug log for `oras cp`

### DIFF
--- a/internal/trace/transport.go
+++ b/internal/trace/transport.go
@@ -22,11 +22,12 @@ import (
 	"sync/atomic"
 )
 
+var count uint64
+
 // Transport is an http.RoundTripper that keeps track of the in-flight
 // request and add hooks to report HTTP tracing events.
 type Transport struct {
 	http.RoundTripper
-	count uint64
 }
 
 // NewTransport creates and returns a new instance of Transport
@@ -38,7 +39,7 @@ func NewTransport(base http.RoundTripper) *Transport {
 
 // RoundTrip calls base roundtrip while keeping track of the current request.
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	number := atomic.AddUint64(&t.count, 1) - 1
+	number := atomic.AddUint64(&count, 1) - 1
 	ctx := req.Context()
 	e := Logger(ctx)
 

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -79,7 +79,7 @@ var _ = Describe("1.1 registry users:", func() {
 			CompareRef(src, dst)
 		})
 
-		It("should copy and show debug logs with duplication", func() {
+		It("should copy and show logs with deduplicated id", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, blob.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("debug-log"), "copied")
 			session := ORAS("cp", src, dst, "-d").Exec()

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -44,9 +43,9 @@ var _ = Describe("ORAS beginners:", func() {
 	When("running cp command", func() {
 		It("should show help doc with feature flags", func() {
 			out := ORAS("cp", "--help").MatchKeyWords("Copy", ExampleDesc).Exec()
-			gomega.Expect(out).Should(gbytes.Say("--from-distribution-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
-			gomega.Expect(out).Should(gbytes.Say("-r, --recursive\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
-			gomega.Expect(out).Should(gbytes.Say("--to-distribution-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
+			Expect(out).Should(gbytes.Say("--from-distribution-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
+			Expect(out).Should(gbytes.Say("-r, --recursive\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
+			Expect(out).Should(gbytes.Say("--to-distribution-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
 		})
 
 		It("should fail when no reference provided", func() {
@@ -77,6 +76,15 @@ var _ = Describe("1.1 registry users:", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, blob.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("artifact-with-blob"), "copied")
 			ORAS("cp", src, dst, "-v").MatchStatus(blob.StateKeys, true, len(blob.StateKeys)).Exec()
+			CompareRef(src, dst)
+		})
+
+		It("should copy and show debug logs with duplication", func() {
+			src := RegistryRef(ZOTHost, ArtifactRepo, blob.Tag)
+			dst := RegistryRef(ZOTHost, cpTestRepo("debug-log"), "copied")
+			session := ORAS("cp", src, dst, "-d").Exec()
+			Expect(session.Err).To(gbytes.Say("Request #0"))
+			Expect(session.Err).NotTo(gbytes.Say("Request #0"))
 			CompareRef(src, dst)
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that causes duplicated numbering for debug logs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1096

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
