### PR TITLE
refactor: pass cobra.Command to all cmd exec functions

### DIFF
--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -90,7 +90,7 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 			return option.Parse(&opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pushBlob(cmd.Context(), &opts)
+			return pushBlob(cmd, &opts)
 		},
 	}
 
@@ -100,8 +100,8 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 	return oerrors.Command(cmd, &opts.Target)
 }
 
-func pushBlob(ctx context.Context, opts *pushBlobOptions) (err error) {
-	ctx, logger := opts.WithContext(ctx)
+func pushBlob(cmd *cobra.Command, opts *pushBlobOptions) (err error) {
+	ctx, logger := opts.WithContext(cmd.Context())
 
 	target, err := opts.NewTarget(opts.Common, logger)
 	if err != nil {

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -16,7 +16,6 @@ limitations under the License.
 package root
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -69,15 +68,15 @@ Example - Log in with username and password in an interactive terminal and no TL
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Hostname = args[0]
-			return runLogin(cmd.Context(), opts)
+			return runLogin(cmd, opts)
 		},
 	}
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)
 }
 
-func runLogin(ctx context.Context, opts loginOptions) (err error) {
-	ctx, logger := opts.WithContext(ctx)
+func runLogin(cmd *cobra.Command, opts loginOptions) (err error) {
+	ctx, logger := opts.WithContext(cmd.Context())
 
 	// prompt for credential
 	if opts.Password == "" {

--- a/cmd/oras/root/logout.go
+++ b/cmd/oras/root/logout.go
@@ -16,8 +16,6 @@ limitations under the License.
 package root
 
 import (
-	"context"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry/remote/credentials"
@@ -46,7 +44,7 @@ Example - Logout:
 		Args: oerrors.CheckArgs(argument.Exactly(1), "the registry you want to log out"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.hostname = args[0]
-			return runLogout(cmd.Context(), opts)
+			return runLogout(cmd, opts)
 		},
 	}
 
@@ -55,7 +53,8 @@ Example - Logout:
 	return cmd
 }
 
-func runLogout(ctx context.Context, opts logoutOptions) error {
+func runLogout(cmd *cobra.Command, opts logoutOptions) error {
+	ctx := cmd.Context()
 	if opts.debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -16,7 +16,6 @@ limitations under the License.
 package root
 
 import (
-	"context"
 	"errors"
 	"strings"
 
@@ -122,7 +121,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPush(cmd.Context(), &opts)
+			return runPush(cmd, &opts)
 		},
 	}
 	cmd.Flags().StringVarP(&opts.manifestConfigRef, "config", "", "", "`path` of image config file")
@@ -133,8 +132,8 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 	return oerrors.Command(cmd, &opts.Target)
 }
 
-func runPush(ctx context.Context, opts *pushOptions) error {
-	ctx, logger := opts.WithContext(ctx)
+func runPush(cmd *cobra.Command, opts *pushOptions) error {
+	ctx, logger := opts.WithContext(cmd.Context())
 	annotations, err := opts.LoadManifestAnnotations()
 	if err != nil {
 		return err

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -16,7 +16,6 @@ limitations under the License.
 package repo
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -62,7 +61,7 @@ Example - List the repositories under the registry that include values lexically
 			if opts.hostname, opts.namespace, err = repository.ParseRepoPath(args[0]); err != nil {
 				return fmt.Errorf("could not parse repository path: %w", err)
 			}
-			return listRepository(cmd.Context(), &opts)
+			return listRepository(cmd, &opts)
 		},
 	}
 
@@ -71,8 +70,8 @@ Example - List the repositories under the registry that include values lexically
 	return oerrors.Command(cmd, &opts.Remote)
 }
 
-func listRepository(ctx context.Context, opts *repositoryOptions) error {
-	ctx, logger := opts.WithContext(ctx)
+func listRepository(cmd *cobra.Command, opts *repositoryOptions) error {
+	ctx, logger := opts.WithContext(cmd.Context())
 	reg, err := opts.Remote.NewRegistry(opts.hostname, opts.Common, logger)
 	if err != nil {
 		return err

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -16,7 +16,6 @@ limitations under the License.
 package repo
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -70,7 +69,7 @@ Example - [Experimental] Show tags associated with a digest:
 			return option.Parse(&opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return showTags(cmd.Context(), &opts)
+			return showTags(cmd, &opts)
 		},
 	}
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the tag specified by `last`")
@@ -79,8 +78,8 @@ Example - [Experimental] Show tags associated with a digest:
 	return oerrors.Command(cmd, &opts.Target)
 }
 
-func showTags(ctx context.Context, opts *showTagsOptions) error {
-	ctx, logger := opts.WithContext(ctx)
+func showTags(cmd *cobra.Command, opts *showTagsOptions) error {
+	ctx, logger := opts.WithContext(cmd.Context())
 	finder, err := opts.NewReadonlyTarget(ctx, opts.Common, logger)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a minor refactor to make the command private methods consistent. Most of them take a cmd and not a context except for these six. The reason for this is to make logging and output more consistent across the commands and the`corbra.Command` has methods like `OutOrStdout`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
