### PR TITLE
refactor: remove build constraint from testutils console

### DIFF
--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -1,5 +1,3 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**What this PR does / why we need it**:

This build constraint on testutils/console is not needed. When I'm trying to debug a build issue on mac, I have to remove this.
