### PR TITLE
chore: Remove deprecated Print method

### DIFF
--- a/cmd/oras/internal/display/status/deprecated.go
+++ b/cmd/oras/internal/display/status/deprecated.go
@@ -16,7 +16,6 @@ limitations under the License.
 package status
 
 import (
-	"os"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -29,34 +28,25 @@ import (
 
 // NewTagStatusHintPrinter creates a wrapper type for printing
 // tag status and hint.
-func NewTagStatusHintPrinter(target oras.Target, refPrefix string) oras.Target {
+func NewTagStatusHintPrinter(printer *Printer, target oras.Target, refPrefix string) oras.Target {
 	var printHint sync.Once
 	var printHintErr error
 	onTagging := func(desc ocispec.Descriptor, tag string) error {
 		printHint.Do(func() {
 			ref := refPrefix + "@" + desc.Digest.String()
-			printHintErr = Print("Tagging", ref)
+			printHintErr = printer.Println("Tagging", ref)
 		})
 		return printHintErr
 	}
 	onTagged := func(desc ocispec.Descriptor, tag string) error {
-		return Print("Tagged", tag)
+		return printer.Println("Tagged", tag)
 	}
 	return listener.NewTagListener(target, onTagging, onTagged)
 }
 
 // NewTagStatusPrinter creates a wrapper type for printing tag status.
-func NewTagStatusPrinter(target oras.Target) oras.Target {
+func NewTagStatusPrinter(printer *Printer, target oras.Target) oras.Target {
 	return listener.NewTagListener(target, nil, func(desc ocispec.Descriptor, tag string) error {
-		return Print("Tagged", tag)
+		return printer.Println("Tagged", tag)
 	})
-}
-
-// printer is used by the code being deprecated. Related functions should be
-// removed when no-longer referenced.
-var printer = NewPrinter(os.Stdout)
-
-// Print objects to display concurrent-safely.
-func Print(a ...any) error {
-	return printer.Println(a...)
 }

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -142,7 +142,7 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 	if len(opts.extraRefs) != 0 {
 		tagNOpts := oras.DefaultTagNOptions
 		tagNOpts.Concurrency = opts.concurrency
-		if _, err = oras.TagN(ctx, status.NewTagStatusPrinter(dst), opts.To.Reference, opts.extraRefs, tagNOpts); err != nil {
+		if _, err = oras.TagN(ctx, status.NewTagStatusPrinter(printer, dst), opts.To.Reference, opts.extraRefs, tagNOpts); err != nil {
 			return err
 		}
 	}

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -190,7 +190,7 @@ func pushManifest(cmd *cobra.Command, opts pushOptions) error {
 	}
 	printer.Println("Pushed", opts.AnnotatedReference())
 	if len(opts.extraRefs) != 0 {
-		if _, err = oras.TagBytesN(ctx, status.NewTagStatusPrinter(target), mediaType, contentBytes, opts.extraRefs, tagBytesNOpts); err != nil {
+		if _, err = oras.TagBytesN(ctx, status.NewTagStatusPrinter(printer, target), mediaType, contentBytes, opts.extraRefs, tagBytesNOpts); err != nil {
 			return err
 		}
 	}

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -98,6 +98,7 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
+	printer := status.NewPrinter(cmd.OutOrStdout())
 	target, err := opts.NewTarget(opts.Common, logger)
 	if err != nil {
 		return err
@@ -110,7 +111,7 @@ func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 	tagNOpts.Concurrency = opts.concurrency
 	_, err = oras.TagN(
 		ctx,
-		status.NewTagStatusHintPrinter(target, fmt.Sprintf("[%s] %s", opts.Type, opts.Path)),
+		status.NewTagStatusHintPrinter(printer, target, fmt.Sprintf("[%s] %s", opts.Type, opts.Path)),
 		opts.Reference,
 		opts.targetRefs,
 		tagNOpts,


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove deprecated Print method
