### PR TITLE
feat: make all go-template key lower-cased

### DIFF
--- a/cmd/oras/internal/display/metadata/model/descriptor.go
+++ b/cmd/oras/internal/display/metadata/model/descriptor.go
@@ -16,13 +16,12 @@ limitations under the License.
 package model
 
 import (
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // DigestReference is a reference to an artifact with digest.
 type DigestReference struct {
-	Ref string
+	Ref string `json:"ref"`
 }
 
 // NewDigestReference creates a new digest reference.
@@ -37,36 +36,14 @@ func NewDigestReference(name string, digest string) DigestReference {
 // annotation key is not uppercase.
 type Descriptor struct {
 	DigestReference
-
-	// MediaType is the media type of the object this schema refers to.
-	MediaType string
-
-	// Digest is the digest of the targeted content.
-	Digest digest.Digest
-
-	// Size specifies the size in bytes of the blob.
-	Size int64
-
-	// URLs specifies a list of URLs from which this object MAY be downloaded
-	URLs []string `json:",omitempty"`
-
-	// Annotations contains arbitrary metadata relating to the targeted content.
-	Annotations map[string]string `json:",omitempty"`
-
-	// ArtifactType is the IANA media type of this artifact.
-	ArtifactType string
+	ocispec.Descriptor
 }
 
 // FromDescriptor converts a OCI descriptor to a descriptor with digest reference.
 func FromDescriptor(name string, desc ocispec.Descriptor) Descriptor {
 	ret := Descriptor{
 		DigestReference: NewDigestReference(name, desc.Digest.String()),
-		MediaType:       desc.MediaType,
-		Digest:          desc.Digest,
-		Size:            desc.Size,
-		URLs:            desc.URLs,
-		Annotations:     desc.Annotations,
-		ArtifactType:    desc.ArtifactType,
+		Descriptor:      desc,
 	}
 	return ret
 }

--- a/cmd/oras/internal/display/metadata/model/discover.go
+++ b/cmd/oras/internal/display/metadata/model/discover.go
@@ -18,7 +18,7 @@ package model
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 type discover struct {
-	Manifests []Descriptor
+	Manifests []Descriptor `json:"manifests"`
 }
 
 // NewDiscover creates a new discover model.

--- a/cmd/oras/internal/display/metadata/model/fetched.go
+++ b/cmd/oras/internal/display/metadata/model/fetched.go
@@ -19,7 +19,7 @@ import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 type fetched struct {
 	Descriptor
-	Content any
+	Content any `json:"content"`
 }
 
 // NewFetched creates a new fetched metadata.

--- a/cmd/oras/internal/display/metadata/model/pull.go
+++ b/cmd/oras/internal/display/metadata/model/pull.go
@@ -56,7 +56,7 @@ func newFile(name string, outputDir string, desc ocispec.Descriptor, descPath st
 
 type pull struct {
 	DigestReference
-	Files []File `json:"Files"`
+	Files []File `json:"files"`
 }
 
 // NewPull creates a new metadata struct for pull command.

--- a/cmd/oras/internal/display/metadata/model/pull.go
+++ b/cmd/oras/internal/display/metadata/model/pull.go
@@ -28,7 +28,7 @@ import (
 // File records metadata of a pulled file.
 type File struct {
 	// Path is the absolute path of the pulled file.
-	Path string
+	Path string `json:"path"`
 	Descriptor
 }
 

--- a/cmd/oras/internal/display/metadata/template/template.go
+++ b/cmd/oras/internal/display/metadata/template/template.go
@@ -20,12 +20,19 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"oras.land/oras/cmd/oras/internal/display/utils"
 )
 
 func parseAndWrite(out io.Writer, object any, templateStr string) error {
+	// parse template
 	t, err := template.New("format output").Funcs(sprig.FuncMap()).Parse(templateStr)
 	if err != nil {
 		return err
 	}
-	return t.Execute(out, object)
+	// convert object to map[string]any
+	converted, err := utils.ToMap(object)
+	if err != nil {
+		return err
+	}
+	return t.Execute(out, converted)
 }

--- a/cmd/oras/internal/display/metadata/template/template_test.go
+++ b/cmd/oras/internal/display/metadata/template/template_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_parseAndWrite_err(t *testing.T) {
+	if err := parseAndWrite(os.Stdout, func() {}, ""); err == nil {
+		t.Errorf("should return error")
+	}
+}

--- a/cmd/oras/internal/display/utils/json.go
+++ b/cmd/oras/internal/display/utils/json.go
@@ -42,3 +42,17 @@ func PrintJSON(out io.Writer, data []byte, pretty bool) error {
 	_, err := out.Write(data)
 	return err
 }
+
+// ToMap converts the data to a map[string]any with json tag as key.
+func ToMap(data any) (map[string]any, error) {
+	// slow but easy
+	content, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	var ret map[string]any
+	if err = json.Unmarshal(content, &ret); err != nil {
+		ret = nil
+	}
+	return ret, err
+}

--- a/cmd/oras/internal/display/utils/json.go
+++ b/cmd/oras/internal/display/utils/json.go
@@ -54,5 +54,5 @@ func ToMap(data any) (map[string]any, error) {
 	if err = json.Unmarshal(content, &ret); err != nil {
 		return nil, err
 	}
-	return ret, err
+	return ret, nil
 }

--- a/cmd/oras/internal/display/utils/json.go
+++ b/cmd/oras/internal/display/utils/json.go
@@ -52,7 +52,7 @@ func ToMap(data any) (map[string]any, error) {
 	}
 	var ret map[string]any
 	if err = json.Unmarshal(content, &ret); err != nil {
-		ret = nil
+		return nil, err
 	}
 	return ret, err
 }

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -137,7 +137,7 @@ var _ = Describe("1.1 registry users:", func() {
 			CopyZOTRepo(ImageRepo, testRepo)
 			// test
 			delimitter := "---"
-			output := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", fmt.Sprintf("{{.ref}}%s{{.ArtifactType}}", delimitter)).
+			output := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", fmt.Sprintf("{{.ref}}%s{{.artifactType}}", delimitter)).
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			ref, artifactType, _ := strings.Cut(string(output), delimitter)
 			// validate

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -107,7 +107,7 @@ var _ = Describe("1.1 registry users:", func() {
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag), subjectRef).Exec()
 			artifactType := "test/attach"
 			// test
-			out := ORAS("attach", "--artifact-type", artifactType, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Digest}}", "--platform", "linux/amd64").
+			out := ORAS("attach", "--artifact-type", artifactType, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.digest}}", "--platform", "linux/amd64").
 				WithWorkDir(PrepareTempFiles()).Exec().Out.Contents()
 			// validate
 			ORAS("discover", "--artifact-type", artifactType, RegistryRef(ZOTHost, testRepo, multi_arch.LinuxAMD64.Digest.String())).MatchKeyWords(string(out)).Exec()
@@ -121,7 +121,7 @@ var _ = Describe("1.1 registry users:", func() {
 			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
 			CopyZOTRepo(ImageRepo, testRepo)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
 			fetched := ORAS("manifest", "fetch", string(ref)).Exec().Out.Contents()
@@ -167,9 +167,9 @@ var _ = Describe("1.1 registry users:", func() {
 			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
 			CopyZOTRepo(ImageRepo, testRepo)
 			// test
-			ref1 := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Ref}}").
+			ref1 := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
-			ref2 := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Ref}}").
+			ref2 := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
 			ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").MatchKeyWords(string(ref1), string(ref2)).Exec()
@@ -181,7 +181,7 @@ var _ = Describe("1.1 registry users:", func() {
 			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
 			CopyZOTRepo(ImageRepo, testRepo)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
 			out := ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
@@ -222,7 +222,7 @@ var _ = Describe("1.0 registry users:", func() {
 			subjectRef := RegistryRef(FallbackHost, testRepo, foobar.Tag)
 			prepare(RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), subjectRef)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
 			out := ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
@@ -235,7 +235,7 @@ var _ = Describe("1.0 registry users:", func() {
 			subjectRef := RegistryRef(FallbackHost, testRepo, foobar.Tag)
 			prepare(RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), subjectRef)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 
 			// validate
@@ -249,7 +249,7 @@ var _ = Describe("1.0 registry users:", func() {
 			subjectRef := RegistryRef(FallbackHost, testRepo, foobar.Tag)
 			prepare(RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), subjectRef)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--distribution-spec", "v1.1-referrers-tag", "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--distribution-spec", "v1.1-referrers-tag", "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 
 			// validate
@@ -275,7 +275,7 @@ var _ = Describe("OCI image layout users:", func() {
 			root := PrepareTempOCI(ImageRepo)
 			subjectRef := LayoutRef(root, foobar.Tag)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", Flags.Layout, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", Flags.Layout, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", "{{.ref}}").
 				WithWorkDir(root).Exec().Out.Contents()
 			// validate
 			fetched := ORAS("manifest", "fetch", Flags.Layout, string(ref)).Exec().Out.Contents()
@@ -287,7 +287,7 @@ var _ = Describe("OCI image layout users:", func() {
 			subjectRef := LayoutRef(root, multi_arch.Tag)
 			artifactType := "test/attach"
 			// test
-			out := ORAS("attach", Flags.Layout, "--artifact-type", artifactType, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Digest}}", "--platform", "linux/amd64").
+			out := ORAS("attach", Flags.Layout, "--artifact-type", artifactType, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.digest}}", "--platform", "linux/amd64").
 				WithWorkDir(PrepareTempFiles()).Exec().Out.Contents()
 			// validate
 			ORAS("discover", Flags.Layout, "--artifact-type", artifactType, LayoutRef(root, multi_arch.LinuxAMD64.Digest.String())).MatchKeyWords(string(out)).Exec()
@@ -297,7 +297,7 @@ var _ = Describe("OCI image layout users:", func() {
 			root := PrepareTempOCI(ImageRepo)
 			subjectRef := LayoutRef(root, foobar.Tag)
 			// test
-			ref := ORAS("attach", "--artifact-type", "test/attach", Flags.Layout, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.Ref}}").
+			ref := ORAS("attach", "--artifact-type", "test/attach", Flags.Layout, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(root).Exec().Out.Contents()
 			// validate
 			out := ORAS("discover", Flags.Layout, subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -137,7 +137,7 @@ var _ = Describe("1.1 registry users:", func() {
 			CopyZOTRepo(ImageRepo, testRepo)
 			// test
 			delimitter := "---"
-			output := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", fmt.Sprintf("{{.Ref}}%s{{.ArtifactType}}", delimitter)).
+			output := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--export-manifest", exportName, "--format", fmt.Sprintf("{{.ref}}%s{{.ArtifactType}}", delimitter)).
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			ref, artifactType, _ := strings.Cut(string(output), delimitter)
 			// validate
@@ -172,7 +172,7 @@ var _ = Describe("1.1 registry users:", func() {
 			ref2 := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
-			ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").MatchKeyWords(string(ref1), string(ref2)).Exec()
+			ORAS("discover", subjectRef, "--format", "{{range .manifests}}{{println .ref}}{{end}}").MatchKeyWords(string(ref1), string(ref2)).Exec()
 		})
 
 		It("should attach a file via a OCI Image", func() {
@@ -184,7 +184,7 @@ var _ = Describe("1.1 registry users:", func() {
 			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
-			out := ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
+			out := ORAS("discover", subjectRef, "--format", "{{range .manifests}}{{println .ref}}{{end}}").Exec().Out
 			Expect(out).To(gbytes.Say(string(ref)))
 		})
 
@@ -225,7 +225,7 @@ var _ = Describe("1.0 registry users:", func() {
 			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out.Contents()
 			// validate
-			out := ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
+			out := ORAS("discover", subjectRef, "--format", "{{range .manifests}}{{println .ref}}{{end}}").Exec().Out
 			Expect(out).To(gbytes.Say(string(ref)))
 		})
 
@@ -239,7 +239,7 @@ var _ = Describe("1.0 registry users:", func() {
 				WithWorkDir(tempDir).Exec().Out.Contents()
 
 			// validate
-			out := ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
+			out := ORAS("discover", subjectRef, "--format", "{{range .manifests}}{{println .ref}}{{end}}").Exec().Out
 			Expect(out).To(gbytes.Say(string(ref)))
 		})
 
@@ -253,7 +253,7 @@ var _ = Describe("1.0 registry users:", func() {
 				WithWorkDir(tempDir).Exec().Out.Contents()
 
 			// validate
-			out := ORAS("discover", subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
+			out := ORAS("discover", subjectRef, "--format", "{{range .manifests}}{{println .ref}}{{end}}").Exec().Out
 			Expect(out).To(gbytes.Say(string(ref)))
 		})
 	})
@@ -300,7 +300,7 @@ var _ = Describe("OCI image layout users:", func() {
 			ref := ORAS("attach", "--artifact-type", "test/attach", Flags.Layout, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "{{.ref}}").
 				WithWorkDir(root).Exec().Out.Contents()
 			// validate
-			out := ORAS("discover", Flags.Layout, subjectRef, "--format", "{{range .Manifests}}{{println .Ref}}{{end}}").Exec().Out
+			out := ORAS("discover", Flags.Layout, subjectRef, "--format", "{{range .manifests}}{{println .ref}}{{end}}").Exec().Out
 			Expect(out).To(gbytes.Say(string(ref)))
 		})
 	})

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -188,7 +188,7 @@ var _ = Describe("1.1 registry users:", func() {
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.Digest), dst)
 
-			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -206,7 +206,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.Digest), dst)
-			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -233,7 +233,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.Digest), dst)
-			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -273,7 +273,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), dst)
-			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -291,7 +291,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
-			digests := ORAS("discover", RegistryRef(ZOTHost, dstRepo, digest), "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", RegistryRef(ZOTHost, dstRepo, digest), "--format", "{{range .manifests}}{{println .digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -188,7 +188,7 @@ var _ = Describe("1.1 registry users:", func() {
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.Digest), dst)
 
-			digests := ORAS("discover", dst, "--format", "{{range .Manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -206,7 +206,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.Digest), dst)
-			digests := ORAS("discover", dst, "--format", "{{range .Manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -233,7 +233,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.Digest), dst)
-			digests := ORAS("discover", dst, "--format", "{{range .Manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -273,7 +273,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), dst)
-			digests := ORAS("discover", dst, "--format", "{{range .Manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", dst, "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}
@@ -291,7 +291,7 @@ var _ = Describe("1.1 registry users:", func() {
 				Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
-			digests := ORAS("discover", RegistryRef(ZOTHost, dstRepo, digest), "--format", "{{range .Manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
+			digests := ORAS("discover", RegistryRef(ZOTHost, dstRepo, digest), "--format", "{{range .manifests}}{{println .Digest}}{{end}}").Exec().Out.Contents()
 			for _, digest := range strings.Split(strings.TrimSpace(string(digests)), "\n") {
 				CompareRef(RegistryRef(ZOTHost, ArtifactRepo, digest), RegistryRef(ZOTHost, dstRepo, digest))
 			}

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -198,7 +198,7 @@ var _ = Describe("1.1 registry users:", func() {
 	})
 	When("running discover command with go-template output", func() {
 		It("should show referrers digest of a subject", func() {
-			ORAS("discover", subjectRef, "--format", "{{(first .Manifests).Ref}}").
+			ORAS("discover", subjectRef, "--format", "{{(first .Manifests).ref}}").
 				MatchContent(RegistryRef(ZOTHost, ArtifactRepo, foobar.SBOMImageReferrer.Digest.String())).
 				Exec()
 		})

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -198,7 +198,7 @@ var _ = Describe("1.1 registry users:", func() {
 	})
 	When("running discover command with go-template output", func() {
 		It("should show referrers digest of a subject", func() {
-			ORAS("discover", subjectRef, "--format", "{{(first .Manifests).ref}}").
+			ORAS("discover", subjectRef, "--format", "{{(first .manifests).ref}}").
 				MatchContent(RegistryRef(ZOTHost, ArtifactRepo, foobar.SBOMImageReferrer.Digest.String())).
 				Exec()
 		})

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -267,7 +267,7 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 
 		It("should fetch manifest with platform validation and output content", func() {
-			out := ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag), "--platform", "linux/amd64", "--format", "{{toJson .Content}}").
+			out := ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag), "--platform", "linux/amd64", "--format", "{{toJson .content}}").
 				Exec().Out.Contents()
 			Expect(out).To(MatchJSON(multi_arch.LinuxAMD64Manifest))
 		})

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -273,7 +273,7 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 
 		It("should fetch manifest and format output", func() {
-			ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, multi_arch.LinuxAMD64.Digest.String()), "--format", "{{(first .Content.layers).digest}}").
+			ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, multi_arch.LinuxAMD64.Digest.String()), "--format", "{{(first .content.layers).digest}}").
 				MatchContent(multi_arch.LayerDigest).
 				Exec()
 		})

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -194,7 +194,7 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 			for _, p := range foobar.ImageLayerNames {
 				paths = append(paths, filepath.Join(tempDir, p))
 			}
-			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, foobar.Tag), "--format", "{{range .Files}}{{println .Path}}{{end}}").
+			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, foobar.Tag), "--format", "{{range .files}}{{println .path}}{{end}}").
 				WithWorkDir(tempDir).MatchKeyWords(paths...).Exec()
 		})
 

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -200,7 +200,7 @@ var _ = Describe("Remote registry users:", func() {
 			tempDir := PrepareTempFiles()
 			extraTag := "2e2"
 
-			ORAS("push", fmt.Sprintf("%s,%s", RegistryRef(ZOTHost, repo, tag), extraTag), foobar.FileBarName, "-v", "--format", "{{.MediaType}}").
+			ORAS("push", fmt.Sprintf("%s,%s", RegistryRef(ZOTHost, repo, tag), extraTag), foobar.FileBarName, "-v", "--format", "{{.mediaType}}").
 				WithWorkDir(tempDir).
 				MatchContent("application/vnd.oci.image.manifest.v1+json").
 				Exec()
@@ -367,7 +367,7 @@ var _ = Describe("Remote registry users:", func() {
 			annotationValue := "value"
 
 			// test
-			out := ORAS("push", RegistryRef(ZOTHost, repo, tag), "-a", fmt.Sprintf("%s=%s", annotationKey, annotationValue), "--format", "{{.Ref}}").
+			out := ORAS("push", RegistryRef(ZOTHost, repo, tag), "-a", fmt.Sprintf("%s=%s", annotationKey, annotationValue), "--format", "{{.ref}}").
 				WithWorkDir(tempDir).Exec().Out
 
 			// validate

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -395,7 +395,7 @@ var _ = Describe("Remote registry users:", func() {
 
 			// validate
 			Expect(out).To(gbytes.Say(RegistryRef(ZOTHost, repo, "")))
-			Expect(out).To(gbytes.Say(regexp.QuoteMeta(fmt.Sprintf(`"ArtifactType": "%s"`, artifactType))))
+			Expect(out).To(gbytes.Say(regexp.QuoteMeta(fmt.Sprintf(`"artifactType": "%s"`, artifactType))))
 		})
 
 		It("should push files", func() {

--- a/test/e2e/suite/scenario/oci_artifact.go
+++ b/test/e2e/suite/scenario/oci_artifact.go
@@ -64,7 +64,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 				WithWorkDir(tempDir).
 				WithDescription("attach with manifest exported").Exec()
 
-			ref := string(ORAS("discover", subject, "--format", "{{(first .Manifests).ref}}").Exec().Out.Contents())
+			ref := string(ORAS("discover", subject, "--format", "{{(first .manifests).ref}}").Exec().Out.Contents())
 			fetched := ORAS("manifest", "fetch", ref).MatchKeyWords(foobar.AttachFileMedia).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 
@@ -81,7 +81,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 				WithWorkDir(tempDir).
 				WithDescription("attach again with manifest exported").Exec()
 
-			ref = string(ORAS("discover", subject, "--format", "{{(first .Manifests).ref}}", "--artifact-type", "test/artifact2").Exec().Out.Contents())
+			ref = string(ORAS("discover", subject, "--format", "{{(first .manifests).ref}}", "--artifact-type", "test/artifact2").Exec().Out.Contents())
 			fetched = ORAS("manifest", "fetch", ref).MatchKeyWords(foobar.AttachFileMedia).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 

--- a/test/e2e/suite/scenario/oci_artifact.go
+++ b/test/e2e/suite/scenario/oci_artifact.go
@@ -64,7 +64,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 				WithWorkDir(tempDir).
 				WithDescription("attach with manifest exported").Exec()
 
-			ref := string(ORAS("discover", subject, "--format", "{{(first .Manifests).Ref}}").Exec().Out.Contents())
+			ref := string(ORAS("discover", subject, "--format", "{{(first .Manifests).ref}}").Exec().Out.Contents())
 			fetched := ORAS("manifest", "fetch", ref).MatchKeyWords(foobar.AttachFileMedia).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 
@@ -81,7 +81,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 				WithWorkDir(tempDir).
 				WithDescription("attach again with manifest exported").Exec()
 
-			ref = string(ORAS("discover", subject, "--format", "{{(first .Manifests).Ref}}", "--artifact-type", "test/artifact2").Exec().Out.Contents())
+			ref = string(ORAS("discover", subject, "--format", "{{(first .Manifests).ref}}", "--artifact-type", "test/artifact2").Exec().Out.Contents())
 			fetched = ORAS("manifest", "fetch", ref).MatchKeyWords(foobar.AttachFileMedia).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes all formattable names of the metadata output  lower cased.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1342

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
