### PR TITLE
fix: should not print copy hint for manifest in verbose mode

### DIFF
--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -268,7 +268,6 @@ func doPull(ctx context.Context, src oras.ReadOnlyTarget, dst oras.GraphTarget, 
 				return nil
 			}
 			name = desc.MediaType
-			skippedLayers++
 		}
 		printed.Store(generateContentKey(desc), true)
 		return display.Print("Downloaded ", display.ShortDigest(desc), name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR avoids wrong hinting on unnamed manifest/index in verbose mode.

Suppose we have below manifest stored in registry
```console
$ oras manifest fetch --pretty localhost:5000/test:config                                                         
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "artifactType": "my.test/example",
  "config": {
    "mediaType": "bar/test",
    "digest": "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
    "size": 3
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
      "size": 3,
      "annotations": {
        "org.opencontainers.image.title": "foo"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2023-11-03T01:20:50Z"
  }
}
```

Before the change, the verbose output will always hint user to use `oras copy` to copy unnamed layer. But actually only the manifest is unnamed
```console
$ oras pull localhost:5000/test:config -o pulled --config my.config -v
✓ Pulled      my.config                                                                                                                                                                       3/3  B 100.00%    3ms
  └─ sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae 
✓ Pulled      foo                                                                                                                                                                             3/3  B 100.00%  706µs
  └─ sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae 
✓ Pulled      application/vnd.oci.image.manifest.v1+json                                                                                                                                  522/522  B 100.00%  262µs
  └─ sha256:007fa1a84c35baf14b14698b8f2f4b3eb99200b496be446e6ea6c478029d75b9 
Skipped pulling layers without file name in "org.opencontainers.image.title"
Use 'oras copy localhost:5000/test:config --to-oci-layout <layout-dir>' to pull all layers.
```

After the change, the verbose output will not do that
```console
oras pull localhost:5000/test:config -o pulled --config my.config 
✓ Pulled      my.config                                                                                                                                                                       3/3  B 100.00%    1ms
  └─ sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae 
✓ Pulled      foo                                                                                                                                                                             3/3  B 100.00%    4ms
  └─ sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae 
✓ Pulled      application/vnd.oci.image.manifest.v1+json                                                                                                                                  522/522  B 100.00%     0s
  └─ sha256:007fa1a84c35baf14b14698b8f2f4b3eb99200b496be446e6ea6c478029d75b9 
Pulled [registry] localhost:5000/test:config
Digest: sha256:007fa1a84c35baf14b14698b8f2f4b3eb99200b496be446e6ea6c478029d75b9
```
