### PR TITLE
chore: Update goreleaser to v6 and configuration to v2

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           go-version: '1.22.3'
       - name: run goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@
 # To release:
 #   GITHUB_TOKEN=*** goreleaser
 
+version: 2
 builds:
 - main: ./cmd/oras
   binary: ./oras


### PR DESCRIPTION
**What this PR does / why we need it**:

Config changes to update `goreleaser`
