### PR TITLE
refactor: create an interface for status console

### DIFF
--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -16,10 +16,9 @@ limitations under the License.
 package console
 
 import (
-	"os"
-
-	"github.com/containerd/console"
+	containerd "github.com/containerd/console"
 	"github.com/morikuni/aec"
+	"os"
 )
 
 const (
@@ -33,52 +32,67 @@ const (
 	Restore = "\0338"
 )
 
-// Console is a wrapper around containerd's console.Console and ANSI escape
-// codes.
-type Console struct {
-	console.Console
+// Console is a wrapper around containerd's Console and ANSI escape codes.
+type Console interface {
+	containerd.Console
+	GetHeightWidth() (height, width int)
+	Save()
+	NewRow()
+	OutputTo(upCnt uint, str string)
+	Restore()
+}
+
+type console struct {
+	containerd.Console
+}
+
+// NewConsole generates a console from a file.
+func NewConsole(f *os.File) (Console, error) {
+	c, err := containerd.ConsoleFromFile(f)
+	if err != nil {
+		return nil, err
+	}
+	return &console{c}, nil
 }
 
 // Size returns the width and height of the console.
 // If the console size cannot be determined, returns a default value of 80x10.
-func (c *Console) Size() (width, height int) {
-	width = MinWidth
-	height = MinHeight
-	size, err := c.Console.Size()
-	if err == nil {
-		if size.Height > MinHeight {
-			height = int(size.Height)
+func (c *console) Size() (size containerd.WinSize, err error) {
+	size, err = c.Console.Size()
+	if err != nil {
+		size.Height = MinHeight
+		size.Width = MinWidth
+	} else {
+		if size.Height < MinHeight {
+			size.Height = MinHeight
 		}
-		if size.Width > MinWidth {
-			width = int(size.Width)
+		if size.Width < MinWidth {
+			size.Width = MinWidth
 		}
 	}
 	return
 }
 
-// New generates a Console from a file.
-func New(f *os.File) (*Console, error) {
-	c, err := console.ConsoleFromFile(f)
-	if err != nil {
-		return nil, err
-	}
-	return &Console{c}, nil
+// GetHeightWidth returns the width and height of the console.
+func (c *console) GetHeightWidth() (height, width int) {
+	windowSize, _ := c.Size()
+	return int(windowSize.Height), int(windowSize.Width)
 }
 
 // Save saves the current cursor position.
-func (c *Console) Save() {
+func (c *console) Save() {
 	_, _ = c.Write([]byte(aec.Hide.Apply(Save)))
 }
 
 // NewRow allocates a horizontal space to the output area with scroll if needed.
-func (c *Console) NewRow() {
+func (c *console) NewRow() {
 	_, _ = c.Write([]byte(Restore))
 	_, _ = c.Write([]byte("\n"))
 	_, _ = c.Write([]byte(Save))
 }
 
 // OutputTo outputs a string to a specific line.
-func (c *Console) OutputTo(upCnt uint, str string) {
+func (c *console) OutputTo(upCnt uint, str string) {
 	_, _ = c.Write([]byte(Restore))
 	_, _ = c.Write([]byte(aec.PreviousLine(upCnt).Apply(str)))
 	_, _ = c.Write([]byte("\n"))
@@ -86,7 +100,7 @@ func (c *Console) OutputTo(upCnt uint, str string) {
 }
 
 // Restore restores the saved cursor position.
-func (c *Console) Restore() {
+func (c *console) Restore() {
 	// cannot use aec.Restore since DEC has better compatibility than SCO
 	_, _ = c.Write([]byte(Restore))
 	_, _ = c.Write([]byte(aec.Column(0).

--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -56,27 +56,19 @@ func NewConsole(f *os.File) (Console, error) {
 	return &console{c}, nil
 }
 
-// Size returns the width and height of the console.
-// If the console size cannot be determined, returns a default value of 80x10.
-func (c *console) Size() (size containerd.WinSize, err error) {
-	size, err = c.Console.Size()
-	if err != nil {
-		size.Height = MinHeight
-		size.Width = MinWidth
-	} else {
-		if size.Height < MinHeight {
-			size.Height = MinHeight
-		}
-		if size.Width < MinWidth {
-			size.Width = MinWidth
-		}
-	}
-	return
-}
-
 // GetHeightWidth returns the width and height of the console.
+// If the console size cannot be determined, returns a default value of 80x10.
 func (c *console) GetHeightWidth() (height, width int) {
-	windowSize, _ := c.Size()
+	windowSize, err := c.Console.Size()
+	if err != nil {
+		return MinHeight, MinWidth
+	}
+	if windowSize.Height < MinHeight {
+		windowSize.Height = MinHeight
+	}
+	if windowSize.Width < MinWidth {
+		windowSize.Width = MinWidth
+	}
 	return int(windowSize.Height), int(windowSize.Width)
 }
 

--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -16,9 +16,10 @@ limitations under the License.
 package console
 
 import (
+	"os"
+
 	containerd "github.com/containerd/console"
 	"github.com/morikuni/aec"
-	"os"
 )
 
 const (

--- a/cmd/oras/internal/display/status/console/console_test.go
+++ b/cmd/oras/internal/display/status/console/console_test.go
@@ -67,17 +67,6 @@ func TestNewConsole(t *testing.T) {
 	}
 }
 
-func TestConsole_Size(t *testing.T) {
-	c, _ := givenConsole(t)
-
-	size, err := c.Size()
-	if err != nil {
-		t.Fatalf("unexpected error getting size: %v", err)
-	}
-	validateSize(t, int(size.Width), int(size.Height), MinWidth, MinHeight)
-
-}
-
 func TestConsole_GetHeightWidth(t *testing.T) {
 	c, pty := givenConsole(t)
 

--- a/cmd/oras/internal/display/status/progress/manager.go
+++ b/cmd/oras/internal/display/status/progress/manager.go
@@ -44,15 +44,15 @@ type Manager interface {
 type manager struct {
 	status       []*status
 	statusLock   sync.RWMutex
-	console      *console.Console
+	console      console.Console
 	updating     sync.WaitGroup
 	renderDone   chan struct{}
 	renderClosed chan struct{}
 }
 
 // NewManager initialized a new progress manager.
-func NewManager(f *os.File) (Manager, error) {
-	c, err := console.New(f)
+func NewManager(tty *os.File) (Manager, error) {
+	c, err := console.NewConsole(tty)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (m *manager) render() {
 	m.statusLock.RLock()
 	defer m.statusLock.RUnlock()
 	// todo: update size in another routine
-	width, height := m.console.Size()
+	height, width := m.console.GetHeightWidth()
 	lineCount := len(m.status) * 2
 	offset := 0
 	if lineCount > height {

--- a/cmd/oras/internal/display/status/progress/manager_test.go
+++ b/cmd/oras/internal/display/status/progress/manager_test.go
@@ -31,10 +31,15 @@ func Test_manager_render(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer device.Close()
-	m := &manager{
-		console: &console.Console{Console: pty},
+	sole, err := console.NewConsole(device)
+	if err != nil {
+		t.Fatal(err)
 	}
-	_, height := m.console.Size()
+
+	m := &manager{
+		console: sole,
+	}
+	height, _ := m.console.GetHeightWidth()
 	for i := 0; i < height; i++ {
 		if _, err := m.Add(); err != nil {
 			t.Fatal(err)

--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -23,13 +23,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/console"
+	containerd "github.com/containerd/console"
 )
 
 // NewPty creates a new pty pair for testing, caller is responsible for closing
 // the returned device file if err is not nil.
-func NewPty() (console.Console, *os.File, error) {
-	pty, devicePath, err := console.NewPty()
+func NewPty() (containerd.Console, *os.File, error) {
+	pty, devicePath, err := containerd.NewPty()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -42,7 +42,7 @@ func NewPty() (console.Console, *os.File, error) {
 
 // MatchPty checks that the output matches the expected strings in specified
 // order.
-func MatchPty(pty console.Console, device *os.File, expected ...string) error {
+func MatchPty(pty containerd.Console, device *os.File, expected ...string) error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	var buffer bytes.Buffer


### PR DESCRIPTION
**What this PR does / why we need it**:

Create a interface for console so that alternate implementations can exist. In doing this, I found the `Size()` method was not properly implemented, so I created a `GetHeightWidth()` method.

Partial: https://github.com/oras-project/oras/issues/1461
