### PR TITLE
build(ci): unset codecov CLI version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,3 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
-          version: v0.6.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Use latest Codecov CLI as the tokenless upload issue is fixed in [v0.7.1](https://github.com/codecov/codecov-cli/releases/tag/v0.7.1), resolves #1423.
