### PR TITLE
bump(ci): update golangci-lint to v4

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -38,4 +38,4 @@ jobs:
         go-version: ${{ matrix.go-version }}
         check-latest: true
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4


### PR DESCRIPTION
This PR updates golang lint GHA