### PR TITLE
ux: improve the usage doc of --image-spec

### DIFF
--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -81,7 +81,8 @@ func (is *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
 	// default to v1.1, unless --config is used and --artifact-type is not used
 	is.PackVersion = oras.PackManifestVersion1_1
 	is.Flag = ImageSpecV1_1
-	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default value is v1.1. The default is overridden to v1.0 if --config is specified and --artifact-type is not specified)`, is.Options()))
+	fs.Var(is, "image-spec", `[Experimental] specify manifest type for building artifact. Options: v1.1(default), v1.0 
+(The default is overridden to v1.0 if --config is specified and --artifact-type is not specified)`)
 }
 
 // DistributionSpec option struct which implements pflag.Value interface.

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -81,7 +81,7 @@ func (is *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
 	// default to v1.1, unless --config is used and --artifact-type is not used
 	is.PackVersion = oras.PackManifestVersion1_1
 	is.Flag = ImageSpecV1_1
-	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default v1.1, unless --config is used and --artifact-type is not used)`, is.Options()))
+	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default value is v1.1. The default is overridden to v1.0 if --config is specified and --artifact-type is not specified)`, is.Options()))
 }
 
 // DistributionSpec option struct which implements pflag.Value interface.

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -81,8 +81,7 @@ func (is *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
 	// default to v1.1, unless --config is used and --artifact-type is not used
 	is.PackVersion = oras.PackManifestVersion1_1
 	is.Flag = ImageSpecV1_1
-	fs.Var(is, "image-spec", `[Experimental] specify manifest type for building artifact. Options: v1.1(default), v1.0 
-(The default is overridden to v1.0 if --config is specified and --artifact-type is not specified)`)
+	fs.Var(is, "image-spec", `[Preview] specify manifest type for building artifact. Options: v1.1, v1.0 (default v1.1, overridden to v1.0 if --config is used without --artifact-type)`)
 }
 
 // DistributionSpec option struct which implements pflag.Value interface.

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -81,7 +81,7 @@ func (is *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
 	// default to v1.1, unless --config is used and --artifact-type is not used
 	is.PackVersion = oras.PackManifestVersion1_1
 	is.Flag = ImageSpecV1_1
-	fs.Var(is, "image-spec", `[Preview] specify manifest type for building artifact. Options: v1.1, v1.0 (default v1.1, overridden to v1.0 if --config is used without --artifact-type)`)
+	fs.Var(is, "image-spec", `[Experimental] specify manifest type for building artifact. Options: v1.1, v1.0 (default v1.1, overridden to v1.0 if --config is used without --artifact-type)`)
 }
 
 // DistributionSpec option struct which implements pflag.Value interface.

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -27,7 +27,6 @@ import (
 const (
 	ImageSpecV1_1 = "v1.1"
 	ImageSpecV1_0 = "v1.0"
-	ImageSpecAuto = "auto"
 )
 
 const (
@@ -45,7 +44,7 @@ type ImageSpec struct {
 func (is *ImageSpec) Set(value string) error {
 	is.Flag = value
 	switch value {
-	case ImageSpecV1_1, ImageSpecAuto:
+	case ImageSpecV1_1:
 		is.PackVersion = oras.PackManifestVersion1_1
 	case ImageSpecV1_0:
 		is.PackVersion = oras.PackManifestVersion1_0
@@ -68,21 +67,21 @@ func (is *ImageSpec) Options() string {
 	return strings.Join([]string{
 		ImageSpecV1_1,
 		ImageSpecV1_0,
-		ImageSpecAuto,
 	}, ", ")
 }
 
 // String returns the string representation of the flag.
 func (is *ImageSpec) String() string {
-	return is.Flag
+	// to avoid printing default value in usage doc
+	return ""
 }
 
 // ApplyFlags applies flags to a command flag set.
 func (is *ImageSpec) ApplyFlags(fs *pflag.FlagSet) {
-	// default to auto
+	// default to v1.1, unless --config is used and --artifact-type is not used
 	is.PackVersion = oras.PackManifestVersion1_1
-	is.Flag = ImageSpecAuto
-	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default %q)`, is.Options(), ImageSpecAuto))
+	is.Flag = ImageSpecV1_1
+	fs.Var(is, "image-spec", fmt.Sprintf(`[Experimental] specify manifest type for building artifact. Options: %s (default v1.1, unless --config is used and --artifact-type is not used)`, is.Options()))
 }
 
 // DistributionSpec option struct which implements pflag.Value interface.

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -110,13 +110,12 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 			}
 
 			if opts.manifestConfigRef != "" && opts.artifactType == "" {
-				switch opts.Flag {
-				case option.ImageSpecAuto:
-					// switch to v1.0 manifest since artifact type is suggested by OCI v1.1
-					// artifact guidance but is not presented
+				if !cmd.Flags().Changed("image-spec") {
+					// switch to v1.0 manifest since artifact type is suggested
+					// by OCI v1.1 artifact guidance but is not presented
 					// see https://github.com/opencontainers/image-spec/blob/e7f7c0ca69b21688c3cea7c87a04e4503e6099e2/manifest.md?plain=1#L170
 					opts.PackVersion = oras.PackManifestVersion1_0
-				case option.ImageSpecV1_1:
+				} else if opts.Flag == option.ImageSpecV1_1 {
 					return &oerrors.Error{
 						Err:            errors.New(`missing artifact type for OCI image-spec v1.1 artifacts`),
 						Recommendation: "set an artifact type via `--artifact-type` or consider image spec v1.0",

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -114,6 +114,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 					// switch to v1.0 manifest since artifact type is suggested
 					// by OCI v1.1 artifact guidance but is not presented
 					// see https://github.com/opencontainers/image-spec/blob/e7f7c0ca69b21688c3cea7c87a04e4503e6099e2/manifest.md?plain=1#L170
+					opts.Flag = option.ImageSpecV1_0
 					opts.PackVersion = oras.PackManifestVersion1_0
 				} else if opts.Flag == option.ImageSpecV1_1 {
 					return &oerrors.Error{


### PR DESCRIPTION
**What this PR does / why we need it**:

`auto` option for `--image-spec` is removed.

current display of `--image-spec` help info:
![image](https://github.com/oras-project/oras/assets/103478229/f774b7f8-d3d2-48c2-a36b-3fe9344d9179)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1061 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
