### PR TITLE
refactor: DRY up text_test

### DIFF
--- a/cmd/oras/internal/display/status/text_test.go
+++ b/cmd/oras/internal/display/status/text_test.go
@@ -43,35 +43,33 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
+func validatePrinted(t *testing.T, expected string) {
+	actual := strings.TrimSpace(builder.String())
+	if expected != actual {
+		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
+	}
+}
+
 func TestTextCopyHandler_OnMounted(t *testing.T) {
-	defer builder.Reset()
-	expected := "Mounted 0b442c23c1dd oci-image"
+	builder.Reset()
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.OnMounted(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnMounted() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Mounted 0b442c23c1dd oci-image")
 }
 
 func TestTextCopyHandler_OnCopySkipped(t *testing.T) {
-	defer builder.Reset()
-	expected := "Exists  0b442c23c1dd oci-image"
+	builder.Reset()
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.OnCopySkipped(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnCopySkipped() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Exists  0b442c23c1dd oci-image")
 }
 
 func TestTextCopyHandler_PostCopy(t *testing.T) {
-	defer builder.Reset()
-	expected := "Copied  0b442c23c1dd oci-image"
+	builder.Reset()
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.PostCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PostCopy() should not return an error")
@@ -79,151 +77,104 @@ func TestTextCopyHandler_PostCopy(t *testing.T) {
 	if ch.PostCopy(ctx, bogus) == nil {
 		t.Error("PostCopy() should return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Copied  0b442c23c1dd oci-image")
 }
 
 func TestTextCopyHandler_PreCopy(t *testing.T) {
-	defer builder.Reset()
-	expected := "Copying 0b442c23c1dd oci-image"
+	builder.Reset()
 	ch := NewTextCopyHandler(printer, mockFetcher.Fetcher)
 	if ch.PreCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PreCopy() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Copying 0b442c23c1dd oci-image")
 }
 
 func TestTextPullHandler_OnNodeDownloaded(t *testing.T) {
-	defer builder.Reset()
-	expected := "Downloaded  0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeDownloaded(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeDownloaded() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Downloaded  0b442c23c1dd oci-image")
 }
 
 func TestTextPullHandler_OnNodeDownloading(t *testing.T) {
-	defer builder.Reset()
-	expected := "Downloading 0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeDownloading(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeDownloading() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Downloading 0b442c23c1dd oci-image")
 }
 
 func TestTextPullHandler_OnNodeProcessing(t *testing.T) {
-	defer builder.Reset()
-	expected := "Processing  0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeProcessing(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeProcessing() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Processing  0b442c23c1dd oci-image")
 }
 
 func TestTextPullHandler_OnNodeRestored(t *testing.T) {
-	defer builder.Reset()
-	expected := "Restored    0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeRestored(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeRestored() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Restored    0b442c23c1dd oci-image")
 }
 
 func TestTextPullHandler_OnNodeSkipped(t *testing.T) {
-	defer builder.Reset()
-	expected := "Skipped     0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPullHandler(printer)
 	if ph.OnNodeSkipped(mockFetcher.OciImage) != nil {
 		t.Error("OnNodeSkipped() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Skipped     0b442c23c1dd oci-image")
 }
 
 func TestTextPushHandler_OnCopySkipped(t *testing.T) {
-	defer builder.Reset()
-	expected := "Exists    0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.OnCopySkipped(ctx, mockFetcher.OciImage) != nil {
 		t.Error("OnCopySkipped() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Exists    0b442c23c1dd oci-image")
 }
 
 func TestTextPushHandler_OnEmptyArtifact(t *testing.T) {
-	defer builder.Reset()
-	expected := "Uploading empty artifact"
+	builder.Reset()
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.OnEmptyArtifact() != nil {
 		t.Error("OnEmptyArtifact() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Uploading empty artifact")
 }
 
 func TestTextPushHandler_OnFileLoading(t *testing.T) {
-	defer builder.Reset()
-	expected := ""
+	builder.Reset()
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.OnFileLoading("name") != nil {
 		t.Error("OnFileLoading() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "")
 }
 
 func TestTextPushHandler_PostCopy(t *testing.T) {
-	defer builder.Reset()
-	expected := "Uploaded  0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.PostCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PostCopy() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Uploaded  0b442c23c1dd oci-image")
 }
 
 func TestTextPushHandler_PreCopy(t *testing.T) {
-	defer builder.Reset()
-	expected := "Uploading 0b442c23c1dd oci-image"
+	builder.Reset()
 	ph := NewTextPushHandler(printer, mockFetcher.Fetcher)
 	if ph.PreCopy(ctx, mockFetcher.OciImage) != nil {
 		t.Error("PreCopy() should not return an error")
 	}
-	actual := strings.TrimSpace(builder.String())
-	if expected != actual {
-		t.Error("Output does not match expected <" + expected + "> actual <" + actual + ">")
-	}
+	validatePrinted(t, "Uploading 0b442c23c1dd oci-image")
 }

--- a/internal/testutils/error_fetcher.go
+++ b/internal/testutils/error_fetcher.go
@@ -1,0 +1,40 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"io"
+)
+
+// ErrorFetcher implements content.Fetcher.
+type ErrorFetcher struct {
+	ExpectedError error
+}
+
+// NewErrorFetcher create and error fetcher
+func NewErrorFetcher() *ErrorFetcher {
+	return &ErrorFetcher{
+		ExpectedError: fmt.Errorf("expected error"),
+	}
+}
+
+// Fetch returns an error.
+func (f *ErrorFetcher) Fetch(context.Context, ocispec.Descriptor) (io.ReadCloser, error) {
+	return nil, f.ExpectedError
+}

--- a/internal/testutils/fetcher.go
+++ b/internal/testutils/fetcher.go
@@ -19,32 +19,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
-
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras/internal/docker"
 )
-
-// ErrorFetcher implements content.Fetcher.
-type ErrorFetcher struct {
-	ExpectedError error
-}
-
-// NewErrorFetcher create and error fetcher
-func NewErrorFetcher() *ErrorFetcher {
-	return &ErrorFetcher{
-		ExpectedError: fmt.Errorf("expected error"),
-	}
-}
-
-// Fetch returns an error.
-func (f *ErrorFetcher) Fetch(context.Context, ocispec.Descriptor) (io.ReadCloser, error) {
-	return nil, f.ExpectedError
-}
 
 // MockFetcher implements content.Fetcher and populates a memory store.
 type MockFetcher struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

The text_test was a little wordy and I though the error fetcher would be easier to find in its own file.
