### PR TITLE
feat: improve returned error for invalid arguments

### DIFF
--- a/cmd/oras/internal/argument/checker.go
+++ b/cmd/oras/internal/argument/checker.go
@@ -1,0 +1,32 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package argument
+
+import "fmt"
+
+// Exactly checks if the number of arguments is exactly cnt.
+func Exactly(cnt int) func(args []string) (bool, string) {
+	return func(args []string) (bool, string) {
+		return len(args) == cnt, fmt.Sprintf("exactly %d argument", cnt)
+	}
+}
+
+// AtLeast checks if the number of arguments is larger or equal to cnt.
+func AtLeast(cnt int) func(args []string) (bool, string) {
+	return func(args []string) (bool, string) {
+		return len(args) >= cnt, fmt.Sprintf("at least %d argument", cnt)
+	}
+}

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -17,6 +17,7 @@ package errors
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
@@ -51,9 +52,9 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 	return func(cmd *cobra.Command, args []string) error {
 		if ok, text := checker(args); !ok {
 			return NewOuput(
-				fmt.Sprintf(`%q requires %s but got %d`, cmd.CommandPath(), text, len(args)),
+				fmt.Sprintf(`%q requires %s but got %q`, cmd.CommandPath(), text, strings.Join(args, ",")),
 				cmd.Use,
-				fmt.Sprintf(`You need to specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
+				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)
 		}
 		return nil

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -52,7 +52,7 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 	return func(cmd *cobra.Command, args []string) error {
 		if ok, text := checker(args); !ok {
 			return NewOuput(
-				fmt.Sprintf(`%q requires %s but got: %s`, cmd.CommandPath(), text, strings.Join(args, " ")),
+				fmt.Sprintf(`%q requires %s but got %d: %s`, cmd.CommandPath(), text, len(args), strings.Join(args, " ")),
 				fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -52,7 +52,7 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 	return func(cmd *cobra.Command, args []string) error {
 		if ok, text := checker(args); !ok {
 			return NewOuput(
-				fmt.Sprintf(`%q requires %s but got %q`, cmd.CommandPath(), text, strings.Join(args, ",")),
+				fmt.Sprintf(`%q requires %s but got %s`, cmd.CommandPath(), text, strings.Join(args, " ")),
 				fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -22,12 +22,14 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+// Error is the error type for CLI error messaging.
 type Error struct {
 	Err            error
 	Usage          string
 	Recommendation string
 }
 
+// Error implements the error interface.
 func (o *Error) Error() string {
 	ret := o.Err.Error()
 	if o.Usage != "" {

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -52,7 +52,7 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 	return func(cmd *cobra.Command, args []string) error {
 		if ok, text := checker(args); !ok {
 			return NewOuput(
-				fmt.Sprintf(`%q requires %s but got %d: %s`, cmd.CommandPath(), text, len(args), strings.Join(args, " ")),
+				fmt.Sprintf(`%q requires %s but got %d: [%s]`, cmd.CommandPath(), text, len(args), strings.Join(args, " ")),
 				fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -21,6 +21,30 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+type output struct {
+	description, usage, suggestion string
+}
+
+func (o *output) Error() string {
+	ret := o.description
+	if o.usage != "" {
+		ret += fmt.Sprintf("\nUsage: %s", o.usage)
+	}
+	if o.suggestion != "" {
+		ret += fmt.Sprintf("\n%s", o.suggestion)
+	}
+	return ret
+}
+
+// NewOuput creates a new error for CLI output.
+func NewOuput(description, usage, suggestion string) error {
+	return &output{
+		description: description,
+		usage:       usage,
+		suggestion:  suggestion,
+	}
+}
+
 // NewErrEmptyTagOrDigest creates a new error based on the reference string.
 func NewErrEmptyTagOrDigest(ref registry.Reference) error {
 	return NewErrEmptyTagOrDigestStr(ref.String())

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -52,7 +52,7 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 	return func(cmd *cobra.Command, args []string) error {
 		if ok, text := checker(args); !ok {
 			return NewOuput(
-				fmt.Sprintf(`%q requires %s but got %s`, cmd.CommandPath(), text, strings.Join(args, " ")),
+				fmt.Sprintf(`%q requires %s but got: %s`, cmd.CommandPath(), text, strings.Join(args, " ")),
 				fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -29,6 +29,11 @@ type Error struct {
 	Recommendation string
 }
 
+// Unwrap implements the errors.Wrapper interface.
+func (o *Error) Unwrap() error {
+	return o.Err
+}
+
 // Error implements the error interface.
 func (o *Error) Error() string {
 	ret := o.Err.Error()

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -53,7 +53,7 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 		if ok, text := checker(args); !ok {
 			return NewOuput(
 				fmt.Sprintf(`%q requires %s but got %q`, cmd.CommandPath(), text, strings.Join(args, ",")),
-				cmd.Use,
+				fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)
 		}

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -18,6 +18,7 @@ package errors
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -42,6 +43,20 @@ func NewOuput(description, usage, suggestion string) error {
 		description: description,
 		usage:       usage,
 		suggestion:  suggestion,
+	}
+}
+
+// ArgsChecker checks the args with the checker function.
+func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if ok, text := checker(args); !ok {
+			return NewOuput(
+				fmt.Sprintf(`%q requires %s but got %d`, cmd.CommandPath(), text, len(args)),
+				cmd.Use,
+				fmt.Sprintf(`You need to specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
+			)
+		}
+		return nil
 	}
 }
 

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -17,7 +17,6 @@ package errors
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry"
@@ -52,7 +51,7 @@ func ArgsChecker(checker func(args []string) (bool, string), usage string) cobra
 	return func(cmd *cobra.Command, args []string) error {
 		if ok, text := checker(args); !ok {
 			return NewOuput(
-				fmt.Sprintf(`%q requires %s but got %d: [%s]`, cmd.CommandPath(), text, len(args), strings.Join(args, " ")),
+				fmt.Sprintf(`%q requires %s but got %d`, cmd.CommandPath(), text, len(args)),
 				fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 				fmt.Sprintf(`Please specify %s as %s. Run "%s -h" for more options and examples`, text, usage, cmd.CommandPath()),
 			)

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -27,6 +27,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -77,10 +78,7 @@ Example - Attach file 'hi.txt' and export the pushed manifest to 'manifest.json'
 Example - Attach file to the manifest tagged 'v1' in an OCI image layout folder 'layout-dir':
   oras attach --oci-layout --artifact-type doc/example layout-dir:v1 hi.txt
 `,
-		Args: oerrors.ArgsChecker(
-			func(args []string) (bool, string) {
-				return len(args) >= 1, "at least 1 argument"
-			}, "the destination artifact for attaching."),
+		Args: oerrors.CheckArgs(argument.AtLeast(1), "the destination artifact for attaching."),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			opts.FileRefs = args[1:]

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -28,6 +28,7 @@ import (
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras/cmd/oras/internal/display/track"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/graph"
 	"oras.land/oras/internal/registryutil"
@@ -75,8 +76,11 @@ Example - Attach file 'hi.txt' and export the pushed manifest to 'manifest.json'
 
 Example - Attach file to the manifest tagged 'v1' in an OCI image layout folder 'layout-dir':
   oras attach --oci-layout --artifact-type doc/example layout-dir:v1 hi.txt
-  `,
-		Args: cobra.MinimumNArgs(1),
+`,
+		Args: oerrors.ArgsChecker(
+			func(args []string) (bool, string) {
+				return len(args) >= 1, "at least 1 argument"
+			}, "the destination artifact for attaching."),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			opts.FileRefs = args[1:]

--- a/cmd/oras/root/blob/delete.go
+++ b/cmd/oras/root/blob/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/registryutil"
@@ -54,9 +55,7 @@ Example - Delete a blob without prompting confirmation:
 Example - Delete a blob and print its descriptor:
   oras blob delete --descriptor --force localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
   `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the target blob to delete"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the target blob to delete"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			if opts.OutputDescriptor && !opts.Force {

--- a/cmd/oras/root/blob/delete.go
+++ b/cmd/oras/root/blob/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/registryutil"
 )
@@ -55,7 +56,9 @@ Example - Delete a blob without prompting confirmation:
 Example - Delete a blob and print its descriptor:
   oras blob delete --descriptor --force localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
   `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the target blob to delete"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.OutputDescriptor && !opts.Force {
 				return errors.New("must apply --force to confirm the deletion if the descriptor is outputted")

--- a/cmd/oras/root/blob/fetch.go
+++ b/cmd/oras/root/blob/fetch.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/display/track"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -67,7 +68,9 @@ Example - Fetch and print a blob from OCI image layout folder 'layout-dir':
 Example - Fetch and print a blob from OCI image layout archive file 'layout.tar':
   oras blob fetch --oci-layout --output - layout.tar@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the target blob to fetch"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputPath == "" && !opts.OutputDescriptor {
 				return errors.New("either `--output` or `--descriptor` must be provided")

--- a/cmd/oras/root/blob/fetch.go
+++ b/cmd/oras/root/blob/fetch.go
@@ -28,6 +28,7 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -68,9 +69,7 @@ Example - Fetch and print a blob from OCI image layout folder 'layout-dir':
 Example - Fetch and print a blob from OCI image layout archive file 'layout.tar':
   oras blob fetch --oci-layout --output - layout.tar@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the target blob to fetch"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the target blob to fetch"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputPath == "" && !opts.OutputDescriptor {
 				return errors.New("either `--output` or `--descriptor` must be provided")

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -25,6 +25,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
@@ -74,9 +75,7 @@ Example - Push blob without TLS:
 Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
   oras blob push --oci-layout layout-dir hi.txt
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 2, "exactly 2 arguments"
-		}, "the destination to push to and the file to read blob content from"),
+		Args: oerrors.CheckArgs(argument.Exactly(2), "the destination to push to and the file to read blob content from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			opts.fileRef = args[1]

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -27,6 +27,7 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/file"
 )
@@ -73,7 +74,9 @@ Example - Push blob without TLS:
 Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
   oras blob push --oci-layout layout-dir hi.txt
 `,
-		Args: cobra.ExactArgs(2),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 2, "exactly 2 arguments"
+		}, "the destination to push to and the file to read blob content from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			opts.fileRef = args[1]

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -85,8 +85,8 @@ Example - Copy an artifact with multiple tags with concurrency tuned:
   oras cp --concurrency 10 localhost:5000/net-monitor:v1 localhost:5000/net-monitor-copy:tag1,tag2,tag3
 `,
 		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) != 2, "exactly 2 arguments"
-		}, "the source and destination for copying."),
+			return len(args) == 2, "exactly 2 arguments"
+		}, "the source and destination for copying"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.From.RawReference = args[0]
 			refs := strings.Split(args[1], ",")

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -31,6 +31,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/docker"
 	"oras.land/oras/internal/graph"
@@ -83,7 +84,9 @@ Example - Copy an artifact with multiple tags:
 Example - Copy an artifact with multiple tags with concurrency tuned:
   oras cp --concurrency 10 localhost:5000/net-monitor:v1 localhost:5000/net-monitor-copy:tag1,tag2,tag3
 `,
-		Args: cobra.ExactArgs(2),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) != 2, "exactly 2 arguments"
+		}, "the source and destination for copying."),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.From.RawReference = args[0]
 			refs := strings.Split(args[1], ",")

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
@@ -84,9 +85,7 @@ Example - Copy an artifact with multiple tags:
 Example - Copy an artifact with multiple tags with concurrency tuned:
   oras cp --concurrency 10 localhost:5000/net-monitor:v1 localhost:5000/net-monitor-copy:tag1,tag2,tag3
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 2, "exactly 2 arguments"
-		}, "the source and destination for copying"),
+		Args: oerrors.CheckArgs(argument.Exactly(2), "the source and destination for copying"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.From.RawReference = args[0]
 			refs := strings.Split(args[1], ",")

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"oras.land/oras-go/v2"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/graph"
 	"oras.land/oras/internal/tree"
@@ -73,7 +74,9 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
   oras discover --oci-layout layout-dir:v1
   oras discover --oci-layout -v -o tree layout-dir:v1
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 arguments"
+		}, "the target artifact to discover referrers from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			return option.Parse(&opts)

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -28,6 +28,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/graph"
@@ -74,9 +75,7 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
   oras discover --oci-layout layout-dir:v1
   oras discover --oci-layout -v -o tree layout-dir:v1
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the target artifact to discover referrers from"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the target artifact to discover referrers from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			return option.Parse(&opts)

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -75,7 +75,7 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
   oras discover --oci-layout -v -o tree layout-dir:v1
 `,
 		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 arguments"
+			return len(args) == 1, "exactly 1 argument"
 		}, "the target artifact to discover referrers from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -25,6 +25,7 @@ import (
 	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/credential"
@@ -62,9 +63,7 @@ Example - Log in with username and password in an interactive terminal:
 Example - Log in with username and password in an interactive terminal and no TLS check:
   oras login --insecure localhost:5000
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the registry to log in to"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the registry to log in to"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return option.Parse(&opts)
 		},

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -63,7 +63,7 @@ Example - Log in with username and password in an interactive terminal and no TL
   oras login --insecure localhost:5000
 `,
 		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 arguments"
