### PR TITLE
refactor: Create text copy handler

### DIFF
--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	fetcher "oras.land/oras-go/v2/content"
 
 	"oras.land/oras/cmd/oras/internal/display/content"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
@@ -173,7 +174,7 @@ func NewManifestPushHandler(printer *output.Printer) metadata.ManifestPushHandle
 	return text.NewManifestPushHandler(printer)
 }
 
-// NewCopyHandler returns a copy handler.
-func NewCopyHandler(printer *output.Printer) metadata.CopyHandler {
-	return text.NewCopyHandler(printer)
+// NewCopyHandler returns copy handlers.
+func NewCopyHandler(printer *output.Printer, fetcher fetcher.Fetcher) (status.CopyHandler, metadata.CopyHandler) {
+	return status.NewTextCopyHandler(printer, fetcher), text.NewCopyHandler(printer)
 }

--- a/cmd/oras/internal/display/status/interface.go
+++ b/cmd/oras/internal/display/status/interface.go
@@ -16,6 +16,7 @@ limitations under the License.
 package status
 
 import (
+	"context"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
@@ -50,4 +51,12 @@ type PullHandler interface {
 	OnNodeRestored(desc ocispec.Descriptor) error
 	// OnNodeSkipped is called when a node is skipped.
 	OnNodeSkipped(desc ocispec.Descriptor) error
+}
+
+// CopyHandler handles status output for cp command.
+type CopyHandler interface {
+	OnCopySkipped(ctx context.Context, desc ocispec.Descriptor) error
+	PreCopy(ctx context.Context, desc ocispec.Descriptor) error
+	PostCopy(ctx context.Context, desc ocispec.Descriptor) error
+	OnMounted(ctx context.Context, desc ocispec.Descriptor) error
 }

--- a/cmd/oras/internal/display/status/utils.go
+++ b/cmd/oras/internal/display/status/utils.go
@@ -32,3 +32,12 @@ const (
 	PushPromptSkipped   = "Skipped  "
 	PushPromptExists    = "Exists   "
 )
+
+// Prompts for cp events.
+const (
+	copyPromptExists  = "Exists "
+	copyPromptCopying = "Copying"
+	copyPromptCopied  = "Copied "
+	copyPromptSkipped = "Skipped"
+	copyPromptMounted = "Mounted"
+)

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oras.land/oras/cmd/oras/internal/display/status"
 	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"strings"
@@ -133,8 +134,9 @@ func Test_doCopy(t *testing.T) {
 	dst := memory.New()
 	builder := &strings.Builder{}
 	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	handler := status.NewTextCopyHandler(printer, dst)
 	// test
-	_, err = doCopy(context.Background(), printer, memStore, dst, &opts)
+	_, err = doCopy(context.Background(), handler, memStore, dst, &opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,8 +159,10 @@ func Test_doCopy_skipped(t *testing.T) {
 	opts.From.Reference = memDesc.Digest.String()
 	builder := &strings.Builder{}
 	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	handler := status.NewTextCopyHandler(printer, memStore)
+
 	// test
-	_, err = doCopy(context.Background(), printer, memStore, memStore, &opts)
+	_, err = doCopy(context.Background(), handler, memStore, memStore, &opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,8 +196,10 @@ func Test_doCopy_mounted(t *testing.T) {
 	to.PlainHTTP = true
 	builder := &strings.Builder{}
 	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	handler := status.NewTextCopyHandler(printer, to)
+
 	// test
-	_, err = doCopy(context.Background(), printer, from, to, &opts)
+	_, err = doCopy(context.Background(), handler, from, to, &opts)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a baby step to creating copy handlers for the cp command
