### PR TITLE
feat: remove empty artifact CLI message and show hints for pulling OCI image layout

### DIFF
--- a/cmd/oras/internal/display/progress/status.go
+++ b/cmd/oras/internal/display/progress/status.go
@@ -131,7 +131,7 @@ func (s *status) String(width int) (string, string) {
 		// bar + wrapper(2) + space(1) + speed + "/s"(2) + wrapper(2) = len(bar) + len(speed) + 7
 		lenLeft = barLength + speedLength + 7
 	} else {
-		left = fmt.Sprintf("√ %s %s", s.prompt, name)
+		left = fmt.Sprintf("✓ %s %s", s.prompt, name)
 	}
 	// mark(1) + space(1) + prompt + space(1) + name = len(prompt) + len(name) + 3
 	lenLeft += utf8.RuneCountInString(s.prompt) + utf8.RuneCountInString(name) + 3

--- a/cmd/oras/internal/display/progress/status_test.go
+++ b/cmd/oras/internal/display/progress/status_test.go
@@ -62,7 +62,7 @@ func Test_status_String(t *testing.T) {
 		descriptor: s.descriptor,
 	})
 	statusStr, digestStr = s.String(120)
-	if err := testutils.OrderedMatch(statusStr+digestStr, "√", s.prompt, s.descriptor.MediaType, "2/2  B", "100.00%", s.descriptor.Digest.String()); err != nil {
+	if err := testutils.OrderedMatch(statusStr+digestStr, "✓", s.prompt, s.descriptor.MediaType, "2/2  B", "100.00%", s.descriptor.Digest.String()); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the message for oras pull of an image to something actionable - 

The current outputs looks like this 
```
❯ oras pull localhost:5000/hello-world:latest
Downloaded empty artifact
Pulled [registry] localhost:5000/hello-world:latest
Digest: sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3
```

The PR modifies this to 
```
❯ go run ./cmd/oras  pull localhost:5000/hello-world:latest
Skipped pulling layers without "org.opencontainers.image.title"
Use 'oras copy localhost:5000/hello-world:latest --to-oci-layout <layout-dir>' to pull all layers.

``` 

Also changed to `✓` character for checkmark. 