+			return len(args) == 1, "exactly 1 argument"
 		}, "the registry to log in to"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return option.Parse(&opts)

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -25,6 +25,7 @@ import (
 	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/credential"
 	"oras.land/oras/internal/io"
@@ -61,7 +62,9 @@ Example - Log in with username and password in an interactive terminal:
 Example - Log in with username and password in an interactive terminal and no TLS check:
   oras login --insecure localhost:5000
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 arguments"
+		}, "the registry to log in to"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return option.Parse(&opts)
 		},

--- a/cmd/oras/root/logout.go
+++ b/cmd/oras/root/logout.go
@@ -21,6 +21,7 @@ import (
 	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/internal/credential"
 )
 
@@ -41,7 +42,9 @@ func logoutCmd() *cobra.Command {
 Example - Logout:
   oras logout localhost:5000
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 arguments"
+		}, "the registry you want to log out"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.hostname = args[0]
 			return runLogout(cmd.Context(), opts)

--- a/cmd/oras/root/logout.go
+++ b/cmd/oras/root/logout.go
@@ -43,7 +43,7 @@ Example - Logout:
   oras logout localhost:5000
 `,
 		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 arguments"
+			return len(args) == 1, "exactly 1 argument"
 		}, "the registry you want to log out"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.hostname = args[0]

--- a/cmd/oras/root/logout.go
+++ b/cmd/oras/root/logout.go
@@ -21,6 +21,7 @@ import (
 	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/internal/credential"
 )
@@ -42,9 +43,7 @@ func logoutCmd() *cobra.Command {
 Example - Logout:
   oras logout localhost:5000
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the registry you want to log out"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the registry you want to log out"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.hostname = args[0]
 			return runLogout(cmd.Context(), opts)

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -59,7 +59,9 @@ Example - Delete a manifest and print its descriptor:
 Example - Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9' from repository 'localhost:5000/hello':
   oras manifest delete localhost:5000/hello@sha:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the manifest to delete"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.OutputDescriptor && !opts.Force {
 				return errors.New("must apply --force to confirm the deletion if the descriptor is outputted")

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/registryutil"
@@ -57,9 +58,7 @@ Example - Delete a manifest and print its descriptor:
 Example - Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9' from repository 'localhost:5000/hello':
   oras manifest delete localhost:5000/hello@sha:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the manifest to delete"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the manifest to delete"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			if opts.OutputDescriptor && !opts.Force {

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/registryutil"
 )

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -69,7 +70,9 @@ Example - Fetch raw manifest from an OCI image layout folder 'layout-dir':
 Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
   oras manifest fetch --oci-layout layout.tar:v1
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the manifest to fetch"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputPath == "-" && opts.OutputDescriptor {
 				return errors.New("`--output -` cannot be used with `--descriptor` at the same time")

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
@@ -70,9 +71,7 @@ Example - Fetch raw manifest from an OCI image layout folder 'layout-dir':
 Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
   oras manifest fetch --oci-layout layout.tar:v1
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the manifest to fetch"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the manifest to fetch"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputPath == "-" && opts.OutputDescriptor {
 				return errors.New("`--output -` cannot be used with `--descriptor` at the same time")

--- a/cmd/oras/root/manifest/fetch_config.go
+++ b/cmd/oras/root/manifest/fetch_config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/descriptor"
@@ -68,9 +69,7 @@ Example - Fetch the descriptor of the config:
 Example - Fetch and print the prettified descriptor of the config:
   oras manifest fetch-config --descriptor --pretty localhost:5000/hello:v1
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the manifest config to fetch"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the manifest config to fetch"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputPath == "-" && opts.OutputDescriptor {
 				return errors.New("`--output -` cannot be used with `--descriptor` at the same time")

--- a/cmd/oras/root/manifest/fetch_config.go
+++ b/cmd/oras/root/manifest/fetch_config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/descriptor"
 )
@@ -67,7 +68,9 @@ Example - Fetch the descriptor of the config:
 Example - Fetch and print the prettified descriptor of the config:
   oras manifest fetch-config --descriptor --pretty localhost:5000/hello:v1
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the manifest config to fetch"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.outputPath == "-" && opts.OutputDescriptor {
 				return errors.New("`--output -` cannot be used with `--descriptor` at the same time")

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -28,6 +28,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -81,9 +82,7 @@ Example - Push a manifest to repository 'localhost:5000/hello' and tag with 'tag
 Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag with 'v1':
   oras manifest push --oci-layout layout-dir:v1 manifest.json
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 2, "exactly 2 arguments"
-		}, "the destination to push to and the file to read manifest content from"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the destination to push to and the file to read manifest content from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.fileRef = args[1]
 			if opts.fileRef == "-" && opts.PasswordFromStdin {

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/display"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/file"
 )
@@ -80,7 +81,9 @@ Example - Push a manifest to repository 'localhost:5000/hello' and tag with 'tag
 Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag with 'v1':
   oras manifest push --oci-layout layout-dir:v1 manifest.json
 `,
