### PR TITLE
fix(e2e): update ZOT image

### DIFF
--- a/test/e2e/scripts/prepare.sh
+++ b/test/e2e/scripts/prepare.sh
@@ -62,5 +62,5 @@ docker run --pull always -dp $ZOT_REGISTRY_PORT:5000 \
   --name $ZOT_CTR_NAME \
   -u $(id -u $(whoami)) \
   --mount type=bind,source="${e2e_root}/testdata/zot/",target=/etc/zot \
-  --rm ghcr.io/project-zot/zot-linux-amd64:v2.0.0-rc6
+  --rm ghcr.io/project-zot/zot-linux-amd64:v2.0.1
 echo " <<< prepared : zot <<< "


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the E2E test failure by updating the used image to `2.0.1`. ZOT removed an obsoleted RC image, which causes the E2E test preparation failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1281

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
