### PR TITLE
fix: oras cp documentation

### DIFF
--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -77,7 +77,7 @@ Example - Copy an artifact and its referrers:
 
 Example - Copy an artifact and referrers using specific methods for the Referrers API:
   oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag \
-    localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1 
+    localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 
 Example - Copy certain platform of an artifact:
   oras cp --platform linux/arm/v5 localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1


### PR DESCRIPTION
This was the only difference I thought should be corrected in the CLI as far as the documentation
