### PR TITLE
refactor: Move printer to output package

### DIFF
--- a/cmd/oras/internal/display/status/deprecated.go
+++ b/cmd/oras/internal/display/status/deprecated.go
@@ -16,6 +16,7 @@ limitations under the License.
 package status
 
 import (
+	"oras.land/oras/cmd/oras/internal/output"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -28,7 +29,7 @@ import (
 
 // NewTagStatusHintPrinter creates a wrapper type for printing
 // tag status and hint.
-func NewTagStatusHintPrinter(printer *Printer, target oras.Target, refPrefix string) oras.Target {
+func NewTagStatusHintPrinter(printer *output.Printer, target oras.Target, refPrefix string) oras.Target {
 	var printHint sync.Once
 	var printHintErr error
 	onTagging := func(desc ocispec.Descriptor, tag string) error {
@@ -45,7 +46,7 @@ func NewTagStatusHintPrinter(printer *Printer, target oras.Target, refPrefix str
 }
 
 // NewTagStatusPrinter creates a wrapper type for printing tag status.
-func NewTagStatusPrinter(printer *Printer, target oras.Target) oras.Target {
+func NewTagStatusPrinter(printer *output.Printer, target oras.Target) oras.Target {
 	return listener.NewTagListener(target, nil, func(desc ocispec.Descriptor, tag string) error {
 		return printer.Println("Tagged", tag)
 	})

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -18,6 +18,7 @@ package status
 import (
 	"context"
 	"io"
+	"oras.land/oras/cmd/oras/internal/output"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -28,14 +29,14 @@ import (
 // TextPushHandler handles text status output for push events.
 type TextPushHandler struct {
 	verbose bool
-	printer *Printer
+	printer *output.Printer
 }
 
 // NewTextPushHandler returns a new handler for push command.
 func NewTextPushHandler(out io.Writer, verbose bool) PushHandler {
 	return &TextPushHandler{
 		verbose: verbose,
-		printer: NewPrinter(out),
+		printer: output.NewPrinter(out),
 	}
 }
 
@@ -75,7 +76,7 @@ func (ph *TextPushHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetche
 	}
 	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		if err := PrintSuccessorStatus(ctx, desc, fetcher, committed, ph.printer.StatusPrinter(promptSkipped, ph.verbose)); err != nil {
+		if err := output.PrintSuccessorStatus(ctx, desc, fetcher, committed, ph.printer.StatusPrinter(promptSkipped, ph.verbose)); err != nil {
 			return err
 		}
 		return ph.printer.PrintStatus(desc, promptUploaded, ph.verbose)
@@ -90,7 +91,7 @@ func NewTextAttachHandler(out io.Writer, verbose bool) AttachHandler {
 // TextPullHandler handles text status output for pull events.
 type TextPullHandler struct {
 	verbose bool
-	printer *Printer
+	printer *output.Printer
 }
 
 // TrackTarget implements PullHander.
@@ -127,6 +128,6 @@ func (ph *TextPullHandler) OnNodeSkipped(desc ocispec.Descriptor) error {
 func NewTextPullHandler(out io.Writer, verbose bool) PullHandler {
 	return &TextPullHandler{
 		verbose: verbose,
-		printer: NewPrinter(out),
+		printer: output.NewPrinter(out),
 	}
 }

--- a/cmd/oras/internal/display/status/tty.go
+++ b/cmd/oras/internal/display/status/tty.go
@@ -17,6 +17,7 @@ package status
 
 import (
 	"context"
+	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"sync"
 
@@ -76,7 +77,7 @@ func (ph *TTYPushHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetcher
 	}
 	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		return PrintSuccessorStatus(ctx, desc, fetcher, committed, func(d ocispec.Descriptor) error {
+		return output.PrintSuccessorStatus(ctx, desc, fetcher, committed, func(d ocispec.Descriptor) error {
 			return ph.tracked.Prompt(d, promptSkipped)
 		})
 	}

--- a/cmd/oras/internal/output/print.go
+++ b/cmd/oras/internal/output/print.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package status
+package output
 
 import (
 	"context"

--- a/cmd/oras/internal/output/print_test.go
+++ b/cmd/oras/internal/output/print_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package status
+package output
 
 import (
 	"fmt"

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -27,7 +28,6 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/command"
-	"oras.land/oras/cmd/oras/internal/display/status"
 	"oras.land/oras/cmd/oras/internal/display/status/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -103,7 +103,7 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 
 func pushBlob(cmd *cobra.Command, opts *pushBlobOptions) (err error) {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := status.NewPrinter(cmd.OutOrStdout())
+	printer := output.NewPrinter(cmd.OutOrStdout())
 
 	target, err := opts.NewTarget(opts.Common, logger)
 	if err != nil {
@@ -145,7 +145,7 @@ func pushBlob(cmd *cobra.Command, opts *pushBlobOptions) (err error) {
 
 	return nil
 }
-func (opts *pushBlobOptions) doPush(ctx context.Context, printer *status.Printer, t oras.Target, desc ocispec.Descriptor, r io.Reader) error {
+func (opts *pushBlobOptions) doPush(ctx context.Context, printer *output.Printer, t oras.Target, desc ocispec.Descriptor, r io.Reader) error {
 	if opts.TTY == nil {
 		// none TTY output
 		if err := printer.PrintStatus(desc, "Uploading", opts.Verbose); err != nil {

--- a/cmd/oras/root/blob/push_test.go
+++ b/cmd/oras/root/blob/push_test.go
@@ -20,7 +20,7 @@ package blob
 import (
 	"bytes"
 	"context"
-	"oras.land/oras/cmd/oras/internal/display/status"
+	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"testing"
 
@@ -40,7 +40,7 @@ func Test_pushBlobOptions_doPush(t *testing.T) {
 	src := memory.New()
 	content := []byte("test")
 	r := bytes.NewReader(content)
-	printer := status.NewPrinter(os.Stdout)
+	printer := output.NewPrinter(os.Stdout)
 	desc := ocispec.Descriptor{
 		MediaType: "application/octet-stream",
 		Digest:    digest.FromBytes(content),

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"oras.land/oras/cmd/oras/internal/display/status"
+	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"strings"
 	"testing"
@@ -132,7 +132,7 @@ func Test_doCopy(t *testing.T) {
 	opts.From.Reference = memDesc.Digest.String()
 	dst := memory.New()
 	builder := &strings.Builder{}
-	printer := status.NewPrinter(builder)
+	printer := output.NewPrinter(builder)
 	// test
 	_, err = doCopy(context.Background(), printer, memStore, dst, &opts)
 	if err != nil {
@@ -156,7 +156,7 @@ func Test_doCopy_skipped(t *testing.T) {
 	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
 	builder := &strings.Builder{}
-	printer := status.NewPrinter(builder)
+	printer := output.NewPrinter(builder)
 	// test
 	_, err = doCopy(context.Background(), printer, memStore, memStore, &opts)
 	if err != nil {
@@ -191,7 +191,7 @@ func Test_doCopy_mounted(t *testing.T) {
 	}
 	to.PlainHTTP = true
 	builder := &strings.Builder{}
-	printer := status.NewPrinter(builder)
+	printer := output.NewPrinter(builder)
 	// test
 	_, err = doCopy(context.Background(), printer, from, to, &opts)
 	if err != nil {

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"strings"
 
@@ -111,7 +112,7 @@ Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag wit
 
 func pushManifest(cmd *cobra.Command, opts pushOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := status.NewPrinter(cmd.OutOrStdout())
+	printer := output.NewPrinter(cmd.OutOrStdout())
 	var target oras.Target
 	var err error
 	target, err = opts.NewTarget(opts.Common, logger)

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -18,6 +18,7 @@ package root
 import (
 	"errors"
 	"fmt"
+	"oras.land/oras/cmd/oras/internal/output"
 
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
@@ -98,7 +99,7 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := status.NewPrinter(cmd.OutOrStdout())
+	printer := output.NewPrinter(cmd.OutOrStdout())
 	target, err := opts.NewTarget(opts.Common, logger)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

The printer is supposed to be a very generic output object and this change moves in that direction.
