### PR TITLE
refactor: create tty copy handler

### DIFF
--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -215,6 +215,9 @@ func NewManifestIndexUpdateHandler(outputPath string, printer *output.Printer, p
 }
 
 // NewCopyHandler returns copy handlers.
-func NewCopyHandler(printer *output.Printer, fetcher fetcher.Fetcher) (status.CopyHandler, metadata.CopyHandler) {
+func NewCopyHandler(printer *output.Printer, tty *os.File, fetcher fetcher.Fetcher) (status.CopyHandler, metadata.CopyHandler) {
+	if tty != nil {
+		return status.NewTTYCopyHandler(tty), text.NewCopyHandler(printer)
+	}
 	return status.NewTextCopyHandler(printer, fetcher), text.NewCopyHandler(printer)
 }

--- a/cmd/oras/internal/display/handler_test.go
+++ b/cmd/oras/internal/display/handler_test.go
@@ -18,6 +18,7 @@ package display
 import (
 	"oras.land/oras/internal/testutils"
 	"os"
+	"reflect"
 	"testing"
 
 	"oras.land/oras/cmd/oras/internal/display/metadata/text"
@@ -28,7 +29,7 @@ import (
 
 func TestNewPushHandler(t *testing.T) {
 	mockFetcher := testutils.NewMockFetcher()
-	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
+	printer := output.NewPrinter(os.Stdout, os.Stderr)
 	_, _, err := NewPushHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout, mockFetcher.Fetcher)
 	if err != nil {
 		t.Errorf("NewPushHandler() error = %v, want nil", err)
@@ -37,7 +38,7 @@ func TestNewPushHandler(t *testing.T) {
 
 func TestNewAttachHandler(t *testing.T) {
 	mockFetcher := testutils.NewMockFetcher()
-	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
+	printer := output.NewPrinter(os.Stdout, os.Stderr)
 	_, _, err := NewAttachHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout, mockFetcher.Fetcher)
 	if err != nil {
 		t.Errorf("NewAttachHandler() error = %v, want nil", err)
@@ -45,7 +46,7 @@ func TestNewAttachHandler(t *testing.T) {
 }
 
 func TestNewPullHandler(t *testing.T) {
-	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
+	printer := output.NewPrinter(os.Stdout, os.Stderr)
 	_, _, err := NewPullHandler(printer, option.Format{Type: option.FormatTypeText.Name}, "", os.Stdout)
 	if err != nil {
 		t.Errorf("NewPullHandler() error = %v, want nil", err)
@@ -53,7 +54,7 @@ func TestNewPullHandler(t *testing.T) {
 }
 
 func TestNewCopyHandler(t *testing.T) {
-	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
+	printer := output.NewPrinter(os.Stdout, os.Stderr)
 	copyHandler, copyMetadataHandler := NewCopyHandler(printer, os.Stdout, nil)
 	if _, ok := copyHandler.(*status.TTYCopyHandler); !ok {
 		t.Errorf("expected *status.TTYCopyHandler actual %v", reflect.TypeOf(copyHandler))

--- a/cmd/oras/internal/display/handler_test.go
+++ b/cmd/oras/internal/display/handler_test.go
@@ -16,18 +16,19 @@ limitations under the License.
 package display
 
 import (
+	"oras.land/oras/internal/testutils"
 	"os"
 	"testing"
 
-	"oras.land/oras/internal/testutils"
-
+	"oras.land/oras/cmd/oras/internal/display/metadata/text"
+	"oras.land/oras/cmd/oras/internal/display/status"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/cmd/oras/internal/output"
 )
 
 func TestNewPushHandler(t *testing.T) {
 	mockFetcher := testutils.NewMockFetcher()
-	printer := output.NewPrinter(os.Stdout, os.Stderr)
+	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
 	_, _, err := NewPushHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout, mockFetcher.Fetcher)
 	if err != nil {
 		t.Errorf("NewPushHandler() error = %v, want nil", err)
@@ -36,7 +37,7 @@ func TestNewPushHandler(t *testing.T) {
 
 func TestNewAttachHandler(t *testing.T) {
 	mockFetcher := testutils.NewMockFetcher()
-	printer := output.NewPrinter(os.Stdout, os.Stderr)
+	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
 	_, _, err := NewAttachHandler(printer, option.Format{Type: option.FormatTypeText.Name}, os.Stdout, mockFetcher.Fetcher)
 	if err != nil {
 		t.Errorf("NewAttachHandler() error = %v, want nil", err)
@@ -44,9 +45,27 @@ func TestNewAttachHandler(t *testing.T) {
 }
 
 func TestNewPullHandler(t *testing.T) {
-	printer := output.NewPrinter(os.Stdout, os.Stderr)
+	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
 	_, _, err := NewPullHandler(printer, option.Format{Type: option.FormatTypeText.Name}, "", os.Stdout)
 	if err != nil {
 		t.Errorf("NewPullHandler() error = %v, want nil", err)
+	}
+}
+
+func TestNewCopyHandler(t *testing.T) {
+	printer := output.NewPrinter(os.Stdout, os.Stderr, false)
+	copyHandler, copyMetadataHandler := NewCopyHandler(printer, os.Stdout, nil)
+	if _, ok := copyHandler.(*status.TTYCopyHandler); !ok {
+		t.Errorf("expected *status.TTYCopyHandler actual %v", reflect.TypeOf(copyHandler))
+	}
+	if _, ok := copyMetadataHandler.(*text.CopyHandler); !ok {
+		t.Errorf("expected metadata.CopyHandler actual %v", reflect.TypeOf(copyMetadataHandler))
+	}
+	copyHandler, copyMetadataHandler = NewCopyHandler(printer, nil, nil)
+	if _, ok := copyHandler.(*status.TextCopyHandler); !ok {
+		t.Errorf("expected *status.TextCopyHandler actual %v", reflect.TypeOf(copyHandler))
+	}
+	if _, ok := copyMetadataHandler.(*text.CopyHandler); !ok {
+		t.Errorf("expected metadata.CopyHandler actual %v", reflect.TypeOf(copyMetadataHandler))
 	}
 }

--- a/cmd/oras/internal/display/status/interface.go
+++ b/cmd/oras/internal/display/status/interface.go
@@ -62,6 +62,8 @@ type CopyHandler interface {
 	PreCopy(ctx context.Context, desc ocispec.Descriptor) error
 	PostCopy(ctx context.Context, desc ocispec.Descriptor) error
 	OnMounted(ctx context.Context, desc ocispec.Descriptor) error
+	StartTracking(gt oras.GraphTarget) (oras.GraphTarget, error)
+	StopTracking()
 }
 
 // ManifestIndexCreateHandler handles status output for manifest index create command.

--- a/cmd/oras/internal/display/status/interface.go
+++ b/cmd/oras/internal/display/status/interface.go
@@ -63,7 +63,7 @@ type CopyHandler interface {
 	PostCopy(ctx context.Context, desc ocispec.Descriptor) error
 	OnMounted(ctx context.Context, desc ocispec.Descriptor) error
 	StartTracking(gt oras.GraphTarget) (oras.GraphTarget, error)
-	StopTracking()
+	StopTracking() error
 }
 
 // ManifestIndexCreateHandler handles status output for manifest index create command.

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -151,6 +151,15 @@ func NewTextCopyHandler(printer *output.Printer, fetcher content.Fetcher) CopyHa
 	}
 }
 
+// StartTracking starts a tracked target from a graph target.
+func (ch *TextCopyHandler) StartTracking(gt oras.GraphTarget) (oras.GraphTarget, error) {
+	return gt, nil
+}
+
+// StopTracking ends the copy tracking for the target.
+func (ch *TextCopyHandler) StopTracking() {
+}
+
 // OnCopySkipped is called when an object already exists.
 func (ch *TextCopyHandler) OnCopySkipped(_ context.Context, desc ocispec.Descriptor) error {
 	ch.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -157,7 +157,8 @@ func (ch *TextCopyHandler) StartTracking(gt oras.GraphTarget) (oras.GraphTarget,
 }
 
 // StopTracking ends the copy tracking for the target.
-func (ch *TextCopyHandler) StopTracking() {
+func (ch *TextCopyHandler) StopTracking() error {
+	return nil
 }
 
 // OnCopySkipped is called when an object already exists.

--- a/cmd/oras/internal/display/status/tty.go
+++ b/cmd/oras/internal/display/status/tty.go
@@ -143,3 +143,62 @@ func (ph *TTYPullHandler) TrackTarget(gt oras.GraphTarget) (oras.GraphTarget, St
 	ph.tracked = tracked
 	return tracked, tracked.Close, nil
 }
+
+// TTYCopyHandler handles tty status output for copy events.
+type TTYCopyHandler struct {
+	tty       *os.File
+	committed *sync.Map
+	tracked   track.GraphTarget
+}
+
+// NewTTYCopyHandler returns a new handler for copy command.
+func NewTTYCopyHandler(tty *os.File) CopyHandler {
+	return &TTYCopyHandler{
+		tty:       tty,
+		committed: &sync.Map{},
+	}
+}
+
+// StartTracking returns a tracked target from a graph target.
+func (ch *TTYCopyHandler) StartTracking(gt oras.GraphTarget) (oras.GraphTarget, error) {
+	tracked, err := track.NewTarget(gt, copyPromptCopying, copyPromptCopied, ch.tty)
+	ch.tracked = tracked
+	return tracked, err
+}
+
+// StopTracking ends the copy tracking for the target.
+func (ch *TTYCopyHandler) StopTracking() {
+	_ = ch.tracked.Close()
+}
+
+// OnCopySkipped is called when an object already exists.
+func (ch *TTYCopyHandler) OnCopySkipped(_ context.Context, desc ocispec.Descriptor) error {
+	ch.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	return ch.tracked.Prompt(desc, copyPromptExists)
+}
+
+// PreCopy implements PreCopy of CopyHandler.
+func (ch *TTYCopyHandler) PreCopy(_ context.Context, _ ocispec.Descriptor) error {
+	return nil
+}
+
+// PostCopy implements PostCopy of CopyHandler.
+func (ch *TTYCopyHandler) PostCopy(ctx context.Context, desc ocispec.Descriptor) error {
+	ch.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	successors, err := graph.FilteredSuccessors(ctx, desc, ch.tracked, DeduplicatedFilter(ch.committed))
+	if err != nil {
+		return err
+	}
+	for _, successor := range successors {
+		if err = ch.tracked.Prompt(successor, copyPromptSkipped); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// OnMounted implements OnMounted of CopyHandler.
+func (ch *TTYCopyHandler) OnMounted(_ context.Context, desc ocispec.Descriptor) error {
+	ch.committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
+	return ch.tracked.Prompt(desc, copyPromptMounted)
+}

--- a/cmd/oras/internal/display/status/tty_console_test.go
+++ b/cmd/oras/internal/display/status/tty_console_test.go
@@ -106,7 +106,7 @@ func TestTTYCopyHandler_OnMounted(t *testing.T) {
 		t.Fatalf("StopTracking() should not return an error: %v", err)
 	}
 
-	if err = testutils.MatchPty(pty, slave, "✓", "Mounted", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100%", mockFetcher.OciImage.Digest.String()); err != nil {
+	if err = testutils.MatchPty(pty, slave, "✓", "Mounted", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100.00%", mockFetcher.OciImage.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/internal/display/status/tty_console_test.go
+++ b/cmd/oras/internal/display/status/tty_console_test.go
@@ -127,8 +127,10 @@ func TestTTYCopyHandler_OnCopySkipped(t *testing.T) {
 		t.Errorf("OnCopySkipped() should not return an error: %v", err)
 	}
 
-	ch.StopTracking()
-	if err = testutils.MatchPty(pty, slave, "Exists", mockFetcher.OciImage.MediaType, strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100%"); err != nil {
+	if err = ch.StopTracking(); err != nil {
+		t.Errorf("StopTracking() should not return an error: %v", err)
+	}
+	if err = testutils.MatchPty(pty, slave, "Exists", "oci-image", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100.00%"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -144,12 +146,14 @@ func TestTTYCopyHandler_PostCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ch.StopTracking()
 
 	if ch.PostCopy(ctx, bogus) == nil {
 		t.Error("PostCopy() should return an error")
 	}
 
+	if err = ch.StopTracking(); err != nil {
+		t.Errorf("StopTracking() should not return an error: %v", err)
+	}
 	if err = testutils.MatchPty(pty, slave, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
 		t.Fatal(err)
 	}
@@ -166,12 +170,14 @@ func TestTTYCopyHandler_PreCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ch.StopTracking()
 
 	if err = ch.PreCopy(ctx, mockFetcher.OciImage); err != nil {
 		t.Errorf("PreCopy() should not return an error: %v", err)
 	}
 
+	if err = ch.StopTracking(); err != nil {
+		t.Errorf("StopTracking() should not return an error: %v", err)
+	}
 	if err = testutils.MatchPty(pty, slave, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/oras/internal/display/status/tty_console_test.go
+++ b/cmd/oras/internal/display/status/tty_console_test.go
@@ -18,10 +18,12 @@ limitations under the License.
 package status
 
 import (
+	"strconv"
+	"testing"
+
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras/internal/testutils"
-	"testing"
 )
 
 type testGraphTarget struct {
@@ -117,13 +119,13 @@ func TestTTYCopyHandler_OnCopySkipped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ch.StopTracking()
 
 	if err = ch.OnCopySkipped(ctx, mockFetcher.OciImage); err != nil {
 		t.Errorf("OnCopySkipped() should not return an error: %v", err)
 	}
 
-	if err = testutils.MatchPty(pty, slave, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
+	ch.StopTracking()
+	if err = testutils.MatchPty(pty, slave, "Exists", mockFetcher.OciImage.MediaType, strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100%"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/internal/display/status/tty_console_test.go
+++ b/cmd/oras/internal/display/status/tty_console_test.go
@@ -97,13 +97,16 @@ func TestTTYCopyHandler_OnMounted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ch.StopTracking()
 
 	if err = ch.OnMounted(ctx, mockFetcher.OciImage); err != nil {
-		t.Errorf("OnMounted() should not return an error: %v", err)
+		t.Fatalf("OnMounted() should not return an error: %v", err)
 	}
 
-	if err = testutils.MatchPty(pty, slave, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
+	if err = ch.StopTracking(); err != nil {
+		t.Fatalf("StopTracking() should not return an error: %v", err)
+	}
+
+	if err = testutils.MatchPty(pty, slave, "✓", "Mounted", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100%", mockFetcher.OciImage.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -174,7 +174,12 @@ func doCopy(ctx context.Context, copyHandler status.CopyHandler, src oras.ReadOn
 	if err != nil {
 		return desc, err
 	}
-	defer copyHandler.StopTracking()
+	defer func() {
+		stopErr := copyHandler.StopTracking()
+		if err == nil {
+			err = stopErr
+		}
+	}()
 	extendedCopyOptions.OnCopySkipped = copyHandler.OnCopySkipped
 	extendedCopyOptions.PreCopy = copyHandler.PreCopy
 	extendedCopyOptions.PostCopy = copyHandler.PostCopy

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -128,9 +128,9 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 		return err
 	}
 	ctx = registryutil.WithScopeHint(ctx, dst, auth.ActionPull, auth.ActionPush)
-	copyHandler, handler := display.NewCopyHandler(opts.Printer, opts.TTY, dst)
+	statusHandler, metadataHandler := display.NewCopyHandler(opts.Printer, opts.TTY, dst)
 
-	desc, err := doCopy(ctx, copyHandler, src, dst, opts)
+	desc, err := doCopy(ctx, statusHandler, src, dst, opts)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 	if len(opts.extraRefs) != 0 {
 		tagNOpts := oras.DefaultTagNOptions
 		tagNOpts.Concurrency = opts.concurrency
-		tagListener := listener.NewTaggedListener(dst, handler.OnTagged)
+		tagListener := listener.NewTaggedListener(dst, metadataHandler.OnTagged)
 		if _, err = oras.TagN(ctx, tagListener, opts.To.Reference, opts.extraRefs, tagNOpts); err != nil {
 			return err
 		}

--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
-
-	"oras.land/oras/cmd/oras/internal/display/status"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -36,7 +33,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/argument"
 	"oras.land/oras/cmd/oras/internal/command"
 	"oras.land/oras/cmd/oras/internal/display"
-	"oras.land/oras/cmd/oras/internal/display/status/track"
+	"oras.land/oras/cmd/oras/internal/display/status"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/docker"
@@ -131,7 +128,7 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 		return err
 	}
 	ctx = registryutil.WithScopeHint(ctx, dst, auth.ActionPull, auth.ActionPush)
-	copyHandler, handler := display.NewCopyHandler(opts.Printer, dst)
+	copyHandler, handler := display.NewCopyHandler(opts.Printer, opts.TTY, dst)
 
 	desc, err := doCopy(ctx, copyHandler, src, dst, opts)
 	if err != nil {
@@ -158,22 +155,14 @@ func runCopy(cmd *cobra.Command, opts *copyOptions) error {
 	return nil
 }
 
-func doCopy(ctx context.Context, copyHandler status.CopyHandler, src oras.ReadOnlyGraphTarget, dst oras.GraphTarget, opts *copyOptions) (ocispec.Descriptor, error) {
+func doCopy(ctx context.Context, copyHandler status.CopyHandler, src oras.ReadOnlyGraphTarget, dst oras.GraphTarget, opts *copyOptions) (desc ocispec.Descriptor, err error) {
 	// Prepare copy options
-	committed := &sync.Map{}
 	extendedCopyOptions := oras.DefaultExtendedCopyOptions
 	extendedCopyOptions.Concurrency = opts.concurrency
 	extendedCopyOptions.FindPredecessors = func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		return registry.Referrers(ctx, src, desc, "")
 	}
 
-	const (
-		promptExists  = "Exists "
-		promptCopying = "Copying"
-		promptCopied  = "Copied "
-		promptSkipped = "Skipped"
-		promptMounted = "Mounted"
-	)
 	srcRepo, srcIsRemote := src.(*remote.Repository)
 	dstRepo, dstIsRemote := dst.(*remote.Repository)
 	if srcIsRemote && dstIsRemote && srcRepo.Reference.Registry == dstRepo.Reference.Registry {
@@ -181,45 +170,16 @@ func doCopy(ctx context.Context, copyHandler status.CopyHandler, src oras.ReadOn
 			return []string{srcRepo.Reference.Repository}, nil
 		}
 	}
-	if opts.TTY == nil {
-		// no TTY output
-		extendedCopyOptions.OnCopySkipped = copyHandler.OnCopySkipped
-		extendedCopyOptions.PreCopy = copyHandler.PreCopy
-		extendedCopyOptions.PostCopy = copyHandler.PostCopy
-		extendedCopyOptions.OnMounted = copyHandler.OnMounted
-	} else {
-		// TTY output
-		tracked, err := track.NewTarget(dst, promptCopying, promptCopied, opts.TTY)
-		if err != nil {
-			return ocispec.Descriptor{}, err
-		}
-		defer tracked.Close()
-		dst = tracked
-		extendedCopyOptions.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
-			committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-			return tracked.Prompt(desc, promptExists)
-		}
-		extendedCopyOptions.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
-			committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-			successors, err := graph.FilteredSuccessors(ctx, desc, tracked, status.DeduplicatedFilter(committed))
-			if err != nil {
-				return err
-			}
-			for _, successor := range successors {
-				if err = tracked.Prompt(successor, promptSkipped); err != nil {
-					return err
-				}
-			}
-			return nil
-		}
-		extendedCopyOptions.OnMounted = func(ctx context.Context, desc ocispec.Descriptor) error {
-			committed.Store(desc.Digest.String(), desc.Annotations[ocispec.AnnotationTitle])
-			return tracked.Prompt(desc, promptMounted)
-		}
+	dst, err = copyHandler.StartTracking(dst)
+	if err != nil {
+		return desc, err
 	}
+	defer copyHandler.StopTracking()
+	extendedCopyOptions.OnCopySkipped = copyHandler.OnCopySkipped
+	extendedCopyOptions.PreCopy = copyHandler.PreCopy
+	extendedCopyOptions.PostCopy = copyHandler.PostCopy
+	extendedCopyOptions.OnMounted = copyHandler.OnMounted
 
-	var desc ocispec.Descriptor
-	var err error
 	rOpts := oras.DefaultResolveOptions
 	rOpts.TargetPlatform = opts.Platform.Platform
 	if opts.recursive {

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -158,7 +158,7 @@ func Test_doCopy_skipped(t *testing.T) {
 	dst := memory.New()
 	builder := &strings.Builder{}
 	printer := output.NewPrinter(builder, os.Stderr)
-	handler := status.NewTextCopyHandler(printer, dst)
+	handler := status.NewTextCopyHandler(printer, memStore)
 
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, memStore, &opts)

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -24,8 +24,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"oras.land/oras/cmd/oras/internal/display/status"
-	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"strings"
 	"testing"
@@ -131,11 +129,10 @@ func Test_doCopy(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
-	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
 	dst := memory.New()
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	printer := output.NewPrinter(builder, os.Stderr)
 	handler := status.NewTextCopyHandler(printer, dst)
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, dst, &opts)
@@ -157,11 +154,10 @@ func Test_doCopy_skipped(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
-	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
 	dst := memory.New()
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	printer := output.NewPrinter(builder, os.Stderr)
 	handler := status.NewTextCopyHandler(printer, dst)
 
 	// test
@@ -184,7 +180,6 @@ func Test_doCopy_mounted(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
-	opts.Verbose = true
 	opts.From.Reference = manifestDigest
 	// mocked repositories
 	from, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, repoFrom))

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -33,7 +32,6 @@ import (
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/display/status"
-	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/testutils"
 )
 
@@ -131,9 +129,7 @@ func Test_doCopy(t *testing.T) {
 	opts.TTY = slave
 	opts.From.Reference = memDesc.Digest.String()
 	dst := memory.New()
-	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr)
-	handler := status.NewTextCopyHandler(printer, dst)
+	handler := status.NewTTYCopyHandler(opts.TTY)
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, dst, &opts)
 	if err != nil {
@@ -155,9 +151,7 @@ func Test_doCopy_skipped(t *testing.T) {
 	var opts copyOptions
 	opts.TTY = slave
 	opts.From.Reference = memDesc.Digest.String()
-	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr)
-	handler := status.NewTextCopyHandler(printer, memStore)
+	handler := status.NewTTYCopyHandler(opts.TTY)
 
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, memStore, &opts)
@@ -191,10 +185,7 @@ func Test_doCopy_mounted(t *testing.T) {
 		t.Fatal(err)
 	}
 	to.PlainHTTP = true
-	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr)
-	printer.Verbose = true
-	handler := status.NewTextCopyHandler(printer, to)
+	handler := status.NewTTYCopyHandler(opts.TTY)
 
 	// test
 	_, err = doCopy(context.Background(), handler, from, to, &opts)

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -24,17 +24,18 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"oras.land/oras/cmd/oras/internal/display/status"
+	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"strings"
 	"testing"
-
-	"oras.land/oras/cmd/oras/internal/display/status"
-	"oras.land/oras/cmd/oras/internal/output"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras/cmd/oras/internal/display/status"
+	"oras.land/oras/cmd/oras/internal/output"
 	"oras.land/oras/internal/testutils"
 )
 
@@ -130,11 +131,11 @@ func Test_doCopy(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
+	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
 	dst := memory.New()
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr)
-	printer.Verbose = true
+	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
 	handler := status.NewTextCopyHandler(printer, dst)
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, dst, &opts)
@@ -156,11 +157,12 @@ func Test_doCopy_skipped(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
+	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
+	dst := memory.New()
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr)
-	printer.Verbose = true
-	handler := status.NewTextCopyHandler(printer, memStore)
+	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	handler := status.NewTextCopyHandler(printer, dst)
 
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, memStore, &opts)
@@ -182,6 +184,7 @@ func Test_doCopy_mounted(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
+	opts.Verbose = true
 	opts.From.Reference = manifestDigest
 	// mocked repositories
 	from, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, repoFrom))

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -155,7 +155,6 @@ func Test_doCopy_skipped(t *testing.T) {
 	var opts copyOptions
 	opts.TTY = slave
 	opts.From.Reference = memDesc.Digest.String()
-	dst := memory.New()
 	builder := &strings.Builder{}
 	printer := output.NewPrinter(builder, os.Stderr)
 	handler := status.NewTextCopyHandler(printer, memStore)


### PR DESCRIPTION
**What this PR does / why we need it**:

Create tty copy handler with new `StartTracking` and `StopTracking` methods.

Partial: https://github.com/oras-project/oras/issues/1542
Closes: https://github.com/oras-project/oras/issues/1548
