### PR TITLE
feat: improve error message when detecting conflicting flags

### DIFF
--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/errcode"
 )
@@ -155,4 +156,28 @@ func NewErrEmptyTagOrDigest(ref string, cmd *cobra.Command, needsTag bool) error
 		Usage:          fmt.Sprintf("%s %s", cmd.Parent().CommandPath(), cmd.Use),
 		Recommendation: fmt.Sprintf(`Please specify a reference in the form of %s. Run "%s -h" for more options and examples`, form, cmd.CommandPath()),
 	}
+}
+
+// CheckMutuallyExclusiveFlags checks if any mutually exclusive flags are used
+// at the same time, returns an error when detecting used exclusive flags. It
+// detects the first set of conflict and returns the error without checking
+// the rest of the flag sets.
+func CheckMutuallyExclusiveFlags(fs *pflag.FlagSet, exclusiveFlagSets ...[]string) error {
+	var checkConflict = func(exclusiveFlagSet []string) []string {
+		changedFlags := []string{}
+		for _, flagName := range exclusiveFlagSet {
+			if fs.Changed(flagName) {
+				changedFlags = append(changedFlags, fmt.Sprintf("--%s", flagName))
+			}
+		}
+		return changedFlags
+	}
+	for _, set := range exclusiveFlagSets {
+		changedFlags := checkConflict(set)
+		if len(changedFlags) >= 2 {
+			flags := strings.Join(changedFlags, ", ")
+			return fmt.Errorf("--%s cannot be used at the same time", flags)
+		}
+	}
+	return nil
 }

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -176,7 +176,7 @@ func CheckMutuallyExclusiveFlags(fs *pflag.FlagSet, exclusiveFlagSets ...[]strin
 		changedFlags := checkConflict(set)
 		if len(changedFlags) >= 2 {
 			flags := strings.Join(changedFlags, ", ")
-			return fmt.Errorf("--%s cannot be used at the same time", flags)
+			return fmt.Errorf("%s cannot be used at the same time", flags)
 		}
 	}
 	return nil

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -149,34 +149,13 @@ func (opts *Remote) Parse(cmd *cobra.Command) error {
 	if cmd.Flags().Lookup(passwordFromStdinFlag) != nil {
 		passwordAndIdTokenFlags = append(passwordAndIdTokenFlags, passwordFromStdinFlag)
 	}
-	if err := CheckMutuallyExclusiveFlags(cmd, usernameAndIdTokenFlags, passwordAndIdTokenFlags); err != nil {
+	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), usernameAndIdTokenFlags, passwordAndIdTokenFlags); err != nil {
 		return err
 	}
 	if err := opts.parseCustomHeaders(); err != nil {
 		return err
 	}
 	return opts.readSecret(cmd)
-}
-
-// CheckMutuallyExclusiveFlags checks if any mutually exclusive flags are both
-// set, returns an error when detecting set exclusive flags.
-func CheckMutuallyExclusiveFlags(cmd *cobra.Command, exclusiveFlagSets ...[]string) error {
-	var checkConflict = func(exclusiveFlagSet []string) []string {
-		changedFlags := []string{}
-		for _, flagName := range exclusiveFlagSet {
-			if cmd.Flags().Changed(flagName) {
-				changedFlags = append(changedFlags, flagName)
-			}
-		}
-		return changedFlags
-	}
-	for _, set := range exclusiveFlagSets {
-		changedFlags := checkConflict(set)
-		if len(changedFlags) >= 2 {
-			return fmt.Errorf("--%s cannot be used with --%s", changedFlags[0], changedFlags[1])
-		}
-	}
-	return nil
 }
 
 // readSecret tries to read password or identity token with


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve error message when detecting conflicting flags. 
Current display:
![image](https://github.com/oras-project/oras/assets/103478229/5f72af40-7f0d-4305-9ed4-dce475e3e3b5)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1340 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
