### PR TITLE
test(unit): exclude darwin from go build constraint

### DIFF
--- a/cmd/oras/internal/display/status/console/console_test.go
+++ b/cmd/oras/internal/display/status/console/console_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/display/status/console/testutils/testutils.go
+++ b/cmd/oras/internal/display/status/console/testutils/testutils.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/display/status/progress/status_test.go
+++ b/cmd/oras/internal/display/status/progress/status_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/display/status/track/target_test.go
+++ b/cmd/oras/internal/display/status/track/target_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/display/status/tty_test.go
+++ b/cmd/oras/internal/display/status/tty_test.go
@@ -1,3 +1,5 @@
+//go:build freebsd || linux || netbsd || openbsd || solaris
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/oras/internal/option/common_unix_test.go
+++ b/cmd/oras/internal/option/common_unix_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/blob/fetch_test.go
+++ b/cmd/oras/root/blob/fetch_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/blob/push_test.go
+++ b/cmd/oras/root/blob/push_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || linux || netbsd || openbsd || solaris
+//go:build freebsd || linux || netbsd || openbsd || solaris
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/pull_test.go
+++ b/cmd/oras/root/pull_test.go
@@ -1,3 +1,5 @@
+//go:build freebsd || linux || netbsd || openbsd || solaris
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed `darwin` from go build constraint for pty-related operations. Tested on arm64 Mac and the tests pass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1277


**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
