### PR TITLE
fix: oras repo tags exlude-digest-tags documentation

### DIFF
--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -46,7 +46,7 @@ Example - Show tags of the target repository:
   oras repo tags localhost:5000/hello
 
 Example - Show tags in the target repository with digest-like tags hidden:
-  oras repo tags --exclude-digest-tag localhost:5000/hello
+  oras repo tags --exclude-digest-tags localhost:5000/hello
 
 Example - Show tags of the target repository that include values lexically after last:
   oras repo tags --last "last_tag" localhost:5000/hello


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes help documtation for `oras repo tags` command.

Closes: https://github.com/oras-project/oras/pull/1444
