### PR TITLE
refactor: Move two output functions to the output package

### DIFF
--- a/cmd/oras/internal/display/content/manifest_fetch.go
+++ b/cmd/oras/internal/display/content/manifest_fetch.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras/cmd/oras/internal/display/utils"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // manifestFetch handles raw content output.
@@ -41,7 +41,7 @@ func (h *manifestFetch) OnContentFetched(desc ocispec.Descriptor, manifest []byt
 		defer f.Close()
 		out = f
 	}
-	return utils.PrintJSON(out, manifest, h.pretty)
+	return output.PrintJSON(out, manifest, h.pretty)
 }
 
 // NewManifestFetchHandler creates a new handler.

--- a/cmd/oras/internal/display/metadata/descriptor/manifest_fetch.go
+++ b/cmd/oras/internal/display/metadata/descriptor/manifest_fetch.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"oras.land/oras/cmd/oras/internal/output"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
-	"oras.land/oras/cmd/oras/internal/display/utils"
 )
 
 // manifestFetchHandler handles metadata descriptor output.
@@ -37,7 +37,7 @@ func (h *manifestFetchHandler) OnFetched(_ string, desc ocispec.Descriptor, _ []
 	if err != nil {
 		return fmt.Errorf("invalid descriptor: %w", err)
 	}
-	return utils.PrintJSON(h.out, descBytes, h.pretty)
+	return output.PrintJSON(h.out, descBytes, h.pretty)
 }
 
 // NewManifestFetchHandler creates a new handler.

--- a/cmd/oras/internal/display/metadata/json/attach.go
+++ b/cmd/oras/internal/display/metadata/json/attach.go
@@ -21,8 +21,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
-	"oras.land/oras/cmd/oras/internal/display/utils"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // AttachHandler handles json metadata output for attach events.
@@ -39,5 +39,5 @@ func NewAttachHandler(out io.Writer) metadata.AttachHandler {
 
 // OnCompleted is called when the attach command is completed.
 func (ah *AttachHandler) OnCompleted(opts *option.Target, root, subject ocispec.Descriptor) error {
-	return utils.PrintPrettyJSON(ah.out, model.NewAttach(root, opts.Path))
+	return output.PrintPrettyJSON(ah.out, model.NewAttach(root, opts.Path))
 }

--- a/cmd/oras/internal/display/metadata/json/discover.go
+++ b/cmd/oras/internal/display/metadata/json/discover.go
@@ -23,7 +23,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
-	"oras.land/oras/cmd/oras/internal/display/utils"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // discoverHandler handles json metadata output for discover events.
@@ -59,5 +59,5 @@ func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) err
 
 // OnCompleted implements metadata.DiscoverHandler.
 func (h *discoverHandler) OnCompleted() error {
-	return utils.PrintPrettyJSON(h.out, model.NewDiscover(h.path, h.referrers))
+	return output.PrintPrettyJSON(h.out, model.NewDiscover(h.path, h.referrers))
 }

--- a/cmd/oras/internal/display/metadata/json/manifest_fetch.go
+++ b/cmd/oras/internal/display/metadata/json/manifest_fetch.go
@@ -22,7 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
-	"oras.land/oras/cmd/oras/internal/display/utils"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // manifestFetchHandler handles JSON metadata output for manifest fetch events.
@@ -43,5 +43,5 @@ func (h *manifestFetchHandler) OnFetched(path string, desc ocispec.Descriptor, c
 	if err := json.Unmarshal(content, &manifest); err != nil {
 		manifest = nil
 	}
-	return utils.PrintPrettyJSON(h.out, model.NewFetched(path, desc, manifest))
+	return output.PrintPrettyJSON(h.out, model.NewFetched(path, desc, manifest))
 }

