### PR TITLE
refactor: assembles printer in the common output option

### DIFF
--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
+	"oras.land/oras/cmd/oras/internal/output"
 )
 
 const NoTTYFlag = "no-tty"
@@ -30,7 +31,7 @@ type Common struct {
 	Debug   bool
 	Verbose bool
 	TTY     *os.File
-
+	*output.Printer
 	noTTY bool
 }
 
@@ -42,7 +43,8 @@ func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
 }
 
 // Parse gets target options from user input.
-func (opts *Common) Parse(*cobra.Command) error {
+func (opts *Common) Parse(cmd *cobra.Command) error {
+	opts.Printer = output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	// use STDERR as TTY output since STDOUT is reserved for pipeable output
 	return opts.parseTTY(os.Stderr)
 }

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -31,7 +31,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/display"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/graph"
 	"oras.land/oras/internal/registryutil"
 )
@@ -110,8 +109,7 @@ Example - Attach file to the manifest tagged 'v1' in an OCI image layout folder 
 
 func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
-	displayStatus, displayMetadata, err := display.NewAttachHandler(printer, opts.Format, opts.TTY)
+	displayStatus, displayMetadata, err := display.NewAttachHandler(opts.Printer, opts.Format, opts.TTY)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/root/blob/delete.go
+++ b/cmd/oras/root/blob/delete.go
@@ -27,7 +27,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/registryutil"
 )
 
@@ -74,7 +73,6 @@ Example - Delete a blob and print its descriptor:
 }
 
 func deleteBlob(cmd *cobra.Command, opts *deleteBlobOptions) (err error) {
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	blobs, err := opts.NewBlobDeleter(opts.Common, logger)
 	if err != nil {
@@ -91,7 +89,7 @@ func deleteBlob(cmd *cobra.Command, opts *deleteBlobOptions) (err error) {
 		if errors.Is(err, errdef.ErrNotFound) {
 			if opts.Force && !opts.OutputDescriptor {
 				// ignore nonexistent
-				_ = printer.Println("Missing", opts.RawReference)
+				_ = opts.Println("Missing", opts.RawReference)
 				return nil
 			}
 			return fmt.Errorf("%s: the specified blob does not exist", opts.RawReference)
@@ -120,7 +118,7 @@ func deleteBlob(cmd *cobra.Command, opts *deleteBlobOptions) (err error) {
 		return opts.Output(os.Stdout, descJSON)
 	}
 
-	_ = printer.Println("Deleted", opts.AnnotatedReference())
+	_ = opts.Println("Deleted", opts.AnnotatedReference())
 
 	return nil
 }

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -110,7 +110,6 @@ Example - Copy an artifact with multiple tags with concurrency tuned:
 
 func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 
 	// Prepare source
 	src, err := opts.From.NewReadonlyTarget(ctx, opts.Common, logger)
@@ -128,7 +127,7 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 	}
 	ctx = registryutil.WithScopeHint(ctx, dst, auth.ActionPull, auth.ActionPush)
 
-	desc, err := doCopy(ctx, printer, src, dst, opts)
+	desc, err := doCopy(ctx, opts.Printer, src, dst, opts)
 	if err != nil {
 		return err
 	}
@@ -137,17 +136,17 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 		// correct source digest
 		opts.From.RawReference = fmt.Sprintf("%s@%s", opts.From.Path, desc.Digest.String())
 	}
-	_ = printer.Println("Copied", opts.From.AnnotatedReference(), "=>", opts.To.AnnotatedReference())
+	_ = opts.Println("Copied", opts.From.AnnotatedReference(), "=>", opts.To.AnnotatedReference())
 
 	if len(opts.extraRefs) != 0 {
 		tagNOpts := oras.DefaultTagNOptions
 		tagNOpts.Concurrency = opts.concurrency
-		if _, err = oras.TagN(ctx, status.NewTagStatusPrinter(printer, dst), opts.To.Reference, opts.extraRefs, tagNOpts); err != nil {
+		if _, err = oras.TagN(ctx, status.NewTagStatusPrinter(opts.Printer, dst), opts.To.Reference, opts.extraRefs, tagNOpts); err != nil {
 			return err
 		}
 	}
 
-	_ = printer.Println("Digest:", desc.Digest)
+	_ = opts.Println("Digest:", desc.Digest)
 
 	return nil
 }

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -29,7 +29,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/credential"
 	orasio "oras.land/oras/internal/io"
 )
