### PR TITLE
fix: coverage.txt file generation contained testutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ debug
 
 # Custom
 coverage.txt
+coverage-all.txt
 test/e2e/coverage.txt
 **/covcounters.*
 **/covmeta.*

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ LDFLAGS += -X $(PROJECT_PKG)/internal/version.GitTreeState=${GIT_DIRTY}
 
 .PHONY: test
 test: tidy vendor check-encoding  ## tidy and run tests
-	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=$($(GO_EXE) list ./... | grep -v internal/testutils | tr '\n' ',') ./...
+	$(GO_EXE) test -race -v -coverprofile=coverage-all.txt -covermode=atomic -coverpkg=$($(GO_EXE) list ./... | tr '\n' ',') ./...
+	grep -v internal/testutils coverage-all.txt >coverage.txt
+	rm -f coverage-all.txt
 
 .PHONY: teste2e
 teste2e:  ## run end to end tests

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,7 @@ LDFLAGS += -X $(PROJECT_PKG)/internal/version.GitTreeState=${GIT_DIRTY}
 
 .PHONY: test
 test: tidy vendor check-encoding  ## tidy and run tests
-	$(GO_EXE) test -race -v -coverprofile=coverage-all.txt -covermode=atomic -coverpkg=$($(GO_EXE) list ./... | tr '\n' ',') ./...
-	grep -v internal/testutils coverage-all.txt >coverage.txt
-	rm -f coverage-all.txt
-
+	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=$(shell $(GO_EXE) list ./... | grep -v '^oras.land/oras/internal/testutils' | paste -sd ',' -) ./...
 .PHONY: teste2e
 teste2e:  ## run end to end tests
 	./test/e2e/scripts/e2e.sh $(shell git rev-parse --show-toplevel) --clean

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ LDFLAGS += -X $(PROJECT_PKG)/internal/version.GitTreeState=${GIT_DIRTY}
 
 .PHONY: test
 test: tidy vendor check-encoding  ## tidy and run tests
-	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=$(shell $(GO_EXE) list ./... | grep -v '^oras.land/oras/internal/testutils' | paste -sd ',' -) ./...
+	$(GO_EXE) test -race -v -coverprofile=coverage-all.txt -covermode=atomic -coverpkg=./... ./...
+	grep -v internal/testutils coverage-all.txt >coverage.txt
+	rm -f coverage-all.txt
 .PHONY: teste2e
 teste2e:  ## run end to end tests
 	./test/e2e/scripts/e2e.sh $(shell git rev-parse --show-toplevel) --clean


### PR DESCRIPTION
**What this PR does / why we need it**:

coverage.txt contained testutils on the last PR https://github.com/oras-project/oras/pull/1443/files#diff-bd7e25b9d11cd3ad1fe54a05a85404a42102e79be984f3f5ae2377c7e95e2eda