--- a/cmd/oras/internal/display/metadata/json/pull.go
+++ b/cmd/oras/internal/display/metadata/json/pull.go
@@ -21,8 +21,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
-	"oras.land/oras/cmd/oras/internal/display/utils"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // PullHandler handles JSON metadata output for pull events.
@@ -52,5 +52,5 @@ func (ph *PullHandler) OnFilePulled(name string, outputDir string, desc ocispec.
 
 // OnCompleted implements metadata.PullHandler.
 func (ph *PullHandler) OnCompleted(opts *option.Target, desc ocispec.Descriptor) error {
-	return utils.PrintPrettyJSON(ph.out, model.NewPull(ph.path+"@"+desc.Digest.String(), ph.pulled.Files()))
+	return output.PrintPrettyJSON(ph.out, model.NewPull(ph.path+"@"+desc.Digest.String(), ph.pulled.Files()))
 }

--- a/cmd/oras/internal/display/metadata/json/push.go
+++ b/cmd/oras/internal/display/metadata/json/push.go
@@ -21,8 +21,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
-	"oras.land/oras/cmd/oras/internal/display/utils"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/contentutil"
 )
 
@@ -57,5 +57,5 @@ func (ph *PushHandler) OnCopied(opts *option.Target) error {
 
 // OnCompleted is called after the push is completed.
 func (ph *PushHandler) OnCompleted(root ocispec.Descriptor) error {
-	return utils.PrintPrettyJSON(ph.out, model.NewPush(root, ph.path, ph.tagged.Tags()))
+	return output.PrintPrettyJSON(ph.out, model.NewPush(root, ph.path, ph.tagged.Tags()))
 }

--- a/cmd/oras/internal/display/metadata/table/discover.go
+++ b/cmd/oras/internal/display/metadata/table/discover.go
@@ -23,7 +23,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
-	"oras.land/oras/cmd/oras/internal/display/utils"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // discoverHandler handles json metadata output for discover events.
@@ -91,7 +91,7 @@ func (h *discoverHandler) printDiscoveredReferrersTable() error {
 	for _, ref := range h.referrers {
 		print(ref.ArtifactType, ref.Digest)
 		if h.verbose {
-			if err := utils.PrintPrettyJSON(h.out, ref); err != nil {
+			if err := output.PrintPrettyJSON(h.out, ref); err != nil {
 				return fmt.Errorf("error printing JSON: %w", err)
 			}
 		}

--- a/cmd/oras/internal/display/metadata/template/attach.go
+++ b/cmd/oras/internal/display/metadata/template/attach.go
@@ -22,6 +22,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // AttachHandler handles go-template metadata output for attach events.
@@ -40,5 +41,5 @@ func NewAttachHandler(out io.Writer, template string) metadata.AttachHandler {
 
 // OnCompleted formats the metadata of attach command.
 func (ah *AttachHandler) OnCompleted(opts *option.Target, root, subject ocispec.Descriptor) error {
-	return parseAndWrite(ah.out, model.NewAttach(root, opts.Path), ah.template)
+	return output.ParseAndWrite(ah.out, model.NewAttach(root, opts.Path), ah.template)
 }

--- a/cmd/oras/internal/display/metadata/template/discover.go
+++ b/cmd/oras/internal/display/metadata/template/discover.go
@@ -23,6 +23,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // discoverHandler handles json metadata output for discover events.
@@ -60,5 +61,5 @@ func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) err
 
 // OnCompleted implements metadata.DiscoverHandler.
 func (h *discoverHandler) OnCompleted() error {
-	return parseAndWrite(h.out, model.NewDiscover(h.path, h.referrers), h.template)
+	return output.ParseAndWrite(h.out, model.NewDiscover(h.path, h.referrers), h.template)
 }

--- a/cmd/oras/internal/display/metadata/template/manifest_fetch.go
+++ b/cmd/oras/internal/display/metadata/template/manifest_fetch.go
@@ -22,6 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // manifestFetchHandler handles JSON metadata output for manifest fetch events.
@@ -44,5 +45,5 @@ func (h *manifestFetchHandler) OnFetched(path string, desc ocispec.Descriptor, c
 	if err := json.Unmarshal(content, &manifest); err != nil {
 		manifest = nil
 	}
-	return parseAndWrite(h.out, model.NewFetched(path, desc, manifest), h.template)
+	return output.ParseAndWrite(h.out, model.NewFetched(path, desc, manifest), h.template)
 }

--- a/cmd/oras/internal/display/metadata/template/pull.go
+++ b/cmd/oras/internal/display/metadata/template/pull.go
@@ -22,6 +22,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // PullHandler handles text metadata output for pull events.
@@ -34,7 +35,7 @@ type PullHandler struct {
 
 // OnCompleted implements metadata.PullHandler.
 func (ph *PullHandler) OnCompleted(opts *option.Target, desc ocispec.Descriptor) error {
-	return parseAndWrite(ph.out, model.NewPull(ph.path+"@"+desc.Digest.String(), ph.pulled.Files()), ph.template)
+	return output.ParseAndWrite(ph.out, model.NewPull(ph.path+"@"+desc.Digest.String(), ph.pulled.Files()), ph.template)
 }
 
 // OnFilePulled implements metadata.PullHandler.

--- a/cmd/oras/internal/display/metadata/template/push.go
+++ b/cmd/oras/internal/display/metadata/template/push.go
@@ -22,6 +22,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/cmd/oras/internal/display/metadata/model"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/contentutil"
 )
 
@@ -47,7 +48,7 @@ func (ph *PushHandler) OnTagged(desc ocispec.Descriptor, tag string) error {
 	return nil
 }
 
-// OnStarted is called after files are copied.
+// OnCopied is called after files are copied.
 func (ph *PushHandler) OnCopied(opts *option.Target) error {
 	if opts.RawReference != "" && !contentutil.IsDigest(opts.Reference) {
 		ph.tagged.AddTag(opts.Reference)
@@ -58,5 +59,5 @@ func (ph *PushHandler) OnCopied(opts *option.Target) error {
 
 // OnCompleted is called after the push is completed.
 func (ph *PushHandler) OnCompleted(root ocispec.Descriptor) error {
-	return parseAndWrite(ph.out, model.NewPush(root, ph.path, ph.tagged.Tags()), ph.template)
+	return output.ParseAndWrite(ph.out, model.NewPush(root, ph.path, ph.tagged.Tags()), ph.template)
 }

--- a/cmd/oras/internal/option/pretty.go
+++ b/cmd/oras/internal/option/pretty.go
@@ -19,7 +19,7 @@ import (
 	"io"
 
 	"github.com/spf13/pflag"
-	"oras.land/oras/cmd/oras/internal/display/utils"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 // Pretty option struct.
@@ -35,5 +35,5 @@ func (opts *Pretty) ApplyFlags(fs *pflag.FlagSet) {
 // Output outputs the prettified content if `--pretty` flag is used. Otherwise
 // outputs the original content.
 func (opts *Pretty) Output(w io.Writer, content []byte) error {
-	return utils.PrintJSON(w, content, opts.Pretty)
+	return output.PrintJSON(w, content, opts.Pretty)
 }

--- a/cmd/oras/internal/output/json.go
+++ b/cmd/oras/internal/output/json.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package output
 
 import (
 	"bytes"

--- a/cmd/oras/internal/output/template.go
+++ b/cmd/oras/internal/output/template.go
@@ -13,24 +13,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package template
+package output
 
 import (
 	"io"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"oras.land/oras/cmd/oras/internal/display/utils"
 )
 
-func parseAndWrite(out io.Writer, object any, templateStr string) error {
+func ParseAndWrite(out io.Writer, object any, templateStr string) error {
 	// parse template
 	t, err := template.New("format output").Funcs(sprig.FuncMap()).Parse(templateStr)
 	if err != nil {
 		return err
 	}
 	// convert object to map[string]any
-	converted, err := utils.ToMap(object)
+	converted, err := ToMap(object)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/internal/output/template_test.go
+++ b/cmd/oras/internal/output/template_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package template
+package output
 
 import (
 	"os"
@@ -21,7 +21,7 @@ import (
 )
 
 func Test_parseAndWrite_err(t *testing.T) {
-	if err := parseAndWrite(os.Stdout, func() {}, ""); err == nil {
+	if err := ParseAndWrite(os.Stdout, func() {}, ""); err == nil {
 		t.Errorf("should return error")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the json and template output methods to the output package.
