### PR TITLE
fix: remove unwanted newline in attach error

### DIFF
--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -107,11 +107,9 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 	}
 	if len(opts.FileRefs) == 0 && len(annotations[option.AnnotationManifest]) == 0 {
 		return &oerrors.Error{
-			Err:   errors.New(`neither file nor annotation provided in the command`),
-			Usage: fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
-			Recommendation: `To attach to an existing artifact, please provide files 
-			via argument or annotations via flag "--annotation". Run "oras attach -h" 
-			for more options and examples`,
+			Err:            errors.New(`neither file nor annotation provided in the command`),
+			Usage:          fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
+			Recommendation: `To attach to an existing artifact, please provide files via argument or annotations via flag "--annotation". Run "oras attach -h" for more options and examples`,
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes unexpected output error in the recommendation. 