### PR TITLE
feat: make `--debug` imply `--no-tty`

### DIFF
--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -17,7 +17,6 @@ package option
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -37,7 +36,7 @@ type Common struct {
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
-	fs.BoolVarP(&opts.Debug, "debug", "d", false, "debug mode")
+	fs.BoolVarP(&opts.Debug, "debug", "d", false, "output debug logs(implies --no-tty)")
 	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose output")
 	fs.BoolVarP(&opts.noTTY, "no-tty", "", false, "[Preview] do not show progress output")
 }
@@ -57,7 +56,6 @@ func (opts *Common) Parse() error {
 func (opts *Common) parseTTY(f *os.File) error {
 	if !opts.noTTY {
 		if opts.Debug {
-			fmt.Println("overwiting --no-tty to true since --debug is set")
 			opts.noTTY = true
 		} else if term.IsTerminal(int(f.Fd())) {
 			opts.TTY = f

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -36,7 +36,7 @@ type Common struct {
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
-	fs.BoolVarP(&opts.Debug, "debug", "d", false, "output debug logs(implies --no-tty)")
+	fs.BoolVarP(&opts.Debug, "debug", "d", false, "output debug logs (implies --no-tty)")
 	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose output")
 	fs.BoolVarP(&opts.noTTY, "no-tty", "", false, "[Preview] do not show progress output")
 }

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -17,7 +17,7 @@ package option
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -55,11 +55,13 @@ func (opts *Common) Parse() error {
 
 // parseTTY gets target options from user input.
 func (opts *Common) parseTTY(f *os.File) error {
-	if !opts.noTTY && term.IsTerminal(int(f.Fd())) {
+	if !opts.noTTY {
 		if opts.Debug {
-			return errors.New("cannot use --debug, add --no-tty to suppress terminal output")
+			fmt.Println("overwiting --no-tty to true since --debug is set")
+			opts.noTTY = true
+		} else if term.IsTerminal(int(f.Fd())) {
+			opts.TTY = f
 		}
-		opts.TTY = f
 	}
 	return nil
 }

--- a/cmd/oras/internal/option/common_unix_test.go
+++ b/cmd/oras/internal/option/common_unix_test.go
@@ -38,7 +38,10 @@ func TestCommon_parseTTY(t *testing.T) {
 
 	// --debug
 	opts.Debug = true
-	if err := opts.parseTTY(device); err == nil {
-		t.Error("expected error when debug is set with TTY output")
+	if err := opts.parseTTY(device); err != nil {
+		t.Errorf("unexpected error with --debug: %v", err)
+	}
+	if !opts.noTTY {
+		t.Errorf("expected --no-tty to be true with --debug")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes `--debug` flag imply `--no-tty` flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #940 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
