### PR TITLE
chore: Ignore e2e test go sum file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ test/e2e/testdata/zot/
 !test/e2e/testdata/zot/command/blobs/**/*
 !test/e2e/testdata/zot/config.json
 !test/e2e/testdata/zot/passwd_bcrypt
+
+test/e2e/go.work.sum


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore the e2e go sum file. Alternate to https://github.com/oras-project/oras/pull/1412
