### PR TITLE
build(ci): set codecov CLI version to avoid tokenless upload failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,7 @@ jobs:
         run: bin/linux/amd64/oras version
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           version: 0.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
+          version: 0.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,8 @@ jobs:
         run: bin/linux/amd64/oras version
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          version: 0.6.0
+          version: v0.6.0


### PR DESCRIPTION
Try reset the CLI version since the last success run was based on Codecov CLI v0.6.0 https://github.com/oras-project/oras/actions/runs/9590619238/job/26446251379