### PR TITLE
fix: return error when --format and --pretty are both used

### DIFF
--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -74,10 +74,14 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 			switch {
 			case opts.outputPath == "-" && opts.Template != "":
 				return fmt.Errorf("`--output -` cannot be used with `--format %s` at the same time", opts.Template)
-			case opts.OutputDescriptor && opts.Template != "":
-				return fmt.Errorf("`--descriptor` cannot be used with `--format %s` at the same time", opts.Template)
 			case opts.OutputDescriptor && opts.outputPath == "-":
 				return fmt.Errorf("`--descriptor` cannot be used with `--output -` at the same time")
+			}
+			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), []string{"format", "pretty"}); err != nil {
+				return err
+			}
+			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), []string{"format", "descriptor"}); err != nil {
+				return err
 			}
 			opts.RawReference = args[0]
 			return option.Parse(cmd, &opts)

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -77,10 +77,10 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 			case opts.OutputDescriptor && opts.outputPath == "-":
 				return fmt.Errorf("`--descriptor` cannot be used with `--output -` at the same time")
 			}
-			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), []string{"format", "pretty"}); err != nil {
+			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), "format", "pretty"); err != nil {
 				return err
 			}
-			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), []string{"format", "descriptor"}); err != nil {
+			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), "format", "descriptor"); err != nil {
 				return err
 			}
 			opts.RawReference = args[0]

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -112,7 +112,7 @@ var _ = Describe("ORAS beginners:", func() {
 					ExpectFailure().Exec()
 				ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--output", "-", "--descriptor").
 					ExpectFailure().Exec()
-				ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--format", "--pretty", "test").
+				ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--format", "test", "--pretty").
 					ExpectFailure().Exec()
 			})
 		})

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -112,6 +112,8 @@ var _ = Describe("ORAS beginners:", func() {
 					ExpectFailure().Exec()
 				ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--output", "-", "--descriptor").
 					ExpectFailure().Exec()
+				ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--format", "--pretty", "test").
+					ExpectFailure().Exec()
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
return error when --format and --pretty are both used for `oras manifest fetch`. Need to rebase after #1354 is merged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1356 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
