### PR TITLE
Revert "bump(ci): update codecov gha to v4 (#1324)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,6 @@ jobs:
       - name: Check Version
         run: bin/linux/amd64/oras version
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
This reverts commit fb3adabb9e96e50d13aaa3290a946d063f8d7b8e.

**What this PR does / why we need it**:

github action broken. The codecov failure should succeed when this merges.


**Which issue(s) this PR fixes**
Related https://github.com/oras-project/oras/issues/1291

