### PR TITLE
fix: ignore --pretty when --output is used for oras manifest fetch

### DIFF
--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -76,7 +76,8 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 				return fmt.Errorf("`--output -` cannot be used with `--format %s` at the same time", opts.Template)
 			case opts.outputPath == "-" && opts.OutputDescriptor:
 				return fmt.Errorf("`--descriptor` cannot be used with `--output -` at the same time")
-			case opts.outputPath != "" && opts.Pretty.Pretty:
+			// ignore --pretty when output to a file
+			case opts.outputPath != "" && opts.outputPath != "-":
 				opts.Pretty.Pretty = false
 			}
 			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), "format", "pretty"); err != nil {

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -74,8 +74,10 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 			switch {
 			case opts.outputPath == "-" && opts.Template != "":
 				return fmt.Errorf("`--output -` cannot be used with `--format %s` at the same time", opts.Template)
-			case opts.OutputDescriptor && opts.outputPath == "-":
+			case opts.outputPath == "-" && opts.OutputDescriptor:
 				return fmt.Errorf("`--descriptor` cannot be used with `--output -` at the same time")
+			case opts.outputPath != "" && opts.Pretty.Pretty:
+				opts.Pretty.Pretty = false
 			}
 			if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), "format", "pretty"); err != nil {
 				return err

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -232,6 +232,13 @@ var _ = Describe("1.1 registry users:", func() {
 			MatchFile(fetchPath, multi_arch.Manifest, DefaultTimeout)
 		})
 
+		It("should ignore --pretty when fetching manifest to a file", func() {
+			fetchPath := filepath.Join(GinkgoT().TempDir(), "fetchedImage")
+			ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag), "--output", fetchPath, "--pretty").
+				Exec()
+			MatchFile(fetchPath, multi_arch.Manifest, DefaultTimeout)
+		})
+
 		It("should fetch manifest to file and output json", func() {
 			fetchPath := filepath.Join(GinkgoT().TempDir(), "fetchedImage")
 			digest := multi_arch.LinuxAMD64.Digest.String()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1361 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
