### PR TITLE
refactor: add display handler for `cp`, `tag` and `manifest push`

### DIFF
--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -16,7 +16,6 @@ limitations under the License.
 package display
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -166,7 +165,7 @@ func NewManifestFetchHandler(out io.Writer, format option.Format, outputDescript
 
 // NewTagHandler returns a tag handler.
 func NewTagHandler(printer *output.Printer, target option.Target) metadata.TagHandler {
-	return text.NewTagHandler(printer, fmt.Sprintf("[%s] %s", target.Type, target.Path))
+	return text.NewTagHandler(printer, target)
 }
 
 // NewManifestPushHandler returns a manifest push handler.

--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -174,7 +174,7 @@ func NewManifestPushHandler(printer *output.Printer) metadata.ManifestPushHandle
 	return text.NewManifestPushHandler(printer)
 }
 
-// NewCopyHandler returns a manifest push handler.
+// NewCopyHandler returns a copy handler.
 func NewCopyHandler(printer *output.Printer) metadata.CopyHandler {
 	return text.NewCopyHandler(printer)
 }

--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -16,6 +16,7 @@ limitations under the License.
 package display
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -161,4 +162,19 @@ func NewManifestFetchHandler(out io.Writer, format option.Format, outputDescript
 		contentHandler = content.NewManifestFetchHandler(out, pretty, outputPath)
 	}
 	return metadataHandler, contentHandler, nil
+}
+
+// NewTagHandler returns a tag handler.
+func NewTagHandler(printer *output.Printer, target option.Target) metadata.TagHandler {
+	return text.NewTagHandler(printer, fmt.Sprintf("[%s] %s", target.Type, target.Path))
+}
+
+// NewManifestPushHandler returns a manifest push handler.
+func NewManifestPushHandler(printer *output.Printer) metadata.ManifestPushHandler {
+	return text.NewManifestPushHandler(printer)
+}
+
+// NewCopyHandler returns a manifest push handler.
+func NewCopyHandler(printer *output.Printer) metadata.CopyHandler {
+	return text.NewCopyHandler(printer)
 }

--- a/cmd/oras/internal/display/metadata/interface.go
+++ b/cmd/oras/internal/display/metadata/interface.go
@@ -72,3 +72,13 @@ type TagHandler interface {
 	OnTagging(desc ocispec.Descriptor, tag string) error
 	TaggedHandler
 }
+
+// ManifestPushHandler handles metadata output for manifest push events.
+type ManifestPushHandler interface {
+	TaggedHandler
+}
+
+// CopyHandler handles metadata output for cp events.
+type CopyHandler interface {
+	TaggedHandler
+}

--- a/cmd/oras/internal/display/metadata/text/copy.go
+++ b/cmd/oras/internal/display/metadata/text/copy.go
@@ -16,44 +16,24 @@ limitations under the License.
 package text
 
 import (
-	"sync"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
-	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/cmd/oras/internal/output"
 )
 
