### PR TITLE
fix: remove non-classic snap plugins

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,6 +47,3 @@ parts:
 apps:
   oras:
     command: bin/oras
-    plugs:
-      - home
-      - network


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR added a fix to remove non-classic snap plugins in the snap build configuration. Will resolve [publish errors](https://github.com/oras-project/oras/actions/runs/9124299668) in the snap release