### PR TITLE
feat: oras discover should show a placeholder of artifactType if it's not presented

### DIFF
--- a/cmd/oras/internal/display/metadata/tree/discover.go
+++ b/cmd/oras/internal/display/metadata/tree/discover.go
@@ -61,6 +61,9 @@ func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) err
 	if !ok {
 		return fmt.Errorf("unexpected subject descriptor: %v", subject)
 	}
+	if referrer.ArtifactType == "" {
+		referrer.ArtifactType = "<unknown>"
+	}
 	referrerNode := node.AddPath(referrer.ArtifactType, referrer.Digest)
 	if h.verbose {
 		for k, v := range referrer.Annotations {

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -172,6 +172,12 @@ var _ = Describe("1.1 registry users:", func() {
 				MatchKeyWords(append(discoverKeyWords(true, referrers...), RegistryRef(ZOTHost, ArtifactRepo, foobar.Digest))...).
 				Exec()
 		})
+
+		It("should display <unknown> for empty artifact type", func() {
+			ORAS("discover", RegistryRef(ZOTHost, ArtifactRepo, "multi"), "--format", format).
+				MatchKeyWords("unknown").
+				Exec()
+		})
 	})
 	When("running discover command with table output", func() {
 		format := "table"

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -173,9 +173,9 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 		})
 
-		It("should display <unknown> for empty artifact type", func() {
+		It("should display <unknown> if a referrer has an empty artifact type", func() {
 			ORAS("discover", RegistryRef(ZOTHost, ArtifactRepo, "multi"), "--format", format).
-				MatchKeyWords("unknown").
+				MatchKeyWords("<unknown>").
 				Exec()
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
current display
![image](https://github.com/oras-project/oras/assets/103478229/7db2685a-4d1e-437b-87a1-9281e411d195)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1108 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
