### PR TITLE
build(actions): update github actions for Node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,9 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
@@ -53,6 +53,6 @@ jobs:
       - name: Check Version
         run: bin/linux/amd64/oras version
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go ${{ matrix.go-version }} environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Go ${{ matrix.go-version }}
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check license header
         uses: apache/skywalking-eyes/header@v0.4.0
         with:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,9 +25,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup go environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21.6'
       - name: run goreleaser


### PR DESCRIPTION
**What this PR does / why we need it**:

Node 16 is deprecated and the v3 actions use it. These actions are available with a Node 20 runner with v4.
