### PR TITLE
chore: Remove deprecated PrintStatus method

### DIFF
--- a/cmd/oras/internal/display/status/deprecated.go
+++ b/cmd/oras/internal/display/status/deprecated.go
@@ -60,8 +60,3 @@ var printer = NewPrinter(os.Stdout)
 func Print(a ...any) error {
 	return printer.Println(a...)
 }
-
-// PrintStatus prints transfer status.
-func PrintStatus(desc ocispec.Descriptor, status string, verbose bool) error {
-	return printer.PrintStatus(desc, status, verbose)
-}

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -100,27 +100,27 @@ func (ph *TextPullHandler) TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, S
 
 // OnNodeDownloading implements PullHandler.
 func (ph *TextPullHandler) OnNodeDownloading(desc ocispec.Descriptor) error {
-	return PrintStatus(desc, PullPromptDownloading, ph.verbose)
+	return ph.printer.PrintStatus(desc, PullPromptDownloading, ph.verbose)
 }
 
 // OnNodeDownloaded implements PullHandler.
 func (ph *TextPullHandler) OnNodeDownloaded(desc ocispec.Descriptor) error {
-	return PrintStatus(desc, PullPromptDownloaded, ph.verbose)
+	return ph.printer.PrintStatus(desc, PullPromptDownloaded, ph.verbose)
 }
 
 // OnNodeRestored implements PullHandler.
 func (ph *TextPullHandler) OnNodeRestored(desc ocispec.Descriptor) error {
-	return PrintStatus(desc, PullPromptRestored, ph.verbose)
+	return ph.printer.PrintStatus(desc, PullPromptRestored, ph.verbose)
 }
 
 // OnNodeProcessing implements PullHandler.
 func (ph *TextPullHandler) OnNodeProcessing(desc ocispec.Descriptor) error {
-	return PrintStatus(desc, PullPromptProcessing, ph.verbose)
+	return ph.printer.PrintStatus(desc, PullPromptProcessing, ph.verbose)
 }
 
 // OnNodeProcessing implements PullHandler.
 func (ph *TextPullHandler) OnNodeSkipped(desc ocispec.Descriptor) error {
-	return PrintStatus(desc, PullPromptSkipped, ph.verbose)
+	return ph.printer.PrintStatus(desc, PullPromptSkipped, ph.verbose)
 }
 
 // NewTextPullHandler returns a new handler for pull command.

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -103,6 +103,7 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 
 func pushBlob(cmd *cobra.Command, opts *pushBlobOptions) (err error) {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
+	printer := status.NewPrinter(cmd.OutOrStdout())
 
 	target, err := opts.NewTarget(opts.Common, logger)
 	if err != nil {
@@ -122,9 +123,9 @@ func pushBlob(cmd *cobra.Command, opts *pushBlobOptions) (err error) {
 	}
 	verbose := opts.Verbose && !opts.OutputDescriptor
 	if exists {
-		err = status.PrintStatus(desc, "Exists", verbose)
+		err = printer.PrintStatus(desc, "Exists", verbose)
 	} else {
-		err = opts.doPush(ctx, target, desc, rc)
+		err = opts.doPush(ctx, printer, target, desc, rc)
 	}
 	if err != nil {
 		return err
@@ -144,16 +145,16 @@ func pushBlob(cmd *cobra.Command, opts *pushBlobOptions) (err error) {
 
 	return nil
 }
-func (opts *pushBlobOptions) doPush(ctx context.Context, t oras.Target, desc ocispec.Descriptor, r io.Reader) error {
+func (opts *pushBlobOptions) doPush(ctx context.Context, printer *status.Printer, t oras.Target, desc ocispec.Descriptor, r io.Reader) error {
 	if opts.TTY == nil {
 		// none TTY output
-		if err := status.PrintStatus(desc, "Uploading", opts.Verbose); err != nil {
+		if err := printer.PrintStatus(desc, "Uploading", opts.Verbose); err != nil {
 			return err
 		}
 		if err := t.Push(ctx, desc, r); err != nil {
 			return err
 		}
-		return status.PrintStatus(desc, "Uploaded ", opts.Verbose)
+		return printer.PrintStatus(desc, "Uploaded ", opts.Verbose)
 	}
 
 	// TTY output

--- a/cmd/oras/root/blob/push_test.go
+++ b/cmd/oras/root/blob/push_test.go
@@ -20,6 +20,8 @@ package blob
 import (
 	"bytes"
 	"context"
+	"oras.land/oras/cmd/oras/internal/display/status"
+	"os"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -38,6 +40,7 @@ func Test_pushBlobOptions_doPush(t *testing.T) {
 	src := memory.New()
 	content := []byte("test")
 	r := bytes.NewReader(content)
+	printer := status.NewPrinter(os.Stdout)
 	desc := ocispec.Descriptor{
 		MediaType: "application/octet-stream",
 		Digest:    digest.FromBytes(content),
@@ -46,7 +49,7 @@ func Test_pushBlobOptions_doPush(t *testing.T) {
 	var opts pushBlobOptions
 	opts.Common.TTY = device
 	// test
-	err = opts.doPush(context.Background(), src, desc, r)
+	err = opts.doPush(context.Background(), printer, src, desc, r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -111,6 +111,7 @@ Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag wit
 
 func pushManifest(cmd *cobra.Command, opts pushOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
+	printer := status.NewPrinter(cmd.OutOrStdout())
 	var target oras.Target
 	var err error
 	target, err = opts.NewTarget(opts.Common, logger)
@@ -156,17 +157,17 @@ func pushManifest(cmd *cobra.Command, opts pushOptions) error {
 	}
 	verbose := opts.Verbose && !opts.OutputDescriptor
 	if match {
-		if err := status.PrintStatus(desc, "Exists", verbose); err != nil {
+		if err := printer.PrintStatus(desc, "Exists", verbose); err != nil {
 			return err
 		}
 	} else {
-		if err = status.PrintStatus(desc, "Uploading", verbose); err != nil {
+		if err = printer.PrintStatus(desc, "Uploading", verbose); err != nil {
 			return err
 		}
 		if _, err := oras.TagBytes(ctx, target, mediaType, contentBytes, ref); err != nil {
 			return err
 		}
-		if err = status.PrintStatus(desc, "Uploaded ", verbose); err != nil {
+		if err = printer.PrintStatus(desc, "Uploaded ", verbose); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes deprecated PrintStatus method