@@ -79,14 +78,13 @@ Example - Log in with username and password in an interactive terminal and no TL
 }
 
 func runLogin(cmd *cobra.Command, opts loginOptions) (err error) {
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 
 	// prompt for credential
 	if opts.Secret == "" {
 		if opts.Username == "" {
 			// prompt for username
-			username, err := readLine(printer, "Username: ", false)
+			username, err := readLine(opts.Printer, "Username: ", false)
 			if err != nil {
 				return err
 			}
@@ -94,14 +92,14 @@ func runLogin(cmd *cobra.Command, opts loginOptions) (err error) {
 		}
 		if opts.Username == "" {
 			// prompt for token
-			if opts.Secret, err = readLine(printer, "Token: ", true); err != nil {
+			if opts.Secret, err = readLine(opts.Printer, "Token: ", true); err != nil {
 				return err
 			} else if opts.Secret == "" {
 				return errors.New("token required")
 			}
 		} else {
 			// prompt for password
-			if opts.Secret, err = readLine(printer, "Password: ", true); err != nil {
+			if opts.Secret, err = readLine(opts.Printer, "Password: ", true); err != nil {
 				return err
 			} else if opts.Secret == "" {
 				return errors.New("password required")
@@ -120,7 +118,7 @@ func runLogin(cmd *cobra.Command, opts loginOptions) (err error) {
 	if err = credentials.Login(ctx, store, remote, opts.Credential()); err != nil {
 		return err
 	}
-	_ = printer.Println("Login Succeeded")
+	_ = opts.Println("Login Succeeded")
 	return nil
 }
 

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -27,7 +27,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/registryutil"
 )
 
@@ -78,7 +77,6 @@ Example - Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614
 }
 
 func deleteManifest(cmd *cobra.Command, opts *deleteOptions) error {
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	manifests, err := opts.NewManifestDeleter(opts.Common, logger)
 	if err != nil {
@@ -100,7 +98,7 @@ func deleteManifest(cmd *cobra.Command, opts *deleteOptions) error {
 		if errors.Is(err, errdef.ErrNotFound) {
 			if opts.Force && !opts.OutputDescriptor {
 				// ignore nonexistent
-				_ = printer.Println("Missing", opts.RawReference)
+				_ = opts.Println("Missing", opts.RawReference)
 				return nil
 			}
 			return fmt.Errorf("%s: the specified manifest does not exist", opts.RawReference)
@@ -129,7 +127,7 @@ func deleteManifest(cmd *cobra.Command, opts *deleteOptions) error {
 		return opts.Output(os.Stdout, descJSON)
 	}
 
-	_ = printer.Println("Deleted", opts.AnnotatedReference())
+	_ = opts.Println("Deleted", opts.AnnotatedReference())
 
 	return nil
 }

--- a/cmd/oras/root/pull.go
+++ b/cmd/oras/root/pull.go
@@ -35,7 +35,6 @@ import (
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/fileref"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/descriptor"
 	"oras.land/oras/internal/graph"
 )
@@ -113,8 +112,7 @@ Example - Pull artifact files from an OCI layout archive 'layout.tar':
 
 func runPull(cmd *cobra.Command, opts *pullOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
-	statusHandler, metadataHandler, err := display.NewPullHandler(printer, opts.Format, opts.Path, opts.TTY)
+	statusHandler, metadataHandler, err := display.NewPullHandler(opts.Printer, opts.Format, opts.Path, opts.TTY)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -33,7 +33,6 @@ import (
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/fileref"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/contentutil"
 	"oras.land/oras/internal/listener"
 	"oras.land/oras/internal/registryutil"
@@ -152,8 +151,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 
 func runPush(cmd *cobra.Command, opts *pushOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
-	displayStatus, displayMetadata, err := display.NewPushHandler(printer, opts.Format, opts.TTY)
+	displayStatus, displayMetadata, err := display.NewPushHandler(opts.Printer, opts.Format, opts.TTY)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -25,7 +25,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/repository"
 )
 
@@ -73,7 +72,6 @@ Example - List the repositories under the registry that include values lexically
 }
 
 func listRepository(cmd *cobra.Command, opts *repositoryOptions) error {
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	reg, err := opts.Remote.NewRegistry(opts.hostname, opts.Common, logger)
 	if err != nil {
@@ -82,7 +80,7 @@ func listRepository(cmd *cobra.Command, opts *repositoryOptions) error {
 	err = reg.Repositories(ctx, opts.last, func(repos []string) error {
 		for _, repo := range repos {
 			if subRepo, found := strings.CutPrefix(repo, opts.namespace); found {
-				_ = printer.Println(subRepo)
+				_ = opts.Println(subRepo)
 			}
 		}
 		return nil

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -24,7 +24,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/contentutil"
 )
 
@@ -81,7 +80,6 @@ Example - [Experimental] Show tags associated with a digest:
 }
 
 func showTags(cmd *cobra.Command, opts *showTagsOptions) error {
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	finder, err := opts.NewReadonlyTarget(ctx, opts.Common, logger)
 	if err != nil {
@@ -107,7 +105,7 @@ func showTags(cmd *cobra.Command, opts *showTagsOptions) error {
 			}
 			if filter != "" {
 				if tag == opts.Reference {
-					_ = printer.Println(tag)
+					_ = opts.Println(tag)
 					continue
 				}
 				desc, err := finder.Resolve(ctx, tag)
@@ -118,7 +116,7 @@ func showTags(cmd *cobra.Command, opts *showTagsOptions) error {
 					continue
 				}
 			}
-			_ = printer.Println(tag)
+			_ = opts.Println(tag)
 		}
 		return nil
 	})

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -24,7 +24,6 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/cmd/oras/internal/output"
 )
 
 type resolveOptions struct {
@@ -63,7 +62,6 @@ Example - Resolve digest of the target artifact:
 }
 
 func runResolve(cmd *cobra.Command, opts *resolveOptions) error {
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	repo, err := opts.NewReadonlyTarget(ctx, opts.Common, logger)
 	if err != nil {
@@ -81,9 +79,9 @@ func runResolve(cmd *cobra.Command, opts *resolveOptions) error {
 	}
 
 	if opts.fullRef {
-		_ = printer.Printf("%s@%s\n", opts.Path, desc.Digest)
+		_ = opts.Printf("%s@%s\n", opts.Path, desc.Digest)
 	} else {
-		_ = printer.Println(desc.Digest.String())
+		_ = opts.Println(desc.Digest.String())
 	}
 
 	return nil

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"oras.land/oras/cmd/oras/internal/output"
-
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/errdef"
@@ -100,7 +98,6 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	printer := output.NewPrinter(cmd.OutOrStdout(), opts.Verbose)
 	target, err := opts.NewTarget(opts.Common, logger)
 	if err != nil {
 		return err
@@ -113,7 +110,7 @@ func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 	tagNOpts.Concurrency = opts.concurrency
 	_, err = oras.TagN(
 		ctx,
-		status.NewTagStatusHintPrinter(printer, target, fmt.Sprintf("[%s] %s", opts.Type, opts.Path)),
+		status.NewTagStatusHintPrinter(opts.Printer, target, fmt.Sprintf("[%s] %s", opts.Type, opts.Path)),
 		opts.Reference,
 		opts.targetRefs,
 		tagNOpts,


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of #1426, de-duplicates `printer` initialization during command run(mentioned in https://github.com/oras-project/oras/pull/1426#pullrequestreview-2133693570)