### PR TITLE
chore: add reference details to registry errors

### DIFF
--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -21,12 +21,12 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
-// NewErrInvalidReference creates a new error based on the reference string.
-func NewErrInvalidReference(ref registry.Reference) error {
-	return NewErrInvalidReferenceStr(ref.String())
+// NewErrEmptyTagOrDigest creates a new error based on the reference string.
+func NewErrEmptyTagOrDigest(ref registry.Reference) error {
+	return NewErrEmptyTagOrDigestStr(ref.String())
 }
 
-// NewErrInvalidReferenceStr creates a new error based on the reference string.
-func NewErrInvalidReferenceStr(ref string) error {
-	return fmt.Errorf("%s: invalid image reference, expecting <name:tag|name@digest>", ref)
+// NewErrEmptyTagOrDigestStr creates a new error based on the reference string.
+func NewErrEmptyTagOrDigestStr(ref string) error {
+	return fmt.Errorf("%q: no tag or digest when expecting <name:tag|name@digest>", ref)
 }

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -18,6 +18,7 @@ package option
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -30,6 +31,7 @@ import (
 	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -290,6 +292,9 @@ func (opts *Remote) NewRegistry(registry string, common Common, logger logrus.Fi
 func (opts *Remote) NewRepository(reference string, common Common, logger logrus.FieldLogger) (repo *remote.Repository, err error) {
 	repo, err = remote.NewRepository(reference)
 	if err != nil {
+		if errors.Unwrap(err) == errdef.ErrInvalidReference {
+			return nil, fmt.Errorf("%q: %v", reference, err)
+		}
 		return nil, err
 	}
 	registry := repo.Reference.Registry

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -177,7 +177,7 @@ func (opts *Target) NewReadonlyTarget(ctx context.Context, common Common, logger
 // EnsureReferenceNotEmpty ensures whether the tag or digest is empty.
 func (opts *Target) EnsureReferenceNotEmpty() error {
 	if opts.Reference == "" {
-		return oerrors.NewErrInvalidReferenceStr(opts.RawReference)
+		return oerrors.NewErrEmptyTagOrDigestStr(opts.RawReference)
 	}
 	return nil
 }

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -85,7 +85,7 @@ func deleteManifest(ctx context.Context, opts deleteOptions) error {
 	}
 
 	if repo.Reference.Reference == "" {
-		return oerrors.NewErrInvalidReference(repo.Reference)
+		return oerrors.NewErrEmptyTagOrDigest(repo.Reference)
 	}
 
 	// add both pull and delete scope hints for dst repository to save potential delete-scope token requests during deleting

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -61,7 +61,7 @@ var _ = Describe("ORAS beginners:", func() {
 		})
 
 		It("should fail when no tag or digest found in provided subject reference", func() {
-			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "invalid image reference").Exec()
+			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
 	})
 })

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -268,7 +268,7 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 
 		It("should fail if no manifest tag or digest is provided", func() {
-			ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "invalid image reference").Exec()
+			ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
 	})
 
@@ -331,7 +331,7 @@ var _ = Describe("1.1 registry users:", func() {
 				MatchContent(multi_arch.LinuxAMD64ConfigDesc).Exec()
 		})
 		It("should fail if no manifest tag or digest is provided", func() {
-			ORAS("manifest", "fetch-config", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "invalid image reference").Exec()
+			ORAS("manifest", "fetch-config", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
 	})
 
@@ -446,7 +446,7 @@ var _ = Describe("OCI image layout users:", func() {
 		It("should fail if no manifest tag or digest is provided", func() {
 			root := PrepareTempOCI(ImageRepo)
 			ORAS("manifest", "fetch", Flags.Layout, root).ExpectFailure().
-				MatchErrKeyWords("Error:", "invalid image reference").Exec()
+				MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
 	})
 
@@ -491,7 +491,7 @@ var _ = Describe("OCI image layout users:", func() {
 		})
 		It("should fail if no manifest tag or digest is provided", func() {
 			root := prepare(foobar.Tag)
-			ORAS("manifest", "fetch-config", Flags.Layout, root).ExpectFailure().MatchErrKeyWords("Error:", "invalid image reference").Exec()
+			ORAS("manifest", "fetch-config", Flags.Layout, root).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
The errors from the oras CLI does not show the actual value that was provided. 
The following PR updates the erros to include the actual user provided reference here - 

```
$ oras copy test someotherregistry.azurecr.ui/myimage:v1
Error: "test": invalid reference: missing registry or repository

$ oras copy test.com someotherregistry.azurecr.ui/myimage:v1
Error: "test.com": invalid reference: missing registry or repository

$ oras copy test.com/test someotherregistry.azurecr.ui/myimage:v1
Error: "test.com/test": no tag or digest when expecting <name:tag|name@digest>

$ oras copy test.com/test: someotherregistry.azurecr.ui/myimage:v1
Error: "test.com/test:": no tag or digest when expecting <name:tag|name@digest>

$ oras copy test.com/test@ someotherregistry.azurecr.ui/myimage:v1
Error: "test.com/test@": no tag or digest when expecting <name:tag|name@digest>

$ oras copy test.com/test:() someotherregistry.azurecr.ui/myimage:v1
Error: "test.com/test:()": invalid reference: invalid tag "()"

$ oras copy test.com/test@invalid someotherregistry.azurecr.ui/myimage:v1
Error: "test.com/test@invalid": invalid reference: invalid digest "invalid": invalid checksum digest format
```
