### PR TITLE
fix: fix error message when output is used before format for oras discover

### DIFF
--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -160,7 +160,7 @@ func NewErrEmptyTagOrDigest(ref string, cmd *cobra.Command, needsTag bool) error
 
 // CheckMutuallyExclusiveFlags checks if any mutually exclusive flags are used
 // at the same time, returns an error when detecting used exclusive flags.
-func CheckMutuallyExclusiveFlags(fs *pflag.FlagSet, exclusiveFlagSet []string) error {
+func CheckMutuallyExclusiveFlags(fs *pflag.FlagSet, exclusiveFlagSet ...string) error {
 	var changedFlags []string
 	for _, flagName := range exclusiveFlagSet {
 		if fs.Changed(flagName) {

--- a/cmd/oras/internal/errors/errors.go
+++ b/cmd/oras/internal/errors/errors.go
@@ -159,25 +159,17 @@ func NewErrEmptyTagOrDigest(ref string, cmd *cobra.Command, needsTag bool) error
 }
 
 // CheckMutuallyExclusiveFlags checks if any mutually exclusive flags are used
-// at the same time, returns an error when detecting used exclusive flags. It
-// detects the first set of conflict and returns the error without checking
-// the rest of the flag sets.
-func CheckMutuallyExclusiveFlags(fs *pflag.FlagSet, exclusiveFlagSets ...[]string) error {
-	var checkConflict = func(exclusiveFlagSet []string) []string {
-		changedFlags := []string{}
-		for _, flagName := range exclusiveFlagSet {
-			if fs.Changed(flagName) {
-				changedFlags = append(changedFlags, fmt.Sprintf("--%s", flagName))
-			}
+// at the same time, returns an error when detecting used exclusive flags.
+func CheckMutuallyExclusiveFlags(fs *pflag.FlagSet, exclusiveFlagSet []string) error {
+	var changedFlags []string
+	for _, flagName := range exclusiveFlagSet {
+		if fs.Changed(flagName) {
+			changedFlags = append(changedFlags, fmt.Sprintf("--%s", flagName))
 		}
-		return changedFlags
 	}
-	for _, set := range exclusiveFlagSets {
-		changedFlags := checkConflict(set)
-		if len(changedFlags) >= 2 {
-			flags := strings.Join(changedFlags, ", ")
-			return fmt.Errorf("%s cannot be used at the same time", flags)
-		}
+	if len(changedFlags) >= 2 {
+		flags := strings.Join(changedFlags, ", ")
+		return fmt.Errorf("%s cannot be used at the same time", flags)
 	}
 	return nil
 }

--- a/cmd/oras/internal/errors/errors_test.go
+++ b/cmd/oras/internal/errors/errors_test.go
@@ -47,7 +47,7 @@ func TestCheckMutuallyExclusiveFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckMutuallyExclusiveFlags(fs, tt.exclusiveFlagSet); (err != nil) != tt.wantErr {
+			if err := CheckMutuallyExclusiveFlags(fs, tt.exclusiveFlagSet...); (err != nil) != tt.wantErr {
 				t.Errorf("CheckMutuallyExclusiveFlags() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/cmd/oras/internal/errors/errors_test.go
+++ b/cmd/oras/internal/errors/errors_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestCheckMutuallyExclusiveFlags(t *testing.T) {
+	fs := &pflag.FlagSet{}
+	var foo, bar, hello bool
+	fs.BoolVar(&foo, "foo", false, "foo test")
+	fs.BoolVar(&bar, "bar", false, "bar test")
+	fs.BoolVar(&hello, "hello", false, "hello test")
+	fs.Lookup("foo").Changed = true
+	fs.Lookup("bar").Changed = true
+	tests := []struct {
+		name             string
+		exclusiveFlagSet []string
+		wantErr          bool
+	}{
+		{
+			"--foo and --bar should not be used at the same time",
+			[]string{"foo", "bar"},
+			true,
+		},
+		{
+			"--foo and --hello are not used at the same time",
+			[]string{"foo", "hello"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CheckMutuallyExclusiveFlags(fs, tt.exclusiveFlagSet); (err != nil) != tt.wantErr {
+				t.Errorf("CheckMutuallyExclusiveFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -157,7 +157,10 @@ func (opts *Remote) Parse(cmd *cobra.Command) error {
 	if cmd.Flags().Lookup(passwordFromStdinFlag) != nil {
 		passwordAndIdTokenFlags = append(passwordAndIdTokenFlags, passwordFromStdinFlag)
 	}
-	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), usernameAndIdTokenFlags, passwordAndIdTokenFlags); err != nil {
+	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), usernameAndIdTokenFlags); err != nil {
+		return err
+	}
+	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), passwordAndIdTokenFlags); err != nil {
 		return err
 	}
 	if err := opts.parseCustomHeaders(); err != nil {

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -157,10 +157,10 @@ func (opts *Remote) Parse(cmd *cobra.Command) error {
 	if cmd.Flags().Lookup(passwordFromStdinFlag) != nil {
 		passwordAndIdTokenFlags = append(passwordAndIdTokenFlags, passwordFromStdinFlag)
 	}
-	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), usernameAndIdTokenFlags); err != nil {
+	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), usernameAndIdTokenFlags...); err != nil {
 		return err
 	}
-	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), passwordAndIdTokenFlags); err != nil {
+	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), passwordAndIdTokenFlags...); err != nil {
 		return err
 	}
 	if err := opts.parseCustomHeaders(); err != nil {

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -74,6 +74,9 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
 `,
 		Args: oerrors.CheckArgs(argument.Exactly(1), "the target artifact to discover referrers from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), []string{"format", "output"}); err != nil {
+				return err
+			}
 			if cmd.Flags().Changed("output") {
 				switch opts.Template {
 				case "tree", "json", "table":
@@ -97,7 +100,6 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
 'table':      Get direct referrers and output in table format
 'json':       Get direct referrers and output in JSON format
 '$TEMPLATE':  Print direct referrers using the given Go template.`)
-	cmd.MarkFlagsMutuallyExclusive("output", "format")
 	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -74,7 +74,7 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
 `,
 		Args: oerrors.CheckArgs(argument.Exactly(1), "the target artifact to discover referrers from"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), []string{"format", "output"}); err != nil {
+			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), "format", "output"); err != nil {
 				return err
 			}
 			if cmd.Flags().Changed("output") {

--- a/test/e2e/suite/command/discover.go
+++ b/test/e2e/suite/command/discover.go
@@ -64,9 +64,15 @@ var _ = Describe("ORAS beginners:", func() {
 			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, "")).ExpectFailure().MatchErrKeyWords("Error:", "no tag or digest specified", "oras discover").Exec()
 		})
 
-		It("should fail if both output and format flags are used", func() {
+		It("should fail with correct error message if both output and format flags are used", func() {
 			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--format", "json", "--output", "json").
-				ExpectFailure().
+				ExpectFailure().MatchErrKeyWords("--format", "--output", "same time").
+				Exec()
+		})
+
+		It("should fail with correct error message if output flag is used before format flag", func() {
+			ORAS("discover", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--output", "json", "--format", "json").
+				ExpectFailure().MatchErrKeyWords("--format", "--output", "same time").
 				Exec()
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1348 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
