### PR TITLE
refactor: Successor getting with separation of concerns

### DIFF
--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -37,12 +37,12 @@ import (
 )
 
 // NewPushHandler returns status and metadata handlers for push command.
-func NewPushHandler(printer *output.Printer, format option.Format, tty *os.File) (status.PushHandler, metadata.PushHandler, error) {
+func NewPushHandler(printer *output.Printer, format option.Format, tty *os.File, fetcher fetcher.Fetcher) (status.PushHandler, metadata.PushHandler, error) {
 	var statusHandler status.PushHandler
 	if tty != nil {
-		statusHandler = status.NewTTYPushHandler(tty)
+		statusHandler = status.NewTTYPushHandler(tty, fetcher)
 	} else if format.Type == option.FormatTypeText.Name {
-		statusHandler = status.NewTextPushHandler(printer)
+		statusHandler = status.NewTextPushHandler(printer, fetcher)
 	} else {
 		statusHandler = status.NewDiscardHandler()
 	}
@@ -62,12 +62,12 @@ func NewPushHandler(printer *output.Printer, format option.Format, tty *os.File)
 }
 
 // NewAttachHandler returns status and metadata handlers for attach command.
-func NewAttachHandler(printer *output.Printer, format option.Format, tty *os.File) (status.AttachHandler, metadata.AttachHandler, error) {
+func NewAttachHandler(printer *output.Printer, format option.Format, tty *os.File, fetcher fetcher.Fetcher) (status.AttachHandler, metadata.AttachHandler, error) {
 	var statusHandler status.AttachHandler
 	if tty != nil {
-		statusHandler = status.NewTTYAttachHandler(tty)
+		statusHandler = status.NewTTYAttachHandler(tty, fetcher)
 	} else if format.Type == option.FormatTypeText.Name {
-		statusHandler = status.NewTextAttachHandler(printer)
+		statusHandler = status.NewTextAttachHandler(printer, fetcher)
 	} else {
 		statusHandler = status.NewDiscardHandler()
 	}

--- a/cmd/oras/internal/display/handler_test.go
+++ b/cmd/oras/internal/display/handler_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package display
 
 import (
+	"oras.land/oras/internal/testutils"
 	"os"
 	"testing"
 
@@ -24,16 +25,18 @@ import (
 )
 
 func TestNewPushHandler(t *testing.T) {
+	mockFetcher := testutils.NewMockFetcher()
 	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
-	_, _, err := NewPushHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout)
+	_, _, err := NewPushHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout, mockFetcher.Fetcher)
 	if err != nil {
 		t.Errorf("NewPushHandler() error = %v, want nil", err)
 	}
 }
 
 func TestNewAttachHandler(t *testing.T) {
+	mockFetcher := testutils.NewMockFetcher()
 	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
-	_, _, err := NewAttachHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout)
+	_, _, err := NewAttachHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout, mockFetcher.Fetcher)
 	if err != nil {
 		t.Errorf("NewAttachHandler() error = %v, want nil", err)
 	}

--- a/cmd/oras/internal/display/status/discard.go
+++ b/cmd/oras/internal/display/status/discard.go
@@ -16,9 +16,10 @@ limitations under the License.
 package status
 
 import (
+	"context"
+
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content"
 )
 
 func discardStopTrack() error {
@@ -48,8 +49,20 @@ func (DiscardHandler) TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, StopTr
 	return gt, discardStopTrack, nil
 }
 
-// UpdateCopyOptions updates the copy options for the artifact push.
-func (DiscardHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetcher content.Fetcher) {}
+// OnCopySkipped is called when an object already exists.
+func (DiscardHandler) OnCopySkipped(_ context.Context, _ ocispec.Descriptor) error {
+	return nil
+}
+
+// PreCopy implements PreCopy of CopyHandler.
+func (DiscardHandler) PreCopy(_ context.Context, _ ocispec.Descriptor) error {
+	return nil
+}
+
+// PostCopy implements PostCopy of CopyHandler.
+func (DiscardHandler) PostCopy(_ context.Context, _ ocispec.Descriptor) error {
+	return nil
+}
 
 // OnNodeDownloading implements PullHandler.
 func (DiscardHandler) OnNodeDownloading(desc ocispec.Descriptor) error {

--- a/cmd/oras/internal/display/status/interface.go
+++ b/cmd/oras/internal/display/status/interface.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content"
 )
 
 // StopTrackTargetFunc is the function type to stop tracking a target.
@@ -30,7 +29,9 @@ type PushHandler interface {
 	OnFileLoading(name string) error
 	OnEmptyArtifact() error
 	TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, StopTrackTargetFunc, error)
-	UpdateCopyOptions(opts *oras.CopyGraphOptions, fetcher content.Fetcher)
+	OnCopySkipped(ctx context.Context, desc ocispec.Descriptor) error
+	PreCopy(ctx context.Context, desc ocispec.Descriptor) error
+	PostCopy(ctx context.Context, desc ocispec.Descriptor) error
 }
 
 // AttachHandler handles text status output for attach command.

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -28,14 +28,19 @@ import (
 
 // TextPushHandler handles text status output for push events.
 type TextPushHandler struct {
-	printer *output.Printer
+	printer   *output.Printer
+	committed *sync.Map
+	fetcher   content.Fetcher
 }
 
 // NewTextPushHandler returns a new handler for push command.
-func NewTextPushHandler(printer *output.Printer) PushHandler {
-	return &TextPushHandler{
-		printer: printer,
+func NewTextPushHandler(printer *output.Printer, fetcher content.Fetcher) PushHandler {
+	tch := TextPushHandler{
+		printer:   printer,
+		fetcher:   fetcher,
+		committed: &sync.Map{},
 	}
+	return &tch
 }
 
 // OnFileLoading is called when a file is being prepared for upload.
@@ -53,34 +58,35 @@ func (ph *TextPushHandler) TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, S
 	return gt, discardStopTrack, nil
 }
 
-// UpdateCopyOptions adds status update to the copy options.
-func (ph *TextPushHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetcher content.Fetcher) {
-	committed := &sync.Map{}
-	opts.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
-		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		return ph.printer.PrintStatus(desc, PushPromptExists)
+// OnCopySkipped is called when an object already exists.
+func (ph *TextPushHandler) OnCopySkipped(_ context.Context, desc ocispec.Descriptor) error {
+	ph.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	return ph.printer.PrintStatus(desc, PushPromptExists)
+}
+
+// PreCopy implements PreCopy of CopyHandler.
+func (ph *TextPushHandler) PreCopy(_ context.Context, desc ocispec.Descriptor) error {
+	return ph.printer.PrintStatus(desc, PushPromptUploading)
+}
+
+// PostCopy implements PostCopy of CopyHandler.
+func (ph *TextPushHandler) PostCopy(ctx context.Context, desc ocispec.Descriptor) error {
+	ph.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	successors, err := graph.FilteredSuccessors(ctx, desc, ph.fetcher, DeduplicatedFilter(ph.committed))
+	if err != nil {
+		return err
 	}
-	opts.PreCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
-		return ph.printer.PrintStatus(desc, PushPromptUploading)
-	}
-	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
-		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		successors, err := graph.FilteredSuccessors(ctx, desc, fetcher, DeduplicatedFilter(committed))
-		if err != nil {
+	for _, successor := range successors {
+		if err = ph.printer.PrintStatus(successor, PushPromptExists); err != nil {
 			return err
 		}
-		for _, successor := range successors {
-			if err = ph.printer.PrintStatus(successor, PushPromptSkipped); err != nil {
-				return err
-			}
-		}
-		return ph.printer.PrintStatus(desc, PushPromptUploaded)
 	}
+	return ph.printer.PrintStatus(desc, PushPromptUploaded)
 }
 
 // NewTextAttachHandler returns a new handler for attach command.
-func NewTextAttachHandler(printer *output.Printer) AttachHandler {
-	return NewTextPushHandler(printer)
+func NewTextAttachHandler(printer *output.Printer, fetcher content.Fetcher) AttachHandler {
+	return NewTextPushHandler(printer, fetcher)
 }
 
 // TextPullHandler handles text status output for pull events.
@@ -160,7 +166,7 @@ func (ch *TextCopyHandler) PostCopy(ctx context.Context, desc ocispec.Descriptor
 		return err
 	}
 	for _, successor := range successors {
-		if err = ch.printer.PrintStatus(successor, copyPromptSkipped); err != nil {
+		if err = ch.printer.PrintStatus(successor, copyPromptExists); err != nil {
 			return err
 		}
 	}

--- a/cmd/oras/internal/display/status/text_test.go
+++ b/cmd/oras/internal/display/status/text_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 
 func TestTextCopyHandler_OnMounted(t *testing.T) {
 	defer builder.Reset()
-	expected := "Mounted 6f42718876ce oci-image"
+	expected := "Mounted 0b442c23c1dd oci-image"
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.OnMounted(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnMounted() should not return an error")
@@ -58,7 +58,7 @@ func TestTextCopyHandler_OnMounted(t *testing.T) {
 
 func TestTextCopyHandler_OnCopySkipped(t *testing.T) {
 	defer builder.Reset()
-	expected := "Exists  6f42718876ce oci-image"
+	expected := "Exists  0b442c23c1dd oci-image"
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.OnCopySkipped(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnCopySkipped() should not return an error")
@@ -71,7 +71,7 @@ func TestTextCopyHandler_OnCopySkipped(t *testing.T) {
 
 func TestTextCopyHandler_PostCopy(t *testing.T) {
 	defer builder.Reset()
-	expected := "Copied  6f42718876ce oci-image"
+	expected := "Copied  0b442c23c1dd oci-image"
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.PostCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PostCopy() should not return an error")
@@ -87,7 +87,7 @@ func TestTextCopyHandler_PostCopy(t *testing.T) {
 
 func TestTextCopyHandler_PreCopy(t *testing.T) {
 	defer builder.Reset()
-	expected := "Copying 6f42718876ce oci-image"
+	expected := "Copying 0b442c23c1dd oci-image"
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.PreCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PreCopy() should not return an error")
@@ -100,7 +100,7 @@ func TestTextCopyHandler_PreCopy(t *testing.T) {
 
 func TestTextPullHandler_OnNodeDownloaded(t *testing.T) {
 	defer builder.Reset()
-	expected := "Downloaded  6f42718876ce oci-image"
+	expected := "Downloaded  0b442c23c1dd oci-image"
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeDownloaded(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeDownloaded() should not return an error")
@@ -113,7 +113,7 @@ func TestTextPullHandler_OnNodeDownloaded(t *testing.T) {
 
 func TestTextPullHandler_OnNodeDownloading(t *testing.T) {
 	defer builder.Reset()
-	expected := "Downloading 6f42718876ce oci-image"
+	expected := "Downloading 0b442c23c1dd oci-image"
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeDownloading(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeDownloading() should not return an error")
@@ -126,7 +126,7 @@ func TestTextPullHandler_OnNodeDownloading(t *testing.T) {
 
 func TestTextPullHandler_OnNodeProcessing(t *testing.T) {
 	defer builder.Reset()
-	expected := "Processing  6f42718876ce oci-image"
+	expected := "Processing  0b442c23c1dd oci-image"
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeProcessing(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeProcessing() should not return an error")
@@ -139,7 +139,7 @@ func TestTextPullHandler_OnNodeProcessing(t *testing.T) {
 
 func TestTextPullHandler_OnNodeRestored(t *testing.T) {
 	defer builder.Reset()
-	expected := "Restored    6f42718876ce oci-image"
+	expected := "Restored    0b442c23c1dd oci-image"
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeRestored(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeRestored() should not return an error")
@@ -152,7 +152,7 @@ func TestTextPullHandler_OnNodeRestored(t *testing.T) {
 
 func TestTextPullHandler_OnNodeSkipped(t *testing.T) {
 	defer builder.Reset()
-	expected := "Skipped     6f42718876ce oci-image"
+	expected := "Skipped     0b442c23c1dd oci-image"
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeSkipped(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeSkipped() should not return an error")
@@ -165,7 +165,7 @@ func TestTextPullHandler_OnNodeSkipped(t *testing.T) {
 
 func TestTextPushHandler_OnCopySkipped(t *testing.T) {
 	defer builder.Reset()
-	expected := "Exists    6f42718876ce oci-image"
+	expected := "Exists    0b442c23c1dd oci-image"
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.OnCopySkipped(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnCopySkipped() should not return an error")
@@ -204,7 +204,7 @@ func TestTextPushHandler_OnFileLoading(t *testing.T) {
 
 func TestTextPushHandler_PostCopy(t *testing.T) {
 	defer builder.Reset()
-	expected := "Uploaded  6f42718876ce oci-image"
+	expected := "Uploaded  0b442c23c1dd oci-image"
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.PostCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PostCopy() should not return an error")
@@ -217,7 +217,7 @@ func TestTextPushHandler_PostCopy(t *testing.T) {
 
 func TestTextPushHandler_PreCopy(t *testing.T) {
 	defer builder.Reset()
-	expected := "Uploading 6f42718876ce oci-image"
+	expected := "Uploading 0b442c23c1dd oci-image"
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.PreCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PreCopy() should not return an error")

--- a/cmd/oras/internal/display/status/text_test.go
+++ b/cmd/oras/internal/display/status/text_test.go
@@ -16,79 +16,26 @@ limitations under the License.
 package status
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/testutils"
 )
 
 var (
-	ctx          context.Context
-	builder      *strings.Builder
-	printer      *output.Printer
-	bogus        ocispec.Descriptor
-	memStore     *memory.Store
-	layerDesc    ocispec.Descriptor
-	manifestDesc ocispec.Descriptor
-	wantedError  = fmt.Errorf("wanted error")
+	ctx         context.Context
+	builder     *strings.Builder
+	printer     *output.Printer
+	bogus       ocispec.Descriptor
+	mockFetcher testutils.MockFetcher
 )
 
 func TestMain(m *testing.M) {
-	// memory store for testing
-	memStore = memory.New()
-	layerContent := []byte("test")
-	r := bytes.NewReader(layerContent)
-	layerDesc = ocispec.Descriptor{
-		MediaType: "application/octet-stream",
-		Digest:    digest.FromBytes(layerContent),
-		Size:      int64(len(layerContent)),
-	}
-	if err := memStore.Push(context.Background(), layerDesc, r); err != nil {
-		fmt.Println("Setup failed:", err)
-		os.Exit(1)
-	}
-	if err := memStore.Tag(context.Background(), layerDesc, layerDesc.Digest.String()); err != nil {
-		fmt.Println("Setup failed:", err)
-		os.Exit(1)
-	}
-
-	layer1Desc := layerDesc
-	layer1Desc.Annotations = map[string]string{ocispec.AnnotationTitle: "layer1"}
-	layer2Desc := layerDesc
-	layer2Desc.Annotations = map[string]string{ocispec.AnnotationTitle: "layer2"}
-	manifest := ocispec.Manifest{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Layers:    []ocispec.Descriptor{layer1Desc, layer2Desc},
-		Config:    layerDesc,
-	}
-	manifestContent, err := json.Marshal(&manifest)
-	if err != nil {
-		fmt.Println("Setup failed:", err)
-		os.Exit(1)
-	}
-	manifestDesc = ocispec.Descriptor{
-		MediaType: manifest.MediaType,
-		Size:      int64(len(manifestContent)),
-		Digest:    digest.FromBytes(manifestContent),
-	}
-	if err := memStore.Push(context.Background(), manifestDesc, strings.NewReader(string(manifestContent))); err != nil {
-		fmt.Println("Setup failed:", err)
-		os.Exit(1)
-	}
-	if err := memStore.Tag(context.Background(), layerDesc, layerDesc.Digest.String()); err != nil {
-		fmt.Println("Setup failed:", err)
-		os.Exit(1)
-	}
-
+	mockFetcher = testutils.NewMockFetcher()
 	ctx = context.Background()
 	builder = &strings.Builder{}
 	printer = output.NewPrinter(builder, os.Stderr, false)
@@ -97,37 +44,186 @@ func TestMain(m *testing.M) {
 }
 
 func TestTextCopyHandler_OnMounted(t *testing.T) {
-	fetcher := testutils.NewMockFetcher(t)
-	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
-	if ch.OnMounted(ctx, fetcher.OciImage) != nil {
+	defer builder.Reset()
+	expected := "Mounted 6f42718876ce oci-image"
+	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
+	if ch.OnMounted(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnMounted() should not return an error")
 	}
-
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
 }
 
 func TestTextCopyHandler_OnCopySkipped(t *testing.T) {
-	fetcher := testutils.NewMockFetcher(t)
-	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
-	if ch.OnCopySkipped(ctx, fetcher.OciImage) != nil {
+	defer builder.Reset()
+	expected := "Exists  6f42718876ce oci-image"
+	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
+	if ch.OnCopySkipped(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnCopySkipped() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
 	}
 }
 
 func TestTextCopyHandler_PostCopy(t *testing.T) {
-	fetcher := testutils.NewMockFetcher(t)
-	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
-	if ch.PostCopy(ctx, fetcher.OciImage) != nil {
+	defer builder.Reset()
+	expected := "Copied  6f42718876ce oci-image"
+	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
+	if ch.PostCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PostCopy() should not return an error")
 	}
 	if ch.PostCopy(ctx, bogus) == nil {
 		t.Error("PostCopy() should return an error")
 	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
 }
 
 func TestTextCopyHandler_PreCopy(t *testing.T) {
-	fetcher := testutils.NewMockFetcher(t)
-	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
-	if ch.PreCopy(ctx, fetcher.OciImage) != nil {
+	defer builder.Reset()
+	expected := "Copying 6f42718876ce oci-image"
+	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
+	if ch.PreCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PreCopy() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPullHandler_OnNodeDownloaded(t *testing.T) {
+	defer builder.Reset()
+	expected := "Downloaded  6f42718876ce oci-image"
+	ph := NewTextPullHandler(printer)
+	if ph.OnNodeDownloaded(mockFetcher.OciImage) != nil {
+		t.Error("OnNodeDownloaded() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPullHandler_OnNodeDownloading(t *testing.T) {
+	defer builder.Reset()
+	expected := "Downloading 6f42718876ce oci-image"
+	ph := NewTextPullHandler(printer)
+	if ph.OnNodeDownloading(mockFetcher.OciImage) != nil {
+		t.Error("OnNodeDownloading() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPullHandler_OnNodeProcessing(t *testing.T) {
+	defer builder.Reset()
+	expected := "Processing  6f42718876ce oci-image"
+	ph := NewTextPullHandler(printer)
+	if ph.OnNodeProcessing(mockFetcher.OciImage) != nil {
+		t.Error("OnNodeProcessing() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPullHandler_OnNodeRestored(t *testing.T) {
+	defer builder.Reset()
+	expected := "Restored    6f42718876ce oci-image"
+	ph := NewTextPullHandler(printer)
+	if ph.OnNodeRestored(mockFetcher.OciImage) != nil {
+		t.Error("OnNodeRestored() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPullHandler_OnNodeSkipped(t *testing.T) {
+	defer builder.Reset()
+	expected := "Skipped     6f42718876ce oci-image"
+	ph := NewTextPullHandler(printer)
+	if ph.OnNodeSkipped(mockFetcher.OciImage) != nil {
+		t.Error("OnNodeSkipped() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPushHandler_OnCopySkipped(t *testing.T) {
+	defer builder.Reset()
+	expected := "Exists    6f42718876ce oci-image"
+	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
+	if ph.OnCopySkipped(ctx, mockFetcher.OciImage) != nil {
+		t.Error("OnCopySkipped() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPushHandler_OnEmptyArtifact(t *testing.T) {
+	defer builder.Reset()
+	expected := "Uploading empty artifact"
+	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
+	if ph.OnEmptyArtifact() != nil {
+		t.Error("OnEmptyArtifact() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPushHandler_OnFileLoading(t *testing.T) {
+	defer builder.Reset()
+	expected := ""
+	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
+	if ph.OnFileLoading("name") != nil {
+		t.Error("OnFileLoading() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPushHandler_PostCopy(t *testing.T) {
+	defer builder.Reset()
+	expected := "Uploaded  6f42718876ce oci-image"
+	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
+	if ph.PostCopy(ctx, mockFetcher.OciImage) != nil {
+		t.Error("PostCopy() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
+func TestTextPushHandler_PreCopy(t *testing.T) {
+	defer builder.Reset()
+	expected := "Uploading 6f42718876ce oci-image"
+	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
+	if ph.PreCopy(ctx, mockFetcher.OciImage) != nil {
+		t.Error("PreCopy() should not return an error")
+	}
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
 	}
 }

--- a/cmd/oras/internal/display/status/text_test.go
+++ b/cmd/oras/internal/display/status/text_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras/cmd/oras/internal/output"
+	"oras.land/oras/internal/testutils"
+	"os"
+	"strings"
+	"testing"
+)
+
+var (
+	ctx          context.Context
+	builder      *strings.Builder
+	printer      *output.Printer
+	bogus        ocispec.Descriptor
+	memStore     *memory.Store
+	memDesc      ocispec.Descriptor
+	manifestDesc ocispec.Descriptor
+)
+
+func TestMain(m *testing.M) {
+	// memory store for testing
+	memStore = memory.New()
+	content := []byte("test")
+	r := bytes.NewReader(content)
+	memDesc = ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+	}
+	if err := memStore.Push(context.Background(), memDesc, r); err != nil {
+		fmt.Println("Setup failed:", err)
+		os.Exit(1)
+	}
+	if err := memStore.Tag(context.Background(), memDesc, memDesc.Digest.String()); err != nil {
+		fmt.Println("Setup failed:", err)
+		os.Exit(1)
+	}
+
+	layer1Desc := memDesc
+	layer1Desc.Annotations = map[string]string{ocispec.AnnotationTitle: "layer1"}
+	layer2Desc := memDesc
+	layer2Desc.Annotations = map[string]string{ocispec.AnnotationTitle: "layer2"}
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Layers:    []ocispec.Descriptor{layer1Desc, layer2Desc},
+		Config:    memDesc,
+	}
+	manifestContent, err := json.Marshal(&manifest)
+	if err != nil {
+		fmt.Println("Setup failed:", err)
+		os.Exit(1)
+	}
+	manifestDesc = ocispec.Descriptor{
+		MediaType: manifest.MediaType,
+		Size:      int64(len(manifestContent)),
+		Digest:    digest.FromBytes(manifestContent),
+	}
+	if err := memStore.Push(context.Background(), manifestDesc, strings.NewReader(string(manifestContent))); err != nil {
+		fmt.Println("Setup failed:", err)
+		os.Exit(1)
+	}
+	if err := memStore.Tag(context.Background(), memDesc, memDesc.Digest.String()); err != nil {
+		fmt.Println("Setup failed:", err)
+		os.Exit(1)
+	}
+
+	ctx = context.Background()
+	builder = &strings.Builder{}
+	printer = output.NewPrinter(builder, os.Stderr, false)
+	bogus = ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest}
+	m.Run()
+}
+
+func TestTextCopyHandler_OnMounted(t *testing.T) {
+	fetcher := testutils.NewMockFetcher(t)
+	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
+	if ch.OnMounted(ctx, fetcher.OciImage) != nil {
+		t.Error("OnMounted() should not return an error")
+	}
+
+}
+
+func TestTextCopyHandler_OnCopySkipped(t *testing.T) {
+	fetcher := testutils.NewMockFetcher(t)
+	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
+	if ch.OnCopySkipped(ctx, fetcher.OciImage) != nil {
+		t.Error("OnCopySkipped() should not return an error")
+	}
+}
+
+func TestTextCopyHandler_PostCopy(t *testing.T) {
+	fetcher := testutils.NewMockFetcher(t)
+	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
+	if ch.PostCopy(ctx, fetcher.OciImage) != nil {
+		t.Error("PostCopy() should not return an error")
+	}
+	if ch.PostCopy(ctx, bogus) == nil {
+		t.Error("PostCopy() should return an error")
+	}
+}
+
+func TestTextCopyHandler_PreCopy(t *testing.T) {
+	fetcher := testutils.NewMockFetcher(t)
+	ch := NewTextCopyHandler(printer, fetcher.Fetcher)
+	if ch.PreCopy(ctx, fetcher.OciImage) != nil {
+		t.Error("PreCopy() should not return an error")
+	}
+}

--- a/cmd/oras/internal/display/status/tty.go
+++ b/cmd/oras/internal/display/status/tty.go
@@ -29,14 +29,18 @@ import (
 
 // TTYPushHandler handles TTY status output for push command.
 type TTYPushHandler struct {
-	tty     *os.File
-	tracked track.GraphTarget
+	tty       *os.File
+	tracked   track.GraphTarget
+	committed *sync.Map
+	fetcher   content.Fetcher
 }
 
 // NewTTYPushHandler returns a new handler for push status events.
-func NewTTYPushHandler(tty *os.File) PushHandler {
+func NewTTYPushHandler(tty *os.File, fetcher content.Fetcher) PushHandler {
 	return &TTYPushHandler{
-		tty: tty,
+		tty:       tty,
+		fetcher:   fetcher,
+		committed: &sync.Map{},
 	}
 }
 
@@ -60,32 +64,36 @@ func (ph *TTYPushHandler) TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, St
 	return tracked, tracked.Close, nil
 }
 
-// UpdateCopyOptions adds TTY status output to the copy options.
-func (ph *TTYPushHandler) UpdateCopyOptions(opts *oras.CopyGraphOptions, fetcher content.Fetcher) {
-	committed := &sync.Map{}
-	opts.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
-		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		return ph.tracked.Prompt(desc, PushPromptExists)
+// OnCopySkipped is called when an object already exists.
+func (ph *TTYPushHandler) OnCopySkipped(_ context.Context, desc ocispec.Descriptor) error {
+	ph.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	return ph.tracked.Prompt(desc, PushPromptExists)
+}
+
+// PreCopy implements PreCopy of CopyHandler.
+func (ph *TTYPushHandler) PreCopy(_ context.Context, _ ocispec.Descriptor) error {
+	return nil
+}
+
+// PostCopy implements PostCopy of CopyHandler.
+func (ph *TTYPushHandler) PostCopy(ctx context.Context, desc ocispec.Descriptor) error {
+	ph.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	successors, err := graph.FilteredSuccessors(ctx, desc, ph.fetcher, DeduplicatedFilter(ph.committed))
+	if err != nil {
+		return err
 	}
-	opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
-		committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-		successors, err := graph.FilteredSuccessors(ctx, desc, fetcher, DeduplicatedFilter(committed))
+	for _, successor := range successors {
+		err = ph.tracked.Prompt(successor, PushPromptSkipped)
 		if err != nil {
 			return err
 		}
-		for _, successor := range successors {
-			err = ph.tracked.Prompt(successor, PushPromptSkipped)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
 	}
+	return nil
 }
 
 // NewTTYAttachHandler returns a new handler for attach status events.
-func NewTTYAttachHandler(tty *os.File) AttachHandler {
-	return NewTTYPushHandler(tty)
+func NewTTYAttachHandler(tty *os.File, fetcher content.Fetcher) AttachHandler {
+	return NewTTYPushHandler(tty, fetcher)
 }
 
 // TTYPullHandler handles TTY status output for pull events.

--- a/cmd/oras/internal/display/status/tty.go
+++ b/cmd/oras/internal/display/status/tty.go
@@ -17,9 +17,10 @@ package status
 
 import (
 	"context"
-	"oras.land/oras/internal/graph"
 	"os"
 	"sync"
+
+	"oras.land/oras/internal/graph"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -83,8 +84,7 @@ func (ph *TTYPushHandler) PostCopy(ctx context.Context, desc ocispec.Descriptor)
 		return err
 	}
 	for _, successor := range successors {
-		err = ph.tracked.Prompt(successor, PushPromptSkipped)
-		if err != nil {
+		if err = ph.tracked.Prompt(successor, PushPromptSkipped); err != nil {
 			return err
 		}
 	}

--- a/cmd/oras/internal/display/status/tty_test.go
+++ b/cmd/oras/internal/display/status/tty_test.go
@@ -17,30 +17,30 @@ package status
 
 import (
 	"context"
-	"io"
 	"os"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2"
+
+	"oras.land/oras/internal/testutils"
 )
 
 func TestTTYPushHandler_OnFileLoading(t *testing.T) {
-	ph := NewTTYPushHandler(os.Stdout)
+	ph := NewTTYPushHandler(os.Stdout, mockFetcher.Fetcher)
 	if ph.OnFileLoading("test") != nil {
 		t.Error("OnFileLoading() should not return an error")
 	}
 }
 
 func TestTTYPushHandler_OnEmptyArtifact(t *testing.T) {
-	ph := NewTTYAttachHandler(os.Stdout)
+	ph := NewTTYAttachHandler(os.Stdout, mockFetcher.Fetcher)
 	if ph.OnEmptyArtifact() != nil {
 		t.Error("OnEmptyArtifact() should not return an error")
 	}
 }
 
 func TestTTYPushHandler_TrackTarget_invalidTTY(t *testing.T) {
-	ph := NewTTYPushHandler(os.Stdin)
+	ph := NewTTYPushHandler(os.Stdin, mockFetcher.Fetcher)
 	if _, _, err := ph.TrackTarget(nil); err == nil {
 		t.Error("TrackTarget() should return an error for non-tty file")
 	}
@@ -67,47 +67,13 @@ func TestTTYPullHandler_OnNodeProcessing(t *testing.T) {
 	}
 }
 
-// ErrorFetcher implements content.Fetcher.
-type ErrorFetcher struct{}
-
-// Fetch returns an error.
-func (f *ErrorFetcher) Fetch(context.Context, ocispec.Descriptor) (io.ReadCloser, error) {
-	return nil, wantedError
-}
-
 func TestTTYPushHandler_errGetSuccessor(t *testing.T) {
-	ph := NewTTYPushHandler(nil)
-	opts := oras.CopyGraphOptions{}
-	ph.UpdateCopyOptions(&opts, &ErrorFetcher{})
-	if err := opts.PostCopy(context.Background(), ocispec.Descriptor{
+	errorFetcher := testutils.NewErrorFetcher()
+	ph := NewTTYPushHandler(nil, errorFetcher)
+	err := ph.PostCopy(context.Background(), ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageManifest,
-	}); err != wantedError {
-		t.Error("PostCopy() should return expected error")
-	}
-}
-
-// ErrorPromptor mocks trackable GraphTarget.
-type ErrorPromptor struct {
-	oras.GraphTarget
-	io.Closer
-}
-
-// Prompt mocks an errored prompt.
-func (p *ErrorPromptor) Prompt(ocispec.Descriptor, string) error {
-	return wantedError
-}
-
-func TestTTYPushHandler_errPrompt(t *testing.T) {
-	ph := TTYPushHandler{
-		tracked: &ErrorPromptor{},
-	}
-	opts := oras.CopyGraphOptions{}
-	ph.UpdateCopyOptions(&opts, memStore)
-	if err := opts.OnCopySkipped(ctx, layerDesc); err != wantedError {
-		t.Error("OnCopySkipped() should return expected error")
-	}
-	// test
-	if err := opts.PostCopy(context.Background(), manifestDesc); err != wantedError {
-		t.Error("PostCopy() should return expected error")
+	})
+	if err.Error() != errorFetcher.ExpectedError.Error() {
+		t.Errorf("PostCopy() should return expected error got %v", err.Error())
 	}
 }

--- a/cmd/oras/internal/display/status/utils.go
+++ b/cmd/oras/internal/display/status/utils.go
@@ -15,6 +15,12 @@ limitations under the License.
 
 package status
 
+import (
+	"sync"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
 // Prompts for pull events.
 const (
 	PullPromptDownloading = "Downloading"
@@ -41,3 +47,13 @@ const (
 	copyPromptSkipped = "Skipped"
 	copyPromptMounted = "Mounted"
 )
+
+// DeduplicatedFilter filters out deduplicated descriptors.
+func DeduplicatedFilter(committed *sync.Map) func(desc ocispec.Descriptor) bool {
+	return func(desc ocispec.Descriptor) bool {
+		name := desc.Annotations[ocispec.AnnotationTitle]
+		v, ok := committed.Load(desc.Digest.String())
+		// committed but not printed == deduplicated
+		return ok && v != name
+	}
+}

--- a/cmd/oras/root/attach_test.go
+++ b/cmd/oras/root/attach_test.go
@@ -17,10 +17,11 @@ package root
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/spf13/cobra"
-	"oras.land/oras/cmd/oras/internal/errors"
+
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -31,12 +32,13 @@ func Test_runAttach_errType(t *testing.T) {
 
 	// test
 	opts := &attachOptions{
-		Format: option.Format{
-			Type: "unknown",
+		Packer: option.Packer{
+			AnnotationFilePath:  "/tmp/whatever",
+			ManifestAnnotations: []string{"one", "two"},
 		},
 	}
 	got := runAttach(cmd, opts).Error()
-	want := errors.UnsupportedFormatTypeError(opts.Format.Type).Error()
+	want := errors.New("`--annotation` and `--annotation-file` cannot be both specified").Error()
 	if got != want {
 		t.Fatalf("got %v, want %v", got, want)
 	}

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -18,7 +18,6 @@ package descriptor
 import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-
 	"oras.land/oras/internal/docker"
 )
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -130,3 +130,19 @@ func FindPredecessors(ctx context.Context, src oras.ReadOnlyGraphTarget, descs [
 	}
 	return referrers, nil
 }
+
+// FilteredSuccessors fetches successors and returns filtered ones.
+func FilteredSuccessors(ctx context.Context, desc ocispec.Descriptor, fetcher content.Fetcher, filter func(ocispec.Descriptor) bool) ([]ocispec.Descriptor, error) {
+	allSuccessors, err := content.Successors(ctx, fetcher, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	var successors []ocispec.Descriptor
+	for _, s := range allSuccessors {
+		if filter(s) {
+			successors = append(successors, s)
+		}
+	}
+	return successors, nil
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -45,9 +45,9 @@ func TestSuccessors(t *testing.T) {
 	}{
 		{"should failed to get non-existent OCI image", args{ctx, fetcher, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest}}, nil, nil, nil, true},
 		{"should failed to get non-existent docker image", args{ctx, fetcher, ocispec.Descriptor{MediaType: docker.MediaTypeManifest}}, nil, nil, nil, true},
-		{"should get success of a docker image", args{ctx, fetcher, mockFetcher.DockerImage}, nil, &mockFetcher.Subject, &mockFetcher.Config, false},
-		{"should get success of an OCI image", args{ctx, fetcher, mockFetcher.OciImage}, nil, &mockFetcher.Subject, &mockFetcher.Config, false},
-		{"should get success of an index", args{ctx, fetcher, mockFetcher.Index}, []ocispec.Descriptor{mockFetcher.Subject}, nil, nil, false},
+		{"should get successors of a docker image", args{ctx, fetcher, mockFetcher.DockerImage}, nil, nil, &mockFetcher.Config, false},
+		{"should get successors of an OCI image", args{ctx, fetcher, mockFetcher.OciImage}, []ocispec.Descriptor{mockFetcher.ImageLayer}, &mockFetcher.Subject, &mockFetcher.Config, false},
+		{"should get successors of an index", args{ctx, fetcher, mockFetcher.Index}, []ocispec.Descriptor{mockFetcher.Subject}, nil, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestDescriptor_GetSuccessors(t *testing.T) {
 	if nil != err {
 		t.Errorf("FilteredSuccessors unexpected error %v", err)
 	}
-	if len(got) != 2 {
+	if len(got) != 3 {
 		t.Errorf("Expected 2 successors got %v", len(got))
 	}
 	if mockFetcher.Subject.Digest != got[0].Digest {
@@ -96,7 +96,7 @@ func TestDescriptor_GetSuccessors(t *testing.T) {
 	if nil != err {
 		t.Errorf("FilteredSuccessors unexpected error %v", err)
 	}
-	if len(got) != 1 {
+	if len(got) != 2 {
 		t.Errorf("Expected 1 successors got %v", len(got))
 	}
 	if mockFetcher.Subject.Digest != got[0].Digest {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestSuccessors(t *testing.T) {
-	mockFetcher := testutils.NewMockFetcher(t)
+	mockFetcher := testutils.NewMockFetcher()
 	fetcher := mockFetcher.Fetcher
 	ctx := context.Background()
 	type args struct {
@@ -70,7 +70,7 @@ func TestSuccessors(t *testing.T) {
 }
 
 func TestDescriptor_GetSuccessors(t *testing.T) {
-	mockFetcher := testutils.NewMockFetcher(t)
+	mockFetcher := testutils.NewMockFetcher()
 
 	allFilter := func(ocispec.Descriptor) bool {
 		return true

--- a/internal/testutils/prompt.go
+++ b/internal/testutils/prompt.go
@@ -1,0 +1,53 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+)
+
+// PromptDiscarder mocks trackable GraphTarget with discarded prompt.
+type PromptDiscarder struct {
+	oras.GraphTarget
+	io.Closer
+}
+
+// Prompt discards the prompt.
+func (p *PromptDiscarder) Prompt(ocispec.Descriptor, string) error {
+	return nil
+}
+
+// ErrorPrompt mocks an errored prompt.
+type ErrorPrompt struct {
+	oras.GraphTarget
+	io.Closer
+	wanted error
+}
+
+// NewErrorPrompt creates an error prompt.
+func NewErrorPrompt(err error) *ErrorPrompt {
+	return &ErrorPrompt{
+		wanted: err,
+	}
+}
+
+// Prompt mocks an errored prompt.
+func (e *ErrorPrompt) Prompt(ocispec.Descriptor, string) error {
+	return e.wanted
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The PrintSuccessorStatus method was complicated with the function passed in and it didn't show the best separation of concerns. The print module ideally wouldn't know about a fetcher for example.
