### PR TITLE
build(ci): make coverage upload and calculation mandatory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,5 @@ jobs:
         run: bin/linux/amd64/oras version
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometime codecov job might silently fail without calculating the code coverage and do checking(see [logs](https://github.com/oras-project/oras/actions/runs/7405557847/job/20148684470#step:8:32)). This PR enforces the success of codecov job with code check.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
