### PR TITLE
fix: disable oras tag fallback to tag schema when tagging a referrer

### DIFF
--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -104,8 +104,8 @@ func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 		return err
 	}
 	if targetRepo, ok := target.(*remote.Repository); ok {
-		// Since referrer capability has not be set or detected yet, nil
-		// is the only returned value and thus can be ignored
+		// Since referrer capability has not been set or detected yet,
+		// nil is the only returned value and thus can be ignored
 		_ = targetRepo.SetReferrersCapability(true)
 	}
 	if err := opts.EnsureReferenceNotEmpty(cmd, true); err != nil {

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -58,6 +58,10 @@ Example - Tag the manifest 'v1.0.1' in 'localhost:5000/hello' to 'v1.0.1', 'v1.0
 
 Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'layout-dir':
   oras tag --oci-layout layout-dir:v1.0.1 v1.0.2
+
+Example - Tag the referrers with digest sha256:9463e0d192846bc994279417b50114606712d516aab45f4d8b31cbc6e46aad71 to 'v1.0.2' using specific methods for the Referrers API:
+  oras tag --distribution-spec v1.1-referrers-api localhost:5000/hello@sha256:9463e0d192846bc994279417b50114606712d516aab45f4d8b31cbc6e46aad71 v1.0.2
+  oras tag --distribution-spec v1.1-referrers-tag localhost:5000/hello@sha256:9463e0d192846bc994279417b50114606712d516aab45f4d8b31cbc6e46aad71 v1.0.2
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && (args[0] == "list" || args[0] == "ls") {
@@ -91,6 +95,7 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 		},
 	}
 
+	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/command"
 	"oras.land/oras/cmd/oras/internal/display/status"
@@ -58,10 +59,6 @@ Example - Tag the manifest 'v1.0.1' in 'localhost:5000/hello' to 'v1.0.1', 'v1.0
 
 Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'layout-dir':
   oras tag --oci-layout layout-dir:v1.0.1 v1.0.2
-
-Example - Tag the referrers with digest sha256:9463e0d192846bc994279417b50114606712d516aab45f4d8b31cbc6e46aad71 to 'v1.0.2' using specific methods for the Referrers API:
-  oras tag --distribution-spec v1.1-referrers-api localhost:5000/hello@sha256:9463e0d192846bc994279417b50114606712d516aab45f4d8b31cbc6e46aad71 v1.0.2
-  oras tag --distribution-spec v1.1-referrers-tag localhost:5000/hello@sha256:9463e0d192846bc994279417b50114606712d516aab45f4d8b31cbc6e46aad71 v1.0.2
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && (args[0] == "list" || args[0] == "ls") {
@@ -95,7 +92,6 @@ Example - Tag the referrers with digest sha256:9463e0d192846bc994279417b50114606
 		},
 	}
 
-	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
 	return oerrors.Command(cmd, &opts.Target)
@@ -104,6 +100,12 @@ Example - Tag the referrers with digest sha256:9463e0d192846bc994279417b50114606
 func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	target, err := opts.NewTarget(opts.Common, logger)
