### PR TITLE
fix: resolve regression made in #1164

### DIFF
--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -231,6 +231,11 @@ func doPull(ctx context.Context, src oras.ReadOnlyTarget, dst oras.GraphTarget, 
 		for _, s := range nodes {
 			if s.Annotations[ocispec.AnnotationTitle] == "" {
 				if content.Equal(s, ocispec.DescriptorEmptyJSON) {
+					// empty layer
+					continue
+				}
+				if s.Annotations[ocispec.AnnotationTitle] == "" {
+					// unnamed layers are skipped
 					skippedLayers++
 				}
 				ss, err := content.Successors(ctx, fetcher, s)


### PR DESCRIPTION
**What this PR does / why we need it**:
#1164 has a regression which only print skip hints for empty layers. This PR fixed it. Tested with below command. Will add E2E tests to cover all possibility for the skip hint

```console
✗ ./bin/linux/amd64/oras pull ghcr.io/oras-project/oras:v1.1.0 -o pulled --platform linux/amd64
✓ Skipped     application/vnd.oci.image.layer.v1.tar+gzip                                                                                                                                                                                                                                            3.21/3.21 MB 100.00%     0s
  └─ sha256:8921db27df2831fa6eaa85321205a2470c669b855f3ec95d5a3c2b46de0442c9 
✓ Skipped     application/vnd.oci.image.layer.v1.tar+gzip                                                                                                                                                                                                                                            2.74/2.74 MB 100.00%     0s
  └─ sha256:c03f8561538a489bffa3df71a54f0bb1d61b73b1146e9afaefff90264972d15d 
✓ Skipped     application/vnd.oci.image.layer.v1.tar+gzip                                                                                                                                                                                                                                            3.57/3.57 MB 100.00%     0s
  └─ sha256:fb7cddd3bf538e066da2433159de5b759336497e6e6d14b0d30097f6fee60436 
✓ Skipped     application/vnd.oci.image.layer.v1.tar+gzip                                                                                                                                                                                                                                                97/97  B 100.00%     0s
  └─ sha256:5165500f6395b142b9c4ea6dff0d4ead798b45f36d60559f1023970edb3d9bc2 
✓ Skipped     application/vnd.oci.image.layer.v1.tar+gzip                                                                                                                                                                                                                                                32/32  B 100.00%     0s
  └─ sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 
✓ Skipped     application/vnd.oci.image.config.v1+json                                                                                                                                                                                                                                               1.57/1.57 kB 100.00%     0s
  └─ sha256:7f6a5a12676c0e61ab4847cddee29d4dac535cf10fd1c2c76d501911d892cd40 
✓ Pulled      application/vnd.oci.image.manifest.v1+json                                                                                                                                                                                                                                             1.21/1.21 kB 100.00%     0s 
  └─ sha256:b54d7405f956d7219523a4cd54cf1c6fb4820099e234c0e14566a5113874e7c5 
Skipped pulling layers without file name in "org.opencontainers.image.title"
Use 'oras copy ghcr.io/oras-project/oras:v1.1.0 --to-oci-layout <layout-dir>' to pull all layers.
```
