### PR TITLE
refactor: Move descriptor logic to descriptor

### DIFF
--- a/cmd/oras/internal/output/print.go
+++ b/cmd/oras/internal/output/print.go
@@ -65,13 +65,9 @@ func (p *Printer) PrintVerbose(a ...any) error {
 
 // PrintStatus prints transfer status.
 func (p *Printer) PrintStatus(desc ocispec.Descriptor, status string) error {
-	name, ok := desc.Annotations[ocispec.AnnotationTitle]
-	if !ok {
-		// no status for unnamed content
-		if !p.verbose {
-			return nil
-		}
-		name = desc.MediaType
+	name, isTitle := descriptor.GetTitleOrMediaType(desc)
+	if !isTitle {
+		return p.PrintVerbose(status, descriptor.ShortDigest(desc), name)
 	}
 	return p.Println(status, descriptor.ShortDigest(desc), name)
 }

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -37,3 +37,12 @@ func ShortDigest(desc ocispec.Descriptor) (digestString string) {
 	}
 	return digestString
 }
+
+// GetTitleOrMediaType get a descriptor name using either title or media type
+func GetTitleOrMediaType(desc ocispec.Descriptor) (name string, isTitle bool) {
+	name, ok := desc.Annotations[ocispec.AnnotationTitle]
+	if !ok {
+		return desc.MediaType, false
+	}
+	return name, true
+}

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -38,7 +38,7 @@ func ShortDigest(desc ocispec.Descriptor) (digestString string) {
 	return digestString
 }
 
-// GetTitleOrMediaType get a descriptor name using either title or media type
+// GetTitleOrMediaType gets a descriptor name using either title or media type.
 func GetTitleOrMediaType(desc ocispec.Descriptor) (name string, isTitle bool) {
 	name, ok := desc.Annotations[ocispec.AnnotationTitle]
 	if !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the logic of descriptor title vs media type to the descriptor package.
