### PR TITLE
fix: oras push should return error when artifacttype is empty for spec 1.1

### DIFF
--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -27,6 +27,7 @@ import (
 const (
 	ImageSpecV1_1 = "v1.1"
 	ImageSpecV1_0 = "v1.0"
+	ImageSpecAuto = "auto"
 )
 
 const (
@@ -36,15 +37,15 @@ const (
 
 // ImageSpec option struct which implements pflag.Value interface.
 type ImageSpec struct {
-	flag        string
+	Flag        string
 	PackVersion oras.PackManifestVersion
 }
 
 // Set validates and sets the flag value from a string argument.
 func (is *ImageSpec) Set(value string) error {
-	is.flag = value
+	is.Flag = value
 	switch value {
-	case ImageSpecV1_1:
+	case ImageSpecV1_1, ImageSpecAuto:
 		is.PackVersion = oras.PackManifestVersion1_1
 	case ImageSpecV1_0:
 		is.PackVersion = oras.PackManifestVersion1_0
@@ -67,20 +68,21 @@ func (is *ImageSpec) Options() string {
 	return strings.Join([]string{
 		ImageSpecV1_1,
 		ImageSpecV1_0,
+		ImageSpecAuto,
 	}, ", ")
 }
 
 // String returns the string representation of the flag.
 func (is *ImageSpec) String() string {
-	return is.flag
+	return is.Flag
 }
 
 // ApplyFlags applies flags to a command flag set.
 func (is *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
-	// default to v1.1-rc.4
+	// default to auto
 	is.PackVersion = oras.PackManifestVersion1_1
-	defaultFlag := ImageSpecV1_1
-	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default %q)`, is.Options(), defaultFlag))
+	is.Flag = ImageSpecAuto
+	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default %q)`, is.Options(), ImageSpecAuto))
 }
 
 // DistributionSpec option struct which implements pflag.Value interface.

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -118,7 +118,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 					opts.PackVersion = oras.PackManifestVersion1_0
 				case option.ImageSpecV1_1:
 					return &oerrors.Error{
-						Err:            errors.New(`artifact type missing for OCI image-spec v1.1 artifacts`),
+						Err:            errors.New(`missing artifact type for OCI image-spec v1.1 artifacts`),
 						Recommendation: "set an artifact type via `--artifact-type` or consider image spec v1.0",
 					}
 				}

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -108,6 +108,22 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 			if err := option.Parse(cmd, &opts); err != nil {
 				return err
 			}
+
+			if opts.manifestConfigRef != "" && opts.artifactType == "" {
+				switch opts.Flag {
+				case option.ImageSpecAuto:
+					// switch to v1.0 manifest since artifact type is suggested by OCI v1.1
+					// artifact guidance but is not presented
+					// see https://github.com/opencontainers/image-spec/blob/e7f7c0ca69b21688c3cea7c87a04e4503e6099e2/manifest.md?plain=1#L170
+					opts.PackVersion = oras.PackManifestVersion1_0
+				case option.ImageSpecV1_1:
+					return &oerrors.Error{
+						Err:            errors.New(`artifact type missing for OCI image-spec v1.1 artifacts`),
+						Recommendation: "set an artifact type via `--artifact-type` or consider image spec v1.0",
+					}
+				}
+			}
+
 			switch opts.PackVersion {
 			case oras.PackManifestVersion1_0:
 				if opts.manifestConfigRef != "" && opts.artifactType != "" {

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -109,7 +109,7 @@ var _ = Describe("ORAS beginners:", func() {
 			imageSpecFlag := "v1.1"
 			ORAS("push", subjectRef, "--config", foobar.FileConfigName, Flags.ImageSpec, imageSpecFlag).
 				ExpectFailure().
-				MatchErrKeyWords("artifact type missing for OCI image-spec v1.1 artifacts").
+				MatchErrKeyWords("missing artifact type for OCI image-spec v1.1 artifacts").
 				Exec()
 		})
 	})

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -109,7 +109,7 @@ var _ = Describe("ORAS beginners:", func() {
 			imageSpecFlag := "v1.1"
 			ORAS("push", subjectRef, "--config", foobar.FileConfigName, Flags.ImageSpec, imageSpecFlag).
 				ExpectFailure().
-				MatchErrKeyWords("artifact type missing for OCI v1.1 artifacts").
+				MatchErrKeyWords("artifact type missing for OCI image-spec v1.1 artifacts").
 				Exec()
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
`oras push` should return an error when `--config` is used, `--artifact-type` is not used and `--image-spec` is set to `v1.1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1313 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
