### PR TITLE
chore: add preview feature mark to platform-specific attaching

### DIFF
--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -98,7 +98,7 @@ Example - Attach file to the manifest tagged 'v1' in an OCI image layout folder 
 
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
-	opts.FlagDescription = "attach to an arch-specific subject"
+	opts.FlagDescription = "[Preview] attach to an arch-specific subject"
 	_ = cmd.MarkFlagRequired("artifact-type")
 	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())


### PR DESCRIPTION
**What this PR does / why we need it**:
As a complement of #1309, this PR adds preview feature mark to allow future changes on the flag.
