### PR TITLE
fix: variable name conflicts with built in function

### DIFF
--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -27,9 +27,9 @@ const (
 	MinWidth = 80
 	// MinHeight is the minimal height of supported console.
 	MinHeight = 10
-	// cannot use aec.Save since DEC has better compatilibity than SCO
+	// Save cannot use aec.Save since DEC has better compatibility than SCO
 	Save = "\0337"
-	// cannot use aec.Restore since DEC has better compatilibity than SCO
+	// Restore cannot use aec.Restore since DEC has better compatibility than SCO
 	Restore = "\0338"
 )
 
@@ -87,7 +87,7 @@ func (c *Console) OutputTo(upCnt uint, str string) {
 
 // Restore restores the saved cursor position.
 func (c *Console) Restore() {
-	// cannot use aec.Restore since DEC has better compatilibity than SCO
+	// cannot use aec.Restore since DEC has better compatibility than SCO
 	_, _ = c.Write([]byte(Restore))
 	_, _ = c.Write([]byte(aec.Column(0).
 		With(aec.EraseLine(aec.EraseModes.All)).

--- a/cmd/oras/internal/display/status/progress/manager.go
+++ b/cmd/oras/internal/display/status/progress/manager.go
@@ -92,17 +92,17 @@ func (m *manager) render() {
 	defer m.statusLock.RUnlock()
 	// todo: update size in another routine
 	width, height := m.console.Size()
-	len := len(m.status) * 2
+	statusLength := len(m.status) * 2
 	offset := 0
-	if len > height {
+	if statusLength > height {
 		// skip statuses that cannot be rendered
-		offset = len - height
+		offset = statusLength - height
 	}
 
-	for ; offset < len; offset += 2 {
+	for ; offset < statusLength; offset += 2 {
 		status, progress := m.status[offset/2].String(width)
-		m.console.OutputTo(uint(len-offset), status)
-		m.console.OutputTo(uint(len-offset-1), progress)
+		m.console.OutputTo(uint(statusLength-offset), status)
+		m.console.OutputTo(uint(statusLength-offset-1), progress)
 	}
 }
 

--- a/cmd/oras/internal/display/status/progress/manager.go
+++ b/cmd/oras/internal/display/status/progress/manager.go
@@ -92,17 +92,17 @@ func (m *manager) render() {
 	defer m.statusLock.RUnlock()
 	// todo: update size in another routine
 	width, height := m.console.Size()
-	statusLength := len(m.status) * 2
+	lineCount := len(m.status) * 2
 	offset := 0
-	if statusLength > height {
+	if lineCount > height {
 		// skip statuses that cannot be rendered
-		offset = statusLength - height
+		offset = lineCount - height
 	}
 
-	for ; offset < statusLength; offset += 2 {
+	for ; offset < lineCount; offset += 2 {
 		status, progress := m.status[offset/2].String(width)
-		m.console.OutputTo(uint(statusLength-offset), status)
-		m.console.OutputTo(uint(statusLength-offset-1), progress)
+		m.console.OutputTo(uint(lineCount-offset), status)
+		m.console.OutputTo(uint(lineCount-offset-1), progress)
 	}
 }
 

--- a/cmd/oras/internal/display/status/progress/manager_test.go
+++ b/cmd/oras/internal/display/status/progress/manager_test.go
@@ -1,3 +1,5 @@
+//go:build freebsd || linux || netbsd || openbsd || solaris
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/oras/internal/display/status/progress/manager_test.go
+++ b/cmd/oras/internal/display/status/progress/manager_test.go
@@ -34,7 +34,9 @@ func Test_manager_render(t *testing.T) {
 	}
 	_, height := m.console.Size()
 	for i := 0; i < height; i++ {
-		m.Add()
+		if _, err := m.Add(); err != nil {
+			t.Fatal(err)
+		}
 	}
 	m.render()
 	// validate

--- a/cmd/oras/internal/display/status/progress/manager_test.go
+++ b/cmd/oras/internal/display/status/progress/manager_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package progress
+
+import (
+	"fmt"
+	"testing"
+
+	"oras.land/oras/cmd/oras/internal/display/status/console"
+	"oras.land/oras/cmd/oras/internal/display/status/console/testutils"
+)
+
+func Test_manager_render(t *testing.T) {
+	pty, device, err := testutils.NewPty()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer device.Close()
+	m := &manager{
+		console: &console.Console{Console: pty},
+	}
+	_, height := m.console.Size()
+	for i := 0; i < height; i++ {
+		m.Add()
+	}
+	m.render()
+	// validate
+	var want []string
+	for i := height; i > 0; i -= 2 {
+		want = append(want, fmt.Sprintf("%dF%s", i, zeroStatus))
+	}
+	if err = testutils.MatchPty(pty, device, want...); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/oras/internal/display/status/progress/status_test.go
+++ b/cmd/oras/internal/display/status/progress/status_test.go
@@ -68,7 +68,7 @@ func Test_status_String(t *testing.T) {
 	}
 }
 
-func Test_status_String_zeroWitdth(t *testing.T) {
+func Test_status_String_zeroWidth(t *testing.T) {
 	// zero status and progress
 	s := newStatus()
 	if status, digest := s.String(console.MinWidth); status != zeroStatus || digest != zeroDigest {


### PR DESCRIPTION
**What this PR does / why we need it**:

The variable name `len` conflicts with the built in. This will simplify my other PR a bit as well.
