### PR TITLE
bump: tag and release ORAS CLI v1.2.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.2.0-rc.1"
+	Version = "1.2.0"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes to tag v1.2.0 based on https://github.com/oras-project/oras/commit/dcef719e208a9b226b15bc6512ad729a7dd93270 and release. At least 3 approvals are needed from the 5 owners.

Below is a summary of change notes since [v1.2.0-rc.1](https://github.com/oras-project/oras/releases/tag/v1.2.0-rc.1):

## Other Changes
- Dependency updates
- Enhance document for format output
- Code clean

## Detailed Commits
* bump: tag and release ORAS CLI v1.2.0-rc.1 by @qweeah in https://github.com/oras-project/oras/pull/1381
* fix: remove non-classic snap plugins by @qweeah in https://github.com/oras-project/oras/pull/1383
* fix: oras cp documentation by @TerryHowe in https://github.com/oras-project/oras/pull/1384
* build(deps): bump actions/checkout from 3 to 4 by @dependabot in https://github.com/oras-project/oras/pull/1385
* refactor: Get rid of deprecated PrintStatus method by @TerryHowe in https://github.com/oras-project/oras/pull/1378
* build(deps): bump github.com/onsi/ginkgo/v2 from 2.17.3 to 2.18.0 in /test/e2e by @dependabot in https://github.com/oras-project/oras/pull/1388
* build(deps): bump github.com/onsi/ginkgo/v2 from 2.18.0 to 2.19.0 in /test/e2e by @dependabot in https://github.com/oras-project/oras/pull/1390
* chore: Remove deprecated PrintStatus method by @TerryHowe in https://github.com/oras-project/oras/pull/1389
* doc: verify local files by @qweeah in https://github.com/oras-project/oras/pull/1386
* fix: remove call to deprecated print by @TerryHowe in https://github.com/oras-project/oras/pull/1392


**Full Changelog**: https://github.com/oras-project/oras/compare/v1.2.0-rc.1...v1.2.0