+	if targetRepo, ok := target.(*remote.Repository); ok {
+		err := targetRepo.SetReferrersCapability(true)
+		if err != nil {
+			return err
+		}
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -104,10 +104,9 @@ func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 		return err
 	}
 	if targetRepo, ok := target.(*remote.Repository); ok {
-		err := targetRepo.SetReferrersCapability(true)
-		if err != nil {
-			return err
-		}
+		// Since referrer capability has not be set or detected yet, nil
+		// is the only returned value and thus can be ignored
+		_ = targetRepo.SetReferrersCapability(true)
 	}
 	if err := opts.EnsureReferenceNotEmpty(cmd, true); err != nil {
 		return err

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -96,7 +96,7 @@ var _ = Describe("1.1 registry users:", func() {
 
 var _ = Describe("1.0 registry users:", func() {
 	When("running `tag`", func() {
-		It("should tag a referrer witout tag schema", func() {
+		It("should tag a referrer witout tag schema", Focus, func() {
 			// prepare: generate a referrer manifest and push it to the fallback registry
 			root := GinkgoT().TempDir()
 			pushedDigestBytes := ORAS("push", Flags.Layout, root, "--format", "go-template={{.digest}}").
@@ -117,7 +117,7 @@ var _ = Describe("1.0 registry users:", func() {
 			// test
 			tagAndValidate(FallbackHost, repo, attachedDigest, attachedDigest, "tagged-referrer")
 			// ensure no referrer index is created
-			indexReferrerTag := RegistryRef(FallbackHost, ArtifactRepo, strings.Replace(pushedDigest, ":", "-", 1))
+			indexReferrerTag := RegistryRef(FallbackHost, repo, strings.Replace(pushedDigest, ":", "-", 1))
 			ORAS("manifest", "fetch", indexReferrerTag).
 				MatchErrKeyWords(fmt.Sprintf("%s: not found", indexReferrerTag)).
 				ExpectFailure().

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"oras.land/oras/test/e2e/internal/testdata/foobar"
 	"oras.land/oras/test/e2e/internal/testdata/multi_arch"
 	. "oras.land/oras/test/e2e/internal/utils"
 )
@@ -56,14 +58,16 @@ var _ = Describe("ORAS beginners:", func() {
 	})
 })
 
+func tagAndValidate(reg string, repo string, tagOrDigest string, digestText string, tags ...string) {
+	out := ORAS(append([]string{"tag", RegistryRef(reg, repo, tagOrDigest)}, tags...)...).MatchKeyWords(tags...).Exec().Out
+	hint := regexp.QuoteMeta(fmt.Sprintf("Tagging [registry] %s", RegistryRef(reg, repo, digestText)))
+	gomega.Expect(out).To(gbytes.Say(hint))
+	gomega.Expect(out).NotTo(gbytes.Say(hint)) // should only say hint once
+	ORAS("repo", "tags", RegistryRef(reg, repo, "")).MatchKeyWords(tags...).Exec()
+}
+
 var _ = Describe("1.1 registry users:", func() {
-	var tagAndValidate = func(reg string, repo string, tagOrDigest string, digest string, tags ...string) {
-		out := ORAS(append([]string{"tag", RegistryRef(reg, repo, tagOrDigest)}, tags...)...).MatchKeyWords(tags...).Exec().Out
-		hint := regexp.QuoteMeta(fmt.Sprintf("Tagging [registry] %s", RegistryRef(reg, repo, digest)))
-		gomega.Expect(out).To(gbytes.Say(hint))
-		gomega.Expect(out).NotTo(gbytes.Say(hint)) // should only say hint once
-		ORAS("repo", "tags", RegistryRef(reg, repo, "")).MatchKeyWords(tags...).Exec()
-	}
+
 	When("running `tag`", func() {
 		It("should add a tag to an existent manifest when providing tag reference", func() {
 			tagAndValidate(ZOTHost, ImageRepo, multi_arch.Tag, multi_arch.Digest, "tag-via-tag")
@@ -76,6 +80,48 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 		It("should add multiple tags to an existent manifest when providing tag reference", func() {
 			tagAndValidate(ZOTHost, ImageRepo, multi_arch.Tag, multi_arch.Digest, "tag1-via-tag", "tag1-via-tag", "tag1-via-tag")
+		})
+		It("should a referrer witout adding referrer index", func() {
+			referrerDigest := foobar.SBOMImageReferrer.Digest.String()
+			tagAndValidate(ZOTHost, ArtifactRepo, referrerDigest, referrerDigest, "tagged-referrer")
+			// ensure no referrer index is created
+			ref := RegistryRef(ZOTHost, ArtifactRepo, strings.Replace(foobar.Digest, ":", "-", 1))
+			ORAS("manifest", "fetch", ref).
+				MatchErrKeyWords(fmt.Sprintf("%s: not found", ref)).
+				ExpectFailure().
+				Exec()
+		})
+	})
+})
+
+var _ = Describe("1.0 registry users:", func() {
+	When("running `tag`", func() {
+		It("should a referrer witout adding referrer index", func() {
+			// prepare: generate a referrer manifest and push it to the fallback registry
+			root := GinkgoT().TempDir()
+			pushedDigestBytes := ORAS("push", Flags.Layout, root, "--format", "go-template={{.digest}}").
+				Exec().
+				Out.
+				Contents()
+			pushedDigest := string(pushedDigestBytes)
+			manifestPath := filepath.Join(root, "manifest.json")
+			attachedDigestBytes := ORAS("attach", "--artifact-type", "oras/e2e", Flags.Layout, LayoutRef(root, pushedDigest), "-a", "a=b", "--export-manifest", manifestPath, "--format", "go-template={{.digest}}").
+				Exec().
+				Out.
+				Contents()
+			attachedDigest := string(attachedDigestBytes)
+			repo := fmt.Sprintf("command/tag/%d/referrers", GinkgoRandomSeed())
+			attachedRef := RegistryRef(FallbackHost, repo, attachedDigest)
+			ORAS("push", RegistryRef(FallbackHost, repo, ""), "--artifact-type", "oras/e2e").Exec()
+			ORAS("manifest", "push", attachedRef, manifestPath).Exec()
+			// test
+			tagAndValidate(FallbackHost, repo, attachedDigest, attachedDigest, "tagged-referrer")
+			// ensure no referrer index is created
+			indexReferrerTag := RegistryRef(FallbackHost, ArtifactRepo, strings.Replace(pushedDigest, ":", "-", 1))
+			ORAS("manifest", "fetch", indexReferrerTag).
+				MatchErrKeyWords(fmt.Sprintf("%s: not found", indexReferrerTag)).
+				ExpectFailure().
+				Exec()
 		})
 	})
 })

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -81,7 +81,7 @@ var _ = Describe("1.1 registry users:", func() {
 		It("should add multiple tags to an existent manifest when providing tag reference", func() {
 			tagAndValidate(ZOTHost, ImageRepo, multi_arch.Tag, multi_arch.Digest, "tag1-via-tag", "tag1-via-tag", "tag1-via-tag")
 		})
-		It("should a referrer witout adding referrer index", func() {
+		It("should tag a referrer witout tag schema", func() {
 			referrerDigest := foobar.SBOMImageReferrer.Digest.String()
 			tagAndValidate(ZOTHost, ArtifactRepo, referrerDigest, referrerDigest, "tagged-referrer")
 			// ensure no referrer index is created
@@ -96,7 +96,7 @@ var _ = Describe("1.1 registry users:", func() {
 
 var _ = Describe("1.0 registry users:", func() {
 	When("running `tag`", func() {
-		It("should a referrer witout adding referrer index", func() {
+		It("should tag a referrer witout tag schema", func() {
 			// prepare: generate a referrer manifest and push it to the fallback registry
 			root := GinkgoT().TempDir()
 			pushedDigestBytes := ORAS("push", Flags.Layout, root, "--format", "go-template={{.digest}}").

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -67,7 +67,6 @@ func tagAndValidate(reg string, repo string, tagOrDigest string, digestText stri
 }
 
 var _ = Describe("1.1 registry users:", func() {
-
 	When("running `tag`", func() {
 		It("should add a tag to an existent manifest when providing tag reference", func() {
 			tagAndValidate(ZOTHost, ImageRepo, multi_arch.Tag, multi_arch.Digest, "tag-via-tag")
@@ -82,10 +81,14 @@ var _ = Describe("1.1 registry users:", func() {
 			tagAndValidate(ZOTHost, ImageRepo, multi_arch.Tag, multi_arch.Digest, "tag1-via-tag", "tag1-via-tag", "tag1-via-tag")
 		})
 		It("should tag a referrer witout tag schema", func() {
+			// parepare:
+			repo := fmt.Sprintf("command/tag/%d/referrers", GinkgoRandomSeed())
+			ORAS("cp", "-r", RegistryRef(ZOTHost, ArtifactRepo, foobar.Tag), "--to-distribution-spec", "v1.1-referrers-api", RegistryRef(ZOTHost, repo, foobar.Tag)).Exec()
+			// test
 			referrerDigest := foobar.SBOMImageReferrer.Digest.String()
-			tagAndValidate(ZOTHost, ArtifactRepo, referrerDigest, referrerDigest, "tagged-referrer")
+			tagAndValidate(ZOTHost, repo, referrerDigest, referrerDigest, "tagged-referrer")
 			// ensure no referrer index is created
-			ref := RegistryRef(ZOTHost, ArtifactRepo, strings.Replace(foobar.Digest, ":", "-", 1))
+			ref := RegistryRef(ZOTHost, repo, strings.Replace(foobar.Digest, ":", "-", 1))
 			ORAS("manifest", "fetch", ref).
 				MatchErrKeyWords(fmt.Sprintf("%s: not found", ref)).
 				ExpectFailure().
@@ -97,7 +100,7 @@ var _ = Describe("1.1 registry users:", func() {
 var _ = Describe("1.0 registry users:", func() {
 	When("running `tag`", func() {
 		It("should tag a referrer witout tag schema", func() {
-			// prepare: generate a referrer manifest and push it to the fallback registry
+			// prepare: copy to the fallback registry
 			repo := fmt.Sprintf("command/tag/%d/referrers", GinkgoRandomSeed())
 			ORAS("cp", "-r", RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), "--to-distribution-spec", "v1.1-referrers-api", RegistryRef(FallbackHost, repo, foobar.Tag)).Exec()
 			// test


### PR DESCRIPTION
**What this PR does / why we need it**:
- disable oras tag fallback to tag schema when tagging a referrer

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

