### PR TITLE
feat: add color to progress mark and bar

### DIFF
--- a/cmd/oras/internal/display/status/progress/status.go
+++ b/cmd/oras/internal/display/status/progress/status.go
@@ -137,7 +137,7 @@ func (s *status) String(width int) (string, string) {
 		bar := fmt.Sprintf("[%s%s]", progressColor.Apply(strings.Repeat(" ", lenBar)), strings.Repeat(".", barLength-lenBar))
 		speed := s.calculateSpeed()
 		left = fmt.Sprintf("%s %s(%*s/s) %s %s",
-			spinnerColor.Apply(fmt.Sprintf("%c", s.mark.symbol())),
+			spinnerColor.Apply(string(s.mark.symbol())),
 			bar, speedLength, speed, s.prompt, name)
 		// bar + wrapper(2) + space(1) + speed + "/s"(2) + wrapper(2) = len(bar) + len(speed) + 7
 		lenLeft = barLength + speedLength + 7

--- a/cmd/oras/internal/display/status/progress/status.go
+++ b/cmd/oras/internal/display/status/progress/status.go
@@ -35,6 +35,12 @@ const (
 	zeroDigest   = "  └─ loading digest..."
 )
 
+var (
+	spinnerColor  = aec.LightYellowF
+	doneMarkColor = aec.LightGreenF
+	progressColor = aec.LightBlueB
+)
+
 // status is used as message to update progress view.
 type status struct {
 	done           bool // done is true when the end time is set
@@ -128,13 +134,15 @@ func (s *status) String(width int) (string, string) {
 	lenLeft := 0
 	if !s.done {
 		lenBar := int(percent * barLength)
-		bar := fmt.Sprintf("[%s%s]", aec.Inverse.Apply(strings.Repeat(" ", lenBar)), strings.Repeat(".", barLength-lenBar))
+		bar := fmt.Sprintf("[%s%s]", progressColor.Apply(strings.Repeat(" ", lenBar)), strings.Repeat(".", barLength-lenBar))
 		speed := s.calculateSpeed()
-		left = fmt.Sprintf("%c %s(%*s/s) %s %s", s.mark.symbol(), bar, speedLength, speed, s.prompt, name)
+		left = fmt.Sprintf("%s %s(%*s/s) %s %s",
+			spinnerColor.Apply(fmt.Sprintf("%c", s.mark.symbol())),
+			bar, speedLength, speed, s.prompt, name)
 		// bar + wrapper(2) + space(1) + speed + "/s"(2) + wrapper(2) = len(bar) + len(speed) + 7
 		lenLeft = barLength + speedLength + 7
 	} else {
-		left = fmt.Sprintf("✓ %s %s", s.prompt, name)
+		left = fmt.Sprintf("%s %s %s", doneMarkColor.Apply("✓"), s.prompt, name)
 	}
 	// mark(1) + space(1) + prompt + space(1) + name = len(prompt) + len(name) + 3
 	lenLeft += utf8.RuneCountInString(s.prompt) + utf8.RuneCountInString(name) + 3

--- a/cmd/oras/internal/display/status/progress/status_test.go
+++ b/cmd/oras/internal/display/status/progress/status_test.go
@@ -89,7 +89,7 @@ func Test_status_String_zeroWitdth(t *testing.T) {
 	})
 	// not done
 	statusStr, digestStr := s.String(120)
-	if err := testutils.OrderedMatch(statusStr+digestStr, " [\x1b[7m\x1b[0m....................]", s.prompt, s.descriptor.MediaType, "0.00/0  B", "0.00%", s.descriptor.Digest.String()); err != nil {
+	if err := testutils.OrderedMatch(statusStr+digestStr, "\x1b[0m....................]", s.prompt, s.descriptor.MediaType, "0.00/0  B", "0.00%", s.descriptor.Digest.String()); err != nil {
 		t.Error(err)
 	}
 	// done

--- a/cmd/oras/internal/display/status/progress/status_test.go
+++ b/cmd/oras/internal/display/status/progress/status_test.go
@@ -48,12 +48,12 @@ func Test_status_String(t *testing.T) {
 	})
 	// full name
 	statusStr, digestStr := s.String(120)
-	if err := testutils.OrderedMatch(statusStr+digestStr, " [\x1b[7m\x1b[0m....................]", s.prompt, s.descriptor.MediaType, "0.00/2  B", "0.00%", s.descriptor.Digest.String()); err != nil {
+	if err := testutils.OrderedMatch(statusStr+digestStr, "\x1b[0m....................]", s.prompt, s.descriptor.MediaType, "0.00/2  B", "0.00%", s.descriptor.Digest.String()); err != nil {
 		t.Error(err)
 	}
 	// partial name
 	statusStr, digestStr = s.String(console.MinWidth)
-	if err := testutils.OrderedMatch(statusStr+digestStr, " [\x1b[7m\x1b[0m....................]", s.prompt, "application/v.", "0.00/2  B", "0.00%", s.descriptor.Digest.String()); err != nil {
+	if err := testutils.OrderedMatch(statusStr+digestStr, "\x1b[0m....................]", s.prompt, "application/v.", "0.00/2  B", "0.00%", s.descriptor.Digest.String()); err != nil {
 		t.Error(err)
 	}
 	// done


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds color to the TTY output.
- The spinner will be renderred in light yellow
- The done mark will be renderred in light green
- The progress bar will be renderred in light blue

![image](https://github.com/oras-project/oras/assets/4254263/ac0e0f10-a9aa-4eed-a9b0-672d0e032182)


**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
