### PR TITLE
feature: Add manifest fetch documentation for digest

### DIFF
--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -55,6 +55,9 @@ Example - Fetch raw manifest from a registry:
 Example - Fetch the descriptor of a manifest from a registry:
   oras manifest fetch --descriptor localhost:5000/hello:v1
 
+Example - Fetch the manifest digest from a registry:
+  oras manifest fetch --format go-template --template '{{ .digest }}' localhost:5000/hello:v1
+
 Example - Fetch manifest from a registry with specified media type:
   oras manifest fetch --media-type 'application/vnd.oci.image.manifest.v1+json' localhost:5000/hello:v1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an example for `--format` and it is a common task (for me at least) to get the digest.