-		Args: cobra.ExactArgs(2),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 2, "exactly 2 arguments"
+		}, "the destination to push to and the file to read manifest content from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.fileRef = args[1]
 			if opts.fileRef == "-" && opts.PasswordFromStdin {

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -82,7 +82,7 @@ Example - Push a manifest to repository 'localhost:5000/hello' and tag with 'tag
 Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag with 'v1':
   oras manifest push --oci-layout layout-dir:v1 manifest.json
 `,
-		Args: oerrors.CheckArgs(argument.Exactly(1), "the destination to push to and the file to read manifest content from"),
+		Args: oerrors.CheckArgs(argument.Exactly(2), "the destination to push to and the file to read manifest content from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.fileRef = args[1]
 			if opts.fileRef == "-" && opts.PasswordFromStdin {

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -30,6 +30,7 @@ import (
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/fileref"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/graph"
@@ -84,7 +85,9 @@ Example - Pull artifact files from an OCI image layout folder 'layout-dir':
 Example - Pull artifact files from an OCI layout archive 'layout.tar':
   oras pull --oci-layout layout.tar:v1
 `,
-		Args: cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 arguments"
+		}, "the artifact reference you want to pull"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			return option.Parse(&opts)

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -86,7 +86,7 @@ Example - Pull artifact files from an OCI layout archive 'layout.tar':
   oras pull --oci-layout layout.tar:v1
 `,
 		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 arguments"
+			return len(args) == 1, "exactly 1 argument"
 		}, "the artifact reference you want to pull"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -28,6 +28,7 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
@@ -85,9 +86,7 @@ Example - Pull artifact files from an OCI image layout folder 'layout-dir':
 Example - Pull artifact files from an OCI layout archive 'layout.tar':
   oras pull --oci-layout layout.tar:v1
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the artifact reference you want to pull"),
+		Args: oerrors.CheckArgs(argument.Exactly(1), "the artifact reference you want to pull"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			return option.Parse(&opts)

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -101,16 +101,9 @@ Example - Push file "hi.txt" with multiple tags and concurrency level tuned:
 Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with tag 'test':
   oras push --oci-layout layout-dir:test hi.txt
 `,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return oerrors.NewOuput(
-					fmt.Sprintf(`%q requires at least 1 argument`, cmd.CommandPath()),
-					cmd.Use,
-					fmt.Sprintf(`You need to at least specify one arguments as the destination for pushing. Run "%s -h" for more options and examples`, cmd.CommandPath()),
-				)
-			}
-			return nil
-		},
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) >= 1, "at least 1 argument"
+		}, "the destination for pushing"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			refs := strings.Split(args[0], ",")
 			opts.RawReference = refs[0]

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -30,6 +30,7 @@ import (
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
@@ -101,9 +102,7 @@ Example - Push file "hi.txt" with multiple tags and concurrency level tuned:
 Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with tag 'test':
   oras push --oci-layout layout-dir:test hi.txt
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) >= 1, "at least 1 argument"
-		}, "the destination for pushing"),
+		Args: oerrors.CheckArgs(argument.AtLeast(1), "the destination for pushing"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			refs := strings.Split(args[0], ",")
 			opts.RawReference = refs[0]

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -32,6 +32,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/track"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/fileref"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/contentutil"
@@ -100,7 +101,16 @@ Example - Push file "hi.txt" with multiple tags and concurrency level tuned:
 Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with tag 'test':
   oras push --oci-layout layout-dir:test hi.txt
 `,
-		Args: cobra.MinimumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return oerrors.NewOuput(
+					fmt.Sprintf(`%q requires at least 1 argument`, cmd.CommandPath()),
+					cmd.Use,
+					fmt.Sprintf(`You need to at least specify one arguments as the destination for pushing. Run "%s -h" for more options and examples`, cmd.CommandPath()),
+				)
+			}
+			return nil
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			refs := strings.Split(args[0], ",")
 			opts.RawReference = refs[0]

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/repository"
 )
@@ -50,7 +51,9 @@ Example - List the repositories under a namespace in the registry:
 Example - List the repositories under the registry that include values lexically after last:
   oras repo ls --last "last_repo" localhost:5000
 `,
-		Args:    cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the target registry to list repositories from"),
 		Aliases: []string{"list"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return option.Parse(&opts)

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/repository"
@@ -51,9 +52,7 @@ Example - List the repositories under a namespace in the registry:
 Example - List the repositories under the registry that include values lexically after last:
   oras repo ls --last "last_repo" localhost:5000
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the target registry to list repositories from"),
+		Args:    oerrors.CheckArgs(argument.Exactly(1), "the target registry to list repositories from"),
 		Aliases: []string{"list"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return option.Parse(&opts)

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
@@ -62,9 +63,7 @@ Example - [Experimental] Show tags associated with a particular tagged resource:
 Example - [Experimental] Show tags associated with a digest:
   oras repo tags localhost:5000/hello@sha256:c551125a624189cece9135981621f3f3144564ddabe14b523507bf74c2281d9b
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the target repository to list tags from"),
+		Args:    oerrors.CheckArgs(argument.Exactly(1), "the target repository to list tags from"),
 		Aliases: []string{"show-tags"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -61,7 +62,9 @@ Example - [Experimental] Show tags associated with a particular tagged resource:
 Example - [Experimental] Show tags associated with a digest:
   oras repo tags localhost:5000/hello@sha256:c551125a624189cece9135981621f3f3144564ddabe14b523507bf74c2281d9b
 `,
-		Args:    cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 argument"
+		}, "the target repository to list tags from"),
 		Aliases: []string{"show-tags"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/argument"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
@@ -44,9 +45,7 @@ func resolveCmd() *cobra.Command {
 Example - Resolve digest of the target artifact:
   oras resolve localhost:5000/hello-world:v1
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 argument"
-		}, "the target artifact reference to resolve"),
+		Args:    oerrors.CheckArgs(argument.Exactly(1), "the target artifact reference to resolve"),
 		Aliases: []string{"digest"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -45,7 +45,7 @@ Example - Resolve digest of the target artifact:
   oras resolve localhost:5000/hello-world:v1
 `,
 		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) == 1, "exactly 1 arguments"
+			return len(args) == 1, "exactly 1 argument"
 		}, "the target artifact reference to resolve"),
 		Aliases: []string{"digest"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -43,7 +44,9 @@ func resolveCmd() *cobra.Command {
 Example - Resolve digest of the target artifact:
   oras resolve localhost:5000/hello-world:v1
 `,
-		Args:    cobra.ExactArgs(1),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) == 1, "exactly 1 arguments"
+		}, "the target artifact reference to resolve"),
 		Aliases: []string{"digest"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -23,6 +23,7 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras/cmd/oras/internal/display"
+	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -56,7 +57,9 @@ Example - Tag the manifest 'v1.0.1' in 'localhost:5000/hello' to 'v1.0.1', 'v1.0
 Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'layout-dir':
   oras tag layout-dir:v1.0.1 v1.0.2
 `,
-		Args: cobra.MinimumNArgs(2),
+		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
+			return len(args) >= 2, "at least 2 argument"
+		}, "the to-be-retage artifact and the tags to be added"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			if _, err := registry.ParseReference(opts.RawReference); err != nil {

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry"
+	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/display"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -57,9 +58,7 @@ Example - Tag the manifest 'v1.0.1' in 'localhost:5000/hello' to 'v1.0.1', 'v1.0
 Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'layout-dir':
   oras tag layout-dir:v1.0.1 v1.0.2
 `,
-		Args: oerrors.ArgsChecker(func(args []string) (bool, string) {
-			return len(args) >= 2, "at least 2 argument"
-		}, "the to-be-retage artifact and the tags to be added"),
+		Args: oerrors.CheckArgs(argument.AtLeast(1), "the to-be-retage artifact and the tags to be added"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.RawReference = args[0]
 			if _, err := registry.ParseReference(opts.RawReference); err != nil {

--- a/cmd/oras/root/version.go
+++ b/cmd/oras/root/version.go
@@ -17,6 +17,7 @@ package root
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 
@@ -34,7 +35,15 @@ func versionCmd() *cobra.Command {
 Example - print version:
   oras version
 `,
-		Args: cobra.NoArgs,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				_, err := fmt.Fprintf(os.Stderr, "warning: `oras version` requires no argument, %q will be ignored\n", strings.Join(args, ","))
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersion()
 		},

--- a/test/e2e/suite/auth/auth.go
+++ b/test/e2e/suite/auth/auth.go
@@ -63,7 +63,7 @@ var _ = Describe("Common registry user", Ordered, func() {
 		It("should show detailed error description if no argument provided", func() {
 			err := ORAS("login").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
-			Expect(err).Should(gbytes.Say("\nUsage: login"))
+			Expect(err).Should(gbytes.Say("\nUsage: oras login"))
 			Expect(err).Should(gbytes.Say("\n"))
 			Expect(err).Should(gbytes.Say(`Run "oras login -h"`))
 		})

--- a/test/e2e/suite/auth/auth.go
+++ b/test/e2e/suite/auth/auth.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	. "oras.land/oras/test/e2e/internal/utils"
 )
 
@@ -56,6 +58,14 @@ var _ = Describe("Common registry user", Ordered, func() {
 				WithTimeOut(20*time.Second).
 				MatchContent("Login Succeeded\n").
 				MatchErrKeyWords("WARNING", "Using --password via the CLI is insecure", "Use --password-stdin").Exec()
+		})
+
+		It("should show detailed error description if no argument provided", func() {
+			err := ORAS("login").ExpectFailure().Exec().Err
+			Expect(err).Should(gbytes.Say("Error"))
+			Expect(err).Should(gbytes.Say("\nUsage: login"))
+			Expect(err).Should(gbytes.Say("\n"))
+			Expect(err).Should(gbytes.Say(`Run "oras login -h"`))
 		})
 
 		It("should fail if no username input", func() {

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -64,6 +64,14 @@ var _ = Describe("ORAS beginners:", func() {
 			ORAS("attach", "--artifact-type", "oras/test", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--distribution-spec", "???").
 				ExpectFailure().MatchErrKeyWords("unknown distribution specification flag").Exec()
 		})
+
+		It("should show detailed error description if no argument provided", func() {
+			err := ORAS("attach").ExpectFailure().Exec().Err
+			gomega.Expect(err).Should(gbytes.Say("Error"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: attach"))
+			gomega.Expect(err).Should(gbytes.Say("\n"))
+			gomega.Expect(err).Should(gbytes.Say(`Run "oras attach -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -65,7 +65,7 @@ var _ = Describe("ORAS beginners:", func() {
 				ExpectFailure().MatchErrKeyWords("unknown distribution specification flag").Exec()
 		})
 
-		It("should show detailed error description if no argument provided", func() {
+		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("attach").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
 			gomega.Expect(err).Should(gbytes.Say("\nUsage: attach"))

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -68,7 +68,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("attach").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
-			gomega.Expect(err).Should(gbytes.Say("\nUsage: attach"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: oras attach"))
 			gomega.Expect(err).Should(gbytes.Say("\n"))
 			gomega.Expect(err).Should(gbytes.Say(`Run "oras attach -h"`))
 		})

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -110,7 +110,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("blob", "fetch").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras fetch"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras blob fetch"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras blob fetch -h"`))
 			})
@@ -139,7 +139,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("blob", "delete").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras delete"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras blob delete"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras blob delete -h"`))
 			})

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"oras.land/oras/test/e2e/internal/testdata/foobar"
 	. "oras.land/oras/test/e2e/internal/utils"
 )
@@ -105,6 +107,14 @@ var _ = Describe("ORAS beginners:", func() {
 					ExpectFailure().Exec()
 			})
 
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("blob", "fetch").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: fetch"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras blob fetch -h"`))
+			})
+
 			It("should fail if no digest provided", func() {
 				ORAS("blob", "fetch", RegistryRef(ZOTHost, ImageRepo, "")).
 					ExpectFailure().Exec()
@@ -122,6 +132,16 @@ var _ = Describe("ORAS beginners:", func() {
 
 			It("should fail if no reference is provided", func() {
 				ORAS("blob", "fetch").ExpectFailure().Exec()
+			})
+		})
+
+		When("running `blob delete`", func() {
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("blob", "delete").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: delete"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras blob delete -h"`))
 			})
 		})
 	})

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -110,7 +110,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("blob", "fetch").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: fetch"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras fetch"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras blob fetch -h"`))
 			})