-// PushHandler handles text metadata output for push events.
-type PushHandler struct {
+// CopyHandler handles text metadata output for cp events.
+type CopyHandler struct {
 	printer *output.Printer
-	tagLock sync.Mutex
 }
 
-// NewPushHandler returns a new handler for push events.
-func NewPushHandler(printer *output.Printer) metadata.PushHandler {
-	return &PushHandler{
+// NewCopyHandler returns a new handler for cp events.
+func NewCopyHandler(printer *output.Printer) metadata.CopyHandler {
+	return &CopyHandler{
 		printer: printer,
 	}
 }
 
 // OnTagged implements metadata.TaggedHandler.
-func (h *PushHandler) OnTagged(_ ocispec.Descriptor, tag string) error {
-	h.tagLock.Lock()
-	defer h.tagLock.Unlock()
+func (h *CopyHandler) OnTagged(_ ocispec.Descriptor, tag string) error {
 	return h.printer.Println("Tagged", tag)
-}
-
-// OnCopied is called after files are copied.
-func (h *PushHandler) OnCopied(opts *option.Target) error {
-	return h.printer.Println("Pushed", opts.AnnotatedReference())
-}
-
-// OnCompleted is called after the push is completed.
-func (h *PushHandler) OnCompleted(root ocispec.Descriptor) error {
-	err := h.printer.Println("ArtifactType:", root.ArtifactType)
-	if err != nil {
-		return err
-	}
-	return h.printer.Println("Digest:", root.Digest)
 }

--- a/cmd/oras/internal/display/metadata/text/manifest_push.go
+++ b/cmd/oras/internal/display/metadata/text/manifest_push.go
@@ -16,44 +16,24 @@ limitations under the License.
 package text
 
 import (
-	"sync"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
-	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/cmd/oras/internal/output"
 )
 
-// PushHandler handles text metadata output for push events.
-type PushHandler struct {
+// ManifestPushHandler handles text metadata output for manifest push events.
+type ManifestPushHandler struct {
 	printer *output.Printer
-	tagLock sync.Mutex
 }
 
-// NewPushHandler returns a new handler for push events.
-func NewPushHandler(printer *output.Printer) metadata.PushHandler {
-	return &PushHandler{
+// NewManifestPushHandler returns a new handler for manifest push events.
+func NewManifestPushHandler(printer *output.Printer) metadata.ManifestPushHandler {
+	return &ManifestPushHandler{
 		printer: printer,
 	}
 }
 
 // OnTagged implements metadata.TaggedHandler.
-func (h *PushHandler) OnTagged(_ ocispec.Descriptor, tag string) error {
-	h.tagLock.Lock()
-	defer h.tagLock.Unlock()
+func (h *ManifestPushHandler) OnTagged(_ ocispec.Descriptor, tag string) error {
 	return h.printer.Println("Tagged", tag)
-}
-
-// OnCopied is called after files are copied.
-func (h *PushHandler) OnCopied(opts *option.Target) error {
-	return h.printer.Println("Pushed", opts.AnnotatedReference())
-}
-
-// OnCompleted is called after the push is completed.
-func (h *PushHandler) OnCompleted(root ocispec.Descriptor) error {
-	err := h.printer.Println("ArtifactType:", root.ArtifactType)
-	if err != nil {
-		return err
-	}
-	return h.printer.Println("Digest:", root.Digest)
 }

--- a/cmd/oras/internal/display/metadata/text/tag.go
+++ b/cmd/oras/internal/display/metadata/text/tag.go
@@ -16,10 +16,13 @@ limitations under the License.
 package text
 
 import (
+	"fmt"
+	"sync"
+
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
+	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/cmd/oras/internal/output"
-	"sync"
 )
 
 // TagHandler handles text metadata output for tag events.
@@ -30,10 +33,10 @@ type TagHandler struct {
 }
 
 // NewTagHandler returns a new handler for tag events.
-func NewTagHandler(printer *output.Printer, refPrefix string) metadata.TagHandler {
+func NewTagHandler(printer *output.Printer, target option.Target) metadata.TagHandler {
 	return &TagHandler{
 		printer:   printer,
-		refPrefix: refPrefix,
+		refPrefix: fmt.Sprintf("[%s] %s", target.Type, target.Path),
 	}
 }
 

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -33,7 +33,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/command"
-	"oras.land/oras/cmd/oras/internal/display/metadata/text"
+	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/cmd/oras/internal/display/status/track"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -142,8 +142,8 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 	if len(opts.extraRefs) != 0 {
 		tagNOpts := oras.DefaultTagNOptions
 		tagNOpts.Concurrency = opts.concurrency
-		tagHandler := text.NewTagHandler(opts.Printer, "")
-		tagListener := listener.NewTagListener(dst, nil, tagHandler.OnTagged)
+		handler := display.NewCopyHandler(opts.Printer)
+		tagListener := listener.NewTaggedListener(dst, handler.OnTagged)
 		if _, err = oras.TagN(ctx, tagListener, opts.To.Reference, opts.extraRefs, tagNOpts); err != nil {
 			return err
 		}

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -30,7 +30,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/command"
-	"oras.land/oras/cmd/oras/internal/display/metadata/text"
+	"oras.land/oras/cmd/oras/internal/display"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/manifest"
 	"oras.land/oras/cmd/oras/internal/option"
@@ -190,8 +190,8 @@ func pushManifest(cmd *cobra.Command, opts pushOptions) error {
 	}
 	_ = opts.Println("Pushed", opts.AnnotatedReference())
 	if len(opts.extraRefs) != 0 {
-		tagHandler := text.NewTagHandler(opts.Printer, "")
-		tagListener := listener.NewTagListener(target, nil, tagHandler.OnTagged)
+		handler := display.NewManifestPushHandler(opts.Printer)
+		tagListener := listener.NewTaggedListener(target, handler.OnTagged)
 		if _, err = oras.TagBytesN(ctx, tagListener, mediaType, contentBytes, opts.extraRefs, tagBytesNOpts); err != nil {
 			return err
 		}

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -18,7 +18,8 @@ package root
 import (
 	"errors"
 	"fmt"
-	"oras.land/oras/cmd/oras/internal/display/metadata/text"
+
+	"oras.land/oras/cmd/oras/internal/display"
 	"oras.land/oras/internal/listener"
 
 	"github.com/spf13/cobra"
@@ -115,7 +116,7 @@ func tagManifest(cmd *cobra.Command, opts *tagOptions) error {
 
 	tagNOpts := oras.DefaultTagNOptions
 	tagNOpts.Concurrency = opts.concurrency
-	tagHandler := text.NewTagHandler(opts.Printer, fmt.Sprintf("[%s] %s", opts.Type, opts.Path))
+	tagHandler := display.NewTagHandler(opts.Printer, opts.Target)
 	tagListener := listener.NewTagListener(target, tagHandler.OnTagging, tagHandler.OnTagged)
 	_, err = oras.TagN(
 		ctx,

--- a/internal/listener/tag.go
+++ b/internal/listener/tag.go
@@ -41,6 +41,12 @@ func NewTagListener(target oras.Target, onTagging, onTagged func(desc ocispec.De
 	}
 }
 
+// NewTaggedListener creates a wrapper type for printing all tagged statuses.
+// It can only be used for oras.TagBytes and oras.TagBytesN.
+func NewTaggedListener(target oras.Target, onTagged func(desc ocispec.Descriptor, tag string) error) oras.Target {
+	return NewTagListener(target, nil, onTagged)
+}
+
 type tagListenerForRepository struct {
 	registry.Repository
 	onTagging func(desc ocispec.Descriptor, tag string) error


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR unifies display handler usage by adding dedicated handlers to relevant commands, as a follow-up of #1438. 
