### PR TITLE
chore: reset test coverage package list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ LDFLAGS += -X $(PROJECT_PKG)/internal/version.GitTreeState=${GIT_DIRTY}
 
 .PHONY: test
 test: tidy vendor check-encoding  ## tidy and run tests
-	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=$($(GO_EXE) list ./... | grep -v internal/testutils | tr '\n' ',') ./...
+	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...
 
 .PHONY: teste2e
 teste2e:  ## run end to end tests


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change, the nested $() in Makefile `$(GO_EXE) list ./... | grep -v internal/testutils | tr '\n' ','` generates empty return value so `-coverpkg` is actually set to `''`


**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