@@ -139,7 +139,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("blob", "delete").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: delete"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras delete"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras blob delete -h"`))
 			})

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -67,6 +67,14 @@ var _ = Describe("ORAS beginners:", func() {
 			Expect(err).Should(gbytes.Say("\n"))
 			Expect(err).Should(gbytes.Say(`Run "oras cp -h"`))
 		})
+
+		It("should show detailed error description if more than 2 arguments are provided", func() {
+			err := ORAS("cp", "foo", "bar", "buz").ExpectFailure().Exec().Err
+			Expect(err).Should(gbytes.Say("Error"))
+			Expect(err).Should(gbytes.Say("\nUsage: cp"))
+			Expect(err).Should(gbytes.Say("\n"))
+			Expect(err).Should(gbytes.Say(`Run "oras cp -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -63,7 +63,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("cp").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
-			Expect(err).Should(gbytes.Say("\nUsage: cp"))
+			Expect(err).Should(gbytes.Say("\nUsage: oras cp"))
 			Expect(err).Should(gbytes.Say("\n"))
 			Expect(err).Should(gbytes.Say(`Run "oras cp -h"`))
 		})
@@ -71,7 +71,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if more than 2 arguments are provided", func() {
 			err := ORAS("cp", "foo", "bar", "buz").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
-			Expect(err).Should(gbytes.Say("\nUsage: cp"))
+			Expect(err).Should(gbytes.Say("\nUsage: oras cp"))
 			Expect(err).Should(gbytes.Say("\n"))
 			Expect(err).Should(gbytes.Say(`Run "oras cp -h"`))
 		})

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -59,6 +59,14 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail when source doesn't exist", func() {
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, "i-dont-think-this-tag-exists"), RegistryRef(ZOTHost, cpTestRepo("nonexistent-source"), "")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
 		})
+
+		It("should show detailed error description if no argument provided", func() {
+			err := ORAS("cp").ExpectFailure().Exec().Err
+			Expect(err).Should(gbytes.Say("Error"))
+			Expect(err).Should(gbytes.Say("\nUsage: cp"))
+			Expect(err).Should(gbytes.Say("\n"))
+			Expect(err).Should(gbytes.Say(`Run "oras cp -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -60,7 +60,7 @@ var _ = Describe("ORAS beginners:", func() {
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, "i-dont-think-this-tag-exists"), RegistryRef(ZOTHost, cpTestRepo("nonexistent-source"), "")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
 		})
 
-		It("should show detailed error description if no argument provided", func() {
+		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("cp").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
 			Expect(err).Should(gbytes.Say("\nUsage: cp"))
@@ -68,7 +68,7 @@ var _ = Describe("ORAS beginners:", func() {
 			Expect(err).Should(gbytes.Say(`Run "oras cp -h"`))
 		})
 
-		It("should show detailed error description if more than 2 arguments are provided", func() {
+		It("should fail and show detailed error description if more than 2 arguments are provided", func() {
 			err := ORAS("cp", "foo", "bar", "buz").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
 			Expect(err).Should(gbytes.Say("\nUsage: cp"))

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -72,7 +72,7 @@ var _ = Describe("ORAS beginners:", func() {
 			Expect(err).Should(gbytes.Say(`Run "oras discover -h"`))
 		})
 
-		It("should fail and show detailed error description if more than 1 arguments are provided", func() {
+		It("should fail and show detailed error description if more than 1 argument are provided", func() {
 			err := ORAS("discover", "foo", "bar").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
 			Expect(err).Should(gbytes.Say("\nUsage: discover"))

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -63,6 +63,22 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail when no tag or digest found in provided subject reference", func() {
 			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
+
+		It("should show detailed error description if no argument provided", func() {
+			err := ORAS("discover").ExpectFailure().Exec().Err
+			Expect(err).Should(gbytes.Say("Error"))
+			Expect(err).Should(gbytes.Say("\nUsage: discover"))
+			Expect(err).Should(gbytes.Say("\n"))
+			Expect(err).Should(gbytes.Say(`Run "oras discover -h"`))
+		})
+
+		It("should show detailed error description if more than 1 arguments are provided", func() {
+			err := ORAS("discover", "foo", "bar").ExpectFailure().Exec().Err
+			Expect(err).Should(gbytes.Say("Error"))
+			Expect(err).Should(gbytes.Say("\nUsage: discover"))
+			Expect(err).Should(gbytes.Say("\n"))
+			Expect(err).Should(gbytes.Say(`Run "oras discover -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -67,7 +67,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("discover").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
-			Expect(err).Should(gbytes.Say("\nUsage: discover"))
+			Expect(err).Should(gbytes.Say("\nUsage: oras discover"))
 			Expect(err).Should(gbytes.Say("\n"))
 			Expect(err).Should(gbytes.Say(`Run "oras discover -h"`))
 		})
@@ -75,7 +75,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if more than 1 argument are provided", func() {
 			err := ORAS("discover", "foo", "bar").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
-			Expect(err).Should(gbytes.Say("\nUsage: discover"))
+			Expect(err).Should(gbytes.Say("\nUsage: oras discover"))
 			Expect(err).Should(gbytes.Say("\n"))
 			Expect(err).Should(gbytes.Say(`Run "oras discover -h"`))
 		})

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -64,7 +64,7 @@ var _ = Describe("ORAS beginners:", func() {
 			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest").Exec()
 		})
 
-		It("should show detailed error description if no argument provided", func() {
+		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("discover").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
 			Expect(err).Should(gbytes.Say("\nUsage: discover"))
@@ -72,7 +72,7 @@ var _ = Describe("ORAS beginners:", func() {
 			Expect(err).Should(gbytes.Say(`Run "oras discover -h"`))
 		})
 
-		It("should show detailed error description if more than 1 arguments are provided", func() {
+		It("should fail and show detailed error description if more than 1 arguments are provided", func() {
 			err := ORAS("discover", "foo", "bar").ExpectFailure().Exec().Err
 			Expect(err).Should(gbytes.Say("Error"))
 			Expect(err).Should(gbytes.Say("\nUsage: discover"))

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -104,7 +104,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("manifest", "delete").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: delete"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras manifest delete"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest delete -h"`))
 			})

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -66,7 +66,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("manifest", "push").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: push"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras manifest push"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest push -h"`))
 			})
@@ -89,7 +89,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("manifest", "fetch").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: fetch"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras manifest fetch"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest fetch -h"`))
 			})
@@ -169,7 +169,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("manifest", "fetch-config").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: fetch-config"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras manifest fetch-config"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest fetch-config -h"`))
 			})

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -63,11 +63,12 @@ var _ = Describe("ORAS beginners:", func() {
 					Exec()
 			})
 
-			It("should fail pushing without reference provided", func() {
-				ORAS("manifest", "push").
-					ExpectFailure().
-					MatchErrKeyWords("Error:").
-					Exec()
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("manifest", "push").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: push"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest push -h"`))
 			})
 
 			It("should fail pushing with  a manifest from stdin without media type flag", func() {
@@ -84,17 +85,28 @@ var _ = Describe("ORAS beginners:", func() {
 					MatchKeyWords(ExampleDesc).
 					Exec()
 			})
-			It("should fail fetching manifest without reference provided", func() {
-				ORAS("manifest", "fetch").
-					ExpectFailure().
-					MatchErrKeyWords("Error:").
-					Exec()
+
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("manifest", "fetch").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: fetch"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest fetch -h"`))
 			})
 		})
+
 		When("running `manifest delete`", func() {
 			It("should show help doc with feature flags", func() {
 				out := ORAS("manifest", "delete", "--help").MatchKeyWords(ExampleDesc).Exec()
 				gomega.Expect(out).Should(gbytes.Say("--distribution-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
+			})
+
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("manifest", "delete").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: delete"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest delete -h"`))
 			})
 
 			tempTag := "to-delete"
@@ -154,8 +166,12 @@ var _ = Describe("ORAS beginners:", func() {
 					MatchKeyWords(ExampleDesc, "\nUsage:").Exec()
 			})
 
-			It("should fail if no manifest reference provided", func() {
-				ORAS("manifest", "fetch-config").ExpectFailure().Exec()
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("manifest", "fetch-config").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: fetch-config"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras manifest fetch-config -h"`))
 			})
 
 			It("should fail if provided reference does not exist", func() {

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -70,7 +70,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("pull").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
-			gomega.Expect(err).Should(gbytes.Say("\nUsage: pull"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: oras pull"))
 			gomega.Expect(err).Should(gbytes.Say("\n"))
 			gomega.Expect(err).Should(gbytes.Say(`Run "oras pull -h"`))
 		})

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -66,6 +66,14 @@ var _ = Describe("ORAS beginners:", func() {
 			out := ORAS("pull", ref).WithWorkDir(tempDir).Exec().Out
 			gomega.Expect(out).ShouldNot(gbytes.Say(hintMsg(ref)))
 		})
+
+		It("should fail and show detailed error description if no argument provided", func() {
+			err := ORAS("pull").ExpectFailure().Exec().Err
+			gomega.Expect(err).Should(gbytes.Say("Error"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: pull"))
+			gomega.Expect(err).Should(gbytes.Say("\n"))
+			gomega.Expect(err).Should(gbytes.Say(`Run "oras pull -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -41,6 +41,14 @@ var _ = Describe("ORAS beginners:", func() {
 			gomega.Expect(out).Should(gbytes.Say("--image-spec string\\s+%s", regexp.QuoteMeta(feature.Experimental.Mark)))
 		})
 
+		It("should show detailed error description if no argument provided", func() {
+			err := ORAS("push").Exec().Err
+			gomega.Expect(err).Should(gbytes.Say("Error"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: push"))
+			gomega.Expect(err).Should(gbytes.Say("\n"))
+			gomega.Expect(err).Should(gbytes.Say(`Run "oras push -h"`))
+		})
+
 		It("should fail to use --config and --artifact-type at the same time for OCI spec v1.0 registry", func() {
 			tempDir := PrepareTempFiles()
 			repo := pushTestRepo("no-mediatype")

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -41,7 +41,7 @@ var _ = Describe("ORAS beginners:", func() {
 			gomega.Expect(out).Should(gbytes.Say("--image-spec string\\s+%s", regexp.QuoteMeta(feature.Experimental.Mark)))
 		})
 
-		It("should show detailed error description if no argument provided", func() {
+		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("push").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
 			gomega.Expect(err).Should(gbytes.Say("\nUsage: push"))

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -44,7 +44,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("push").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
-			gomega.Expect(err).Should(gbytes.Say("\nUsage: push"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: oras push"))
 			gomega.Expect(err).Should(gbytes.Say("\n"))
 			gomega.Expect(err).Should(gbytes.Say(`Run "oras push -h"`))
 		})

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -42,7 +42,7 @@ var _ = Describe("ORAS beginners:", func() {
 		})
 
 		It("should show detailed error description if no argument provided", func() {
-			err := ORAS("push").Exec().Err
+			err := ORAS("push").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
 			gomega.Expect(err).Should(gbytes.Say("\nUsage: push"))
 			gomega.Expect(err).Should(gbytes.Say("\n"))

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"oras.land/oras/test/e2e/internal/testdata/feature"
@@ -41,8 +42,15 @@ var _ = Describe("ORAS beginners:", func() {
 			})
 
 			It("should fail listing repositories if wrong registry provided", func() {
-				ORAS("repo", "ls").ExpectFailure().MatchErrKeyWords("Error:").Exec()
 				ORAS("repo", "ls", RegistryRef(ZOTHost, ImageRepo, "some-tag")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
+			})
+
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("repo", "ls").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: ls"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras repo ls -h"`))
 			})
 		})
 		When("running `repo tags`", func() {

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -45,7 +45,7 @@ var _ = Describe("ORAS beginners:", func() {
 				ORAS("repo", "ls", RegistryRef(ZOTHost, ImageRepo, "some-tag")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
 			})
 
-			It("should fail and show detailed error description if no argument provided", func() {
+			It("should fail and show detailed error description if no argument provided", Focus, func() {
 				err := ORAS("repo", "ls").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
 				gomega.Expect(err).Should(gbytes.Say("\nUsage: ls"))
@@ -67,6 +67,14 @@ var _ = Describe("ORAS beginners:", func() {
 				ORAS("repo", "tags").ExpectFailure().MatchErrKeyWords("Error:").Exec()
 				ORAS("repo", "tags", ZOTHost).ExpectFailure().MatchErrKeyWords("Error:").Exec()
 				ORAS("repo", "tags", RegistryRef(ZOTHost, ImageRepo, "some-tag")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
+			})
+
+			It("should fail and show detailed error description if no argument provided", func() {
+				err := ORAS("repo", "tags").ExpectFailure().Exec().Err
+				gomega.Expect(err).Should(gbytes.Say("Error"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: tags"))
+				gomega.Expect(err).Should(gbytes.Say("\n"))
+				gomega.Expect(err).Should(gbytes.Say(`Run "oras repo tags -h"`))
 			})
 		})
 	})

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -48,7 +48,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("repo", "ls").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: ls"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras repo ls"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras repo ls -h"`))
 			})
@@ -72,7 +72,7 @@ var _ = Describe("ORAS beginners:", func() {
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("repo", "tags").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
-				gomega.Expect(err).Should(gbytes.Say("\nUsage: tags"))
+				gomega.Expect(err).Should(gbytes.Say("\nUsage: oras repo tags"))
 				gomega.Expect(err).Should(gbytes.Say("\n"))
 				gomega.Expect(err).Should(gbytes.Say(`Run "oras repo tags -h"`))
 			})

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -45,7 +45,7 @@ var _ = Describe("ORAS beginners:", func() {
 				ORAS("repo", "ls", RegistryRef(ZOTHost, ImageRepo, "some-tag")).ExpectFailure().MatchErrKeyWords("Error:").Exec()
 			})
 
-			It("should fail and show detailed error description if no argument provided", Focus, func() {
+			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("repo", "ls").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))
 				gomega.Expect(err).Should(gbytes.Say("\nUsage: ls"))

--- a/test/e2e/suite/command/resolve.go
+++ b/test/e2e/suite/command/resolve.go
@@ -50,6 +50,13 @@ var _ = Describe("ORAS beginners:", func() {
 			ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, "i-dont-think-this-tag-exists")).ExpectFailure().MatchErrKeyWords("Error: failed to resolve digest:", "not found").Exec()
 		})
 
+		It("should fail and show detailed error description if no argument provided", func() {
+			err := ORAS("resolve").ExpectFailure().Exec().Err
+			gomega.Expect(err).Should(gbytes.Say("Error"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: resolve"))
+			gomega.Expect(err).Should(gbytes.Say("\n"))
+			gomega.Expect(err).Should(gbytes.Say(`Run "oras resolve -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/resolve.go
+++ b/test/e2e/suite/command/resolve.go
@@ -53,7 +53,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("resolve").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
-			gomega.Expect(err).Should(gbytes.Say("\nUsage: resolve"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: oras resolve"))
 			gomega.Expect(err).Should(gbytes.Say("\n"))
 			gomega.Expect(err).Should(gbytes.Say(`Run "oras resolve -h"`))
 		})

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -39,6 +39,14 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail when provided invalid reference", func() {
 			ORAS("tag", "list", "tagged").ExpectFailure().MatchErrKeyWords("Error:", "'list'").Exec()
 		})
+
+		It("should fail and show detailed error description if no argument provided", func() {
+			err := ORAS("tag").ExpectFailure().Exec().Err
+			gomega.Expect(err).Should(gbytes.Say("Error"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: tag"))
+			gomega.Expect(err).Should(gbytes.Say("\n"))
+			gomega.Expect(err).Should(gbytes.Say(`Run "oras tag -h"`))
+		})
 	})
 })
 

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -43,7 +43,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("tag").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))
-			gomega.Expect(err).Should(gbytes.Say("\nUsage: tag"))
+			gomega.Expect(err).Should(gbytes.Say("\nUsage: oras tag"))
 			gomega.Expect(err).Should(gbytes.Say("\n"))
 			gomega.Expect(err).Should(gbytes.Say(`Run "oras tag -h"`))
 		})

--- a/test/e2e/suite/command/version.go
+++ b/test/e2e/suite/command/version.go
@@ -27,7 +27,7 @@ var _ = Describe("ORAS user:", func() {
 		})
 
 		It("should run version command and ignore extra arguments with warning", func() {
-			ORAS("version", "foo", "bar").MatchErrKeyWords("warning:").Exec()
+			ORAS("version", "foo", "bar").MatchErrKeyWords("foo", "bar", "warning:").Exec()
 		})
 	})
 })

--- a/test/e2e/suite/command/version.go
+++ b/test/e2e/suite/command/version.go
@@ -25,5 +25,9 @@ var _ = Describe("ORAS user:", func() {
 		It("should run version command", func() {
 			ORAS("version").Exec()
 		})
+
+		It("should run version command and ignore extra arguments with warning", func() {
+			ORAS("version", "foo", "bar").MatchErrKeyWords("warning:").Exec()
+		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the error output when the number of input argument doesn't match expected. In the new output, user will get
1) What kind of input is expecting, as well as the usage hint
2) What's the wrong input
3) Which command to run to get more detailed examples and help

E.g. Taking `oras discover` as an example
```console
# Before
$ oras discover localhost: 5000/test:demo
Error: accepts 1 arg(s), received 2
# After
$ oras discover localhost: 5000/test:demo
Error: "oras discover" requires exactly 1 argument but got 2
Usage: oras discover [flags] <name>{:<tag>|@<digest>}
Please specify exactly 1 argument as the target artifact to discover referrers from. Run "oras discover -h" for more options and examples
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #458

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
