### PR TITLE
feat: add resolve command

### DIFF
--- a/cmd/oras/root/cmd.go
+++ b/cmd/oras/root/cmd.go
@@ -34,6 +34,7 @@ func New() *cobra.Command {
 		logoutCmd(),
 		versionCmd(),
 		discoverCmd(),
+		resolveCmd(),
 		copyCmd(),
 		tagCmd(),
 		attachCmd(),

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -18,7 +18,6 @@ package root
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
@@ -37,7 +36,7 @@ func resolveCmd() *cobra.Command {
 	var opts resolveOptions
 
 	cmd := &cobra.Command{
-		Use:   "resolve [flags] <name>:<tag>",
+		Use:   "resolve [flags] <name>{:<tag>|@<digest>}",
 		Short: "[Experimental] Resolves digest of the target artifact",
 		Long: `[Experimental] Resolves digest of the target artifact
 
@@ -78,11 +77,7 @@ func runResolve(ctx context.Context, opts resolveOptions) error {
 	}
 
 	if opts.FullRef {
-		digest := desc.Digest.String()
-		if !strings.HasSuffix(opts.RawReference, digest) {
-			opts.RawReference = fmt.Sprintf("%s@%s", opts.Path, desc.Digest)
-		}
-		fmt.Printf("%s\n", opts.RawReference)
+		fmt.Printf("%s@%s\n", opts.Path, desc.Digest)
 	} else {
 		fmt.Println(desc.Digest.String())
 	}

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -72,7 +72,11 @@ func runResolve(ctx context.Context, opts resolveOptions) error {
 	}
 
 	if opts.FullRef {
-		fmt.Printf("%s@%s\n", opts.RawReference, desc.Digest.String())
+	      digest := desc.Digest.String()
+	      if !strings.HasSuffix(opts.RawReference, digest) {
+		      opts.RawReference = fmt.Sprintf("%s@%s", opts.Path, subject.Digest)
+	      }
+	      fmt.Printf("%s\n", opts.RawReference)
 	} else {
 		fmt.Println(desc.Digest.String())
 	}

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -1,0 +1,81 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package root
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/option"
+)
+
+type resolveOptions struct {
+	option.Common
+	option.Platform
+	option.Target
+
+	FullRef bool
+}
+
+func resolveCmd() *cobra.Command {
+	var opts resolveOptions
+
+	cmd := &cobra.Command{
+		Use:     "resolve [flags] <name>:<tag>",
+		Short:   "Resolves digest of the target artifact",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"digest"},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.RawReference = args[0]
+			return option.Parse(&opts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResolve(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.FullRef, "full-ref", false, "print the full artifact reference with digest")
+	option.ApplyFlags(&opts, cmd.Flags())
+	return cmd
+}
+
+func runResolve(ctx context.Context, opts resolveOptions) error {
+	ctx, _ = opts.WithContext(ctx)
+	repo, err := opts.NewReadonlyTarget(ctx, opts.Common)
+	if err != nil {
+		return err
+	}
+	if err := opts.EnsureReferenceNotEmpty(); err != nil {
+		return err
+	}
+	resolveOpts := oras.DefaultResolveOptions
+	resolveOpts.TargetPlatform = opts.Platform.Platform
+	desc, err := oras.Resolve(ctx, repo, opts.Reference, resolveOpts)
+
+	if err != nil {
+		return fmt.Errorf("failed to resolve the digest: %w", err)
+	}
+
+	if opts.FullRef {
+		fmt.Printf("%s@%s\n", opts.RawReference, desc.Digest.String())
+	} else {
+		fmt.Println(desc.Digest.String())
+	}
+
+	return nil
+}

--- a/test/e2e/internal/utils/testdata.go
+++ b/test/e2e/internal/utils/testdata.go
@@ -22,6 +22,7 @@ const (
 	BlobRepo     = "command/blobs"
 	ArtifactRepo = "command/artifacts"
 	Namespace    = "command"
+	InvalidRepo  = "INVALID"
 	// env
 	RegHostKey         = "ORAS_REGISTRY_HOST"
 	FallbackRegHostKey = "ORAS_REGISTRY_FALLBACK_HOST"

--- a/test/e2e/suite/command/resolve.go
+++ b/test/e2e/suite/command/resolve.go
@@ -1,0 +1,53 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"oras.land/oras/test/e2e/internal/testdata/multi_arch"
+	. "oras.land/oras/test/e2e/internal/utils"
+)
+
+var _ = Describe("ORAS beginners:", func() {
+	When("running resolve command", func() {
+		It("should fail when no manifest reference provided", func() {
+			ORAS("resolve").ExpectFailure().MatchErrKeyWords("Error:").Exec()
+		})
+		It("should fail when provided manifest reference is not found", func() {
+			ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, "i-dont-think-this-tag-exists")).ExpectFailure().MatchErrKeyWords("Error: failed to resolve digest:", "not found").Exec()
+		})
+		It("should resolve with with just digest", func() {
+			out := ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, multi_arch.Digest)).Exec().Out
+			outString := string(out.Contents())
+			outString = strings.TrimSpace(outString)
+			gomega.Expect(outString).To(gomega.Equal(multi_arch.Digest))
+
+		})
+		It("should resolve with with the fully qualified reference", func() {
+			out := ORAS("resolve", "-l", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag)).Exec().Out
+			gomega.Expect(out).To(gbytes.Say(fmt.Sprintf("%s/%s@%s", ZOTHost, ImageRepo, multi_arch.Digest)))
+		})
+		It("should resolve with a fully qualified reference for a platform", func() {
+			out := ORAS("resolve", "--full-reference", "--platform", "linux/amd64", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag)).Exec().Out
+			gomega.Expect(out).To(gbytes.Say(fmt.Sprintf("%s/%s@%s", ZOTHost, ImageRepo, multi_arch.LinuxAMD64.Digest)))
+		})
+	})
+})

--- a/test/e2e/suite/command/resolve.go
+++ b/test/e2e/suite/command/resolve.go
@@ -31,18 +31,23 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail when no manifest reference provided", func() {
 			ORAS("resolve").ExpectFailure().MatchErrKeyWords("Error:").Exec()
 		})
+		It("should fail when repo is invalid", func() {
+			ORAS("resolve", fmt.Sprintf("%s/%s", ZOTHost, InvalidRepo)).ExpectFailure().MatchErrKeyWords("Error:", fmt.Sprintf("invalid reference: invalid repository %q", InvalidRepo)).Exec()
+		})
+		It("should fail when no tag or digest provided", func() {
+			ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest when expecting <name:tag|name@digest>").Exec()
+		})
 		It("should fail when provided manifest reference is not found", func() {
 			ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, "i-dont-think-this-tag-exists")).ExpectFailure().MatchErrKeyWords("Error: failed to resolve digest:", "not found").Exec()
 		})
-		It("should resolve with with just digest", func() {
+		It("should resolve with just digest", func() {
 			out := ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, multi_arch.Digest)).Exec().Out
 			outString := string(out.Contents())
 			outString = strings.TrimSpace(outString)
 			gomega.Expect(outString).To(gomega.Equal(multi_arch.Digest))
-
 		})
-		It("should resolve with with the fully qualified reference", func() {
-			out := ORAS("resolve", "-l", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag)).Exec().Out
+		It("should resolve with a fully qualified reference", func() {
+			out := ORAS("digest", "-l", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag)).Exec().Out
 			gomega.Expect(out).To(gbytes.Say(fmt.Sprintf("%s/%s@%s", ZOTHost, ImageRepo, multi_arch.Digest)))
 		})
 		It("should resolve with a fully qualified reference for a platform", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an update with a test and flags based of PR from @amands98. 
@amands98  if you would like to combine these commits I'm more than happy to send a PR to your branch. 

- Resolve command with support for platform output of fully qualified reference - 

``` 
❯ oras resolve -l localhost:5000/command/artifacts:multi
localhost:5000/command/artifacts@sha256:e2bfc9cc6a84ec2d7365b5a28c6bc5806b7fa581c9ad7883be955a64e3cc034f
```

```
❯ oras resolve  localhost:5000/command/artifacts:multi --platform linux/amd64
sha256:9d84a5716c66a1d1b9c13f8ed157ba7d1edfe7f9b8766728b8a1f25c0d9c14c1
```

```
❯ oras digest docker.io/library/hello-world:latest
sha256:88ec0acaa3ec199d3b7eaf73588f4518c25f9d34f58ce9a0df68429c5af48e8d
```

Fixes #907.