### PR TITLE
WIP: fix: add image spec option back to attach for expanded compatibility …

### DIFF
--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -27,6 +27,10 @@ import (
 const (
 	ImageSpecV1_1 = "v1.1"
 	ImageSpecV1_0 = "v1.0"
+
+	// Explicit RC versions for expanded compatibility testing during spec development
+	ImageSpecV1_1_RC2 = "v1.1.0-rc2"
+	ImageSpecV1_1_RC4 = "v1.1.0-rc4"
 )
 
 const (
@@ -44,8 +48,10 @@ type ImageSpec struct {
 func (is *ImageSpec) Set(value string) error {
 	is.flag = value
 	switch value {
-	case ImageSpecV1_1:
+	case ImageSpecV1_1, ImageSpecV1_1_RC4:
 		is.PackVersion = oras.PackManifestVersion1_1_RC4
+	case ImageSpecV1_1_RC2:
+		is.PackVersion = oras.PackManifestVersion1_1_RC2
 	case ImageSpecV1_0:
 		is.PackVersion = oras.PackManifestVersion1_0
 	default:
@@ -67,6 +73,9 @@ func (is *ImageSpec) Options() string {
 	return strings.Join([]string{
 		ImageSpecV1_1,
 		ImageSpecV1_0,
+		// release candidates, to be removed when minor version is GA
+		ImageSpecV1_1_RC2,
+		ImageSpecV1_1_RC4,
 	}, ", ")
 }
 

--- a/docs/proposals/compatibility-mode.md
+++ b/docs/proposals/compatibility-mode.md
@@ -16,12 +16,17 @@ This document elaborates on the major changes of ORAS CLI v1.1.0 proposed in [is
 
 Using the following flags in `oras push` and `oras attach` respectively with different variables to configure the manifest build and distribution behaviors. 
 
-- Using a flag `--image-spec` with `oras push`
+- Using a flag `--image-spec` with `oras push` and `oras attach` to configure image specification compatibility.
 - Using a flag `--distribution-spec` with `oras attach`, `oras cp`, and `oras manifest push` to configure compatibility with registry when pushing or copying an OCI image manifest. This flag is also applicable to `oras discover` for viewing and filtering the referrers.
 
 ### Build and push OCI image manifest using a flag `--image-spec`
 
-Use the flag `--image-spec <spec version>` in `oras push` to specify which version of the OCI Image-spec when building and pushing an OCI image manifest. It supports specifying the option `v1.0` or `v1.1` as the spec version. The option `v1.1` is the default behavior in `oras push` since ORAS CLI v1.1.0 so users don't need to manually specify this option.
+Use the flag `--image-spec <spec version>` in `oras push` and `oras attach` to specify which version of the OCI Image specification to use when building and pushing an OCI image manifest. Supported minor versions are `v1.1` (default) and `v1.0`. The v1.1 release candidate versions `v1.1.0-rc4` and `v1.1.0-rc2` are also supported.
+
+For `oras push`, `v1.0` or `v1.1` are supported spec version options. The `v1.0` option is not supported for `oras attach`. With ORAS CLI v1.1.0, `v1.1` is the default version for both commands so users don't need to manually specify this option.
+
+
+During OCI specification development, release candidate versions (e.g. `v1.1.0-rc4`) may also be included in the supported values for `--image-spec`. These are not stable, and likely to be removed when the version of the specification under test is GA. Note supported values may include deprecated RC versions to expand testing compatibility. 1.1.0 release candidate versions `v1.1.0-rc4` and `v1.1.0-rc2` are currently supported.
 
 If users want to build an OCI image manifest to a registry that compliant with OCI Spec v1.0, they can specify `--image-spec v1.0`. An OCI image manifest that conforms the OCI Image-spec v1.0.2 will be packed and uploaded. For example
 


### PR DESCRIPTION
Fixes #1224 

This is a WIP, would like to get opinion from @shizhMSFT @qweeah and others on requiring changes in oras-go or not.

The proposed fix for ECR (and hopefully Gitlab, probably others) is to reinstate the oras client 1.0 behavior which allows the user to specify `--image-spec` w/ `oras attach`, in order to allow users to specify using `v1.1.0-rc2`. This version image manifest was broadly supported by 1.0 registries like ECR. With the default in oras client 1.1 now using `v1.1.0-rc4`, attach is not longer working for ECR (and likely other registries).

I don't think we can cleanly do this with zero changes to oras-go, because the string vals for the oras client `--image-spec` option come from oras-go (`oras.PackManifestVersion`). 

I thought about using `oras.Pack` (as suggested by @shizhMSFT), but I at least need to add `v1.1.0-rc2` as a pack manifest version.

Since the RC version support is unstable and will be removed in the future, I'm leaning toward leaning into an oras-go PR (and version bump for oras client), and putting most of the changes to support deprecated image spec release candidates into oras-go, where it can be limited and eventually removed more easily. 

See accompanying [WIP PR in oras-go](https://github.com/oras-project/oras-go/pull/667) for conversation.

**Please check the following list**:

TODO
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
