### PR TITLE
refactor: clean status prompts

### DIFF
--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -18,8 +18,9 @@ package status
 import (
 	"context"
 	"io"
-	"oras.land/oras/cmd/oras/internal/output"
 	"sync"
+
+	"oras.land/oras/cmd/oras/internal/output"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -63,17 +64,17 @@ func (ph *TextPushHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetche
 	committed := &sync.Map{}
 	opts.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
 		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		return ph.printer.PrintStatus(desc, promptExists, ph.verbose)
+		return ph.printer.PrintStatus(desc, PushPromptExists, ph.verbose)
 	}
 	opts.PreCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
-		return ph.printer.PrintStatus(desc, promptUploading, ph.verbose)
+		return ph.printer.PrintStatus(desc, PushPromptUploading, ph.verbose)
 	}
 	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		if err := output.PrintSuccessorStatus(ctx, desc, fetcher, committed, ph.printer.StatusPrinter(promptSkipped, ph.verbose)); err != nil {
+		if err := output.PrintSuccessorStatus(ctx, desc, fetcher, committed, ph.printer.StatusPrinter(PushPromptSkipped, ph.verbose)); err != nil {
 			return err
 		}
-		return ph.printer.PrintStatus(desc, promptUploaded, ph.verbose)
+		return ph.printer.PrintStatus(desc, PushPromptUploaded, ph.verbose)
 	}
 }
 

--- a/cmd/oras/internal/display/status/tty.go
+++ b/cmd/oras/internal/display/status/tty.go
@@ -17,9 +17,10 @@ package status
 
 import (
 	"context"
-	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"sync"
+
+	"oras.land/oras/cmd/oras/internal/output"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -52,7 +53,7 @@ func (ph *TTYPushHandler) OnEmptyArtifact() error {
 
 // TrackTarget returns a tracked target.
 func (ph *TTYPushHandler) TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, StopTrackTargetFunc, error) {
-	tracked, err := track.NewTarget(gt, promptUploading, promptUploaded, ph.tty)
+	tracked, err := track.NewTarget(gt, PushPromptUploading, PushPromptUploaded, ph.tty)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -65,12 +66,12 @@ func (ph *TTYPushHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetcher
 	committed := &sync.Map{}
 	opts.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
 		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		return ph.tracked.Prompt(desc, promptExists)
+		return ph.tracked.Prompt(desc, PushPromptExists)
 	}
 	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
 		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
 		return output.PrintSuccessorStatus(ctx, desc, fetcher, committed, func(d ocispec.Descriptor) error {
-			return ph.tracked.Prompt(d, promptSkipped)
+			return ph.tracked.Prompt(d, PushPromptSkipped)
 		})
 	}
 }

--- a/cmd/oras/internal/display/status/tty_test.go
+++ b/cmd/oras/internal/display/status/tty_test.go
@@ -66,6 +66,7 @@ func TestMain(m *testing.M) {
 	manifest := ocispec.Manifest{
 		MediaType: ocispec.MediaTypeImageManifest,
 		Layers:    []ocispec.Descriptor{layer1Desc, layer2Desc},
+		Config:    memDesc,
 	}
 	manifestContent, err := json.Marshal(&manifest)
 	if err != nil {
@@ -114,7 +115,7 @@ func TestTTYPushHandler_TrackTarget(t *testing.T) {
 	// test
 	_, fn, err := ph.TrackTarget(store)
 	if err != nil {
-		t.Error("TrackTarget() should not return an error")
+		t.Fatal("TrackTarget() should not return an error")
 	}
 	defer func() {
 		if err := fn(); err != nil {
@@ -122,7 +123,7 @@ func TestTTYPushHandler_TrackTarget(t *testing.T) {
 		}
 	}()
 	if ttyPushHandler, ok := ph.(*TTYPushHandler); !ok {
-		t.Errorf("TrackTarget() should return a *TTYPushHandler, got %T", ttyPushHandler)
+		t.Fatalf("TrackTarget() should return a *TTYPushHandler, got %T", ttyPushHandler)
 	}
 }
 
@@ -143,24 +144,24 @@ func TestTTYPushHandler_UpdateCopyOptions(t *testing.T) {
 	ph := NewTTYPushHandler(slave)
 	gt, _, err := ph.TrackTarget(memory.New())
 	if err != nil {
-		t.Errorf("TrackTarget() should not return an error: %v", err)
+		t.Fatalf("TrackTarget() should not return an error: %v", err)
 	}
 	// test
 	opts := oras.CopyGraphOptions{}
 	ph.UpdateCopyOptions(&opts, memStore)
-	if err := oras.CopyGraph(context.Background(), memStore, gt, memDesc, opts); err != nil {
-		t.Errorf("CopyGraph() should not return an error: %v", err)
+	if err := oras.CopyGraph(context.Background(), memStore, gt, manifestDesc, opts); err != nil {
+		t.Fatalf("CopyGraph() should not return an error: %v", err)
 	}
-	if err := oras.CopyGraph(context.Background(), memStore, gt, memDesc, opts); err != nil {
-		t.Errorf("CopyGraph() should not return an error: %v", err)
+	if err := oras.CopyGraph(context.Background(), memStore, gt, manifestDesc, opts); err != nil {
+		t.Fatalf("CopyGraph() should not return an error: %v", err)
 	}
 	if tracked, ok := gt.(track.GraphTarget); !ok {
-		t.Errorf("TrackTarget() should return a *track.GraphTarget, got %T", tracked)
+		t.Fatalf("TrackTarget() should return a *track.GraphTarget, got %T", tracked)
 	} else {
 		tracked.Close()
 	}
 	// validate
-	if err = testutils.MatchPty(pty, slave, "Exists", memDesc.MediaType, "100.00%", memDesc.Digest.String()); err != nil {
+	if err = testutils.MatchPty(pty, slave, "Exists", manifestDesc.MediaType, "100.00%", manifestDesc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/internal/display/status/tty_test.go
+++ b/cmd/oras/internal/display/status/tty_test.go
@@ -96,6 +96,13 @@ func TestTTYPushHandler_TrackTarget(t *testing.T) {
 	}
 }
 
+func TestTTYPushHandler_TrackTarget_invalidTTY(t *testing.T) {
+	ph := NewTTYPushHandler(os.Stdin)
+	if _, _, err := ph.TrackTarget(nil); err == nil {
+		t.Error("TrackTarget() should return an error for non-tty file")
+	}
+}
+
 func TestTTYPushHandler_UpdateCopyOptions(t *testing.T) {
 	// prepare pty
 	pty, slave, err := testutils.NewPty()

--- a/cmd/oras/internal/display/status/utils.go
+++ b/cmd/oras/internal/display/status/utils.go
@@ -31,8 +31,12 @@ const (
 	PullPromptSkipped     = "Skipped    "
 	PullPromptRestored    = "Restored   "
 	PullPromptDownloaded  = "Downloaded "
-	promptUploaded        = "Uploaded "
-	promptUploading       = "Uploading"
-	promptSkipped         = "Skipped  "
-	promptExists          = "Exists   "
+)
+
+// Prompts for push/attach events.
+const (
+	PushPromptUploaded  = "Uploaded "
+	PushPromptUploading = "Uploading"
+	PushPromptSkipped   = "Skipped  "
+	PushPromptExists    = "Exists   "
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
As a follow up to #1407, this PR aligns the prompts naming for status handlers.
