### PR TITLE
fix: Revert github actions coverage until fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,6 @@ jobs:
       - name: Check Version
         run: bin/linux/amd64/oras version
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
**What this PR does / why we need it**:

It looks like there are problems with v4 coverage I was not aware off. Reverting for now.

https://github.com/codecov/codecov-action/issues/1292
