### PR TITLE
feat: --output for `oras manifest index create`

### DIFF
--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -76,6 +76,9 @@ Example - create an index and push to an OCI image layout folder 'layout-dir' an
 
 Example - create an index and save it locally to index.json, auto push will be disabled:
   oras manifest index create --output index.json localhost:5000/hello linux-amd64 linux-arm64
+
+Example - create an index and output the index to stdout, auto push will be disabled:
+  oras manifest index create --output - localhost:5000/hello linux-arm64
 `,
 		Args: oerrors.CheckArgs(argument.AtLeast(1), "the destination index to create."),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -46,7 +46,6 @@ type createOptions struct {
 	option.Common
 	option.Packer
 	option.Target
-	option.Pretty
 
 	sources   []string
 	extraRefs []string
@@ -70,6 +69,9 @@ Example - create an index from source manifests using both tags and digests, and
 
 Example - create an index and push it with multiple tags:
   oras manifest index create localhost:5000/hello:tag1,tag2,tag3 linux-amd64 linux-arm64 sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
+
+Example - create an index and push to an OCI image layout folder 'layout-dir' and tag with 'v1':
+  oras manifest index create layout-dir:v1 linux-amd64 sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
 
 Example - create an index and export it to index.json, auto push will be disabled:
   oras manifest index create --export-manifest index.json localhost:5000/hello linux-amd64 linux-arm64

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -78,7 +78,7 @@ Example - create an index and save it locally to index.json, auto push will be d
   oras manifest index create --output index.json localhost:5000/hello linux-amd64 linux-arm64
 
 Example - create an index and output the index to stdout, auto push will be disabled:
-  oras manifest index create --output - localhost:5000/hello linux-arm64
+  oras manifest index create localhost:5000/hello linux-arm64 --output - --pretty
 `,
 		Args: oerrors.CheckArgs(argument.AtLeast(1), "the destination index to create."),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/test/e2e/internal/testdata/multi_arch/const.go
+++ b/test/e2e/internal/testdata/multi_arch/const.go
@@ -97,3 +97,8 @@ var (
 		},
 	}
 )
+
+// exported index
+var (
+	CreatedIndex = `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:9d84a5716c66a1d1b9c13f8ed157ba7d1edfe7f9b8766728b8a1f25c0d9c14c1","size":458,"platform":{"architecture":"amd64","os":"linux"}}]}`
+)

--- a/test/e2e/suite/command/manifest_index.go
+++ b/test/e2e/suite/command/manifest_index.go
@@ -143,7 +143,7 @@ var _ = Describe("1.1 registry users:", func() {
 			testRepo := indexTestRepo("create", "output-to-stdout")
 			CopyZOTRepo(ImageRepo, testRepo)
 			ORAS("manifest", "index", "create", RegistryRef(ZOTHost, testRepo, ""), string(multi_arch.LinuxAMD64.Digest),
-				"--output", "-").MatchKeyWords("application/vnd.oci.image.index.v1+json").Exec()
+				"--output", "-").MatchKeyWords(multi_arch.CreatedIndex).Exec()
 		})
 
 		It("should fail if given a reference that does not exist in the repo", func() {
@@ -239,7 +239,7 @@ var _ = Describe("OCI image layout users:", func() {
 			root := PrepareTempOCI(ImageRepo)
 			indexRef := LayoutRef(root, "output-to-stdout")
 			ORAS("manifest", "index", "create", Flags.Layout, indexRef, string(multi_arch.LinuxAMD64.Digest),
-				"--output", "-").MatchKeyWords("application/vnd.oci.image.index.v1+json").Exec()
+				"--output", "-").MatchKeyWords(multi_arch.CreatedIndex).Exec()
 		})
 
 		It("should fail if given a reference that does not exist in the repo", func() {

--- a/test/e2e/suite/command/manifest_index.go
+++ b/test/e2e/suite/command/manifest_index.go
@@ -18,6 +18,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -130,6 +131,14 @@ var _ = Describe("1.1 registry users:", func() {
 			ValidateIndex(content, expectedManifests)
 		})
 
+		It("should output created index to file", func() {
+			testRepo := indexTestRepo("create", "export-manifest")
+			CopyZOTRepo(ImageRepo, testRepo)
+			filePath := filepath.Join(GinkgoT().TempDir(), "createdIndex")
+			ORAS("manifest", "index", "create", RegistryRef(ZOTHost, testRepo, ""), string(multi_arch.LinuxAMD64.Digest), "--export-manifest", filePath).Exec()
+			MatchFile(filePath, multi_arch.CreatedIndex, DefaultTimeout)
+		})
+
 		It("should fail if given a reference that does not exist in the repo", func() {
 			testRepo := indexTestRepo("create", "nonexist-ref")
 			CopyZOTRepo(ImageRepo, testRepo)
@@ -209,6 +218,14 @@ var _ = Describe("OCI image layout users:", func() {
 			content := ORAS("manifest", "fetch", Flags.Layout, indexRef).Exec().Out.Contents()
 			expectedManifests := []ocispec.Descriptor{nonjson_config.Descriptor}
 			ValidateIndex(content, expectedManifests)
+		})
+
+		It("should output created index to file", func() {
+			root := PrepareTempOCI(ImageRepo)
+			indexRef := LayoutRef(root, "export-manifest")
+			filePath := filepath.Join(GinkgoT().TempDir(), "createdIndex")
+			ORAS("manifest", "index", "create", Flags.Layout, indexRef, string(multi_arch.LinuxAMD64.Digest), "--export-manifest", filePath).Exec()
+			MatchFile(filePath, multi_arch.CreatedIndex, DefaultTimeout)
 		})
 
 		It("should fail if given a reference that does not exist in the repo", func() {

--- a/test/e2e/suite/command/manifest_index.go
+++ b/test/e2e/suite/command/manifest_index.go
@@ -139,6 +139,13 @@ var _ = Describe("1.1 registry users:", func() {
 			MatchFile(filePath, multi_arch.CreatedIndex, DefaultTimeout)
 		})
 
+		It("should output created index to stdout", func() {
+			testRepo := indexTestRepo("create", "output-to-stdout")
+			CopyZOTRepo(ImageRepo, testRepo)
+			ORAS("manifest", "index", "create", RegistryRef(ZOTHost, testRepo, ""), string(multi_arch.LinuxAMD64.Digest),
+				"--output", "-").MatchKeyWords("application/vnd.oci.image.index.v1+json").Exec()
+		})
+
 		It("should fail if given a reference that does not exist in the repo", func() {
 			testRepo := indexTestRepo("create", "nonexist-ref")
 			CopyZOTRepo(ImageRepo, testRepo)
@@ -226,6 +233,13 @@ var _ = Describe("OCI image layout users:", func() {
 			filePath := filepath.Join(GinkgoT().TempDir(), "createdIndex")
 			ORAS("manifest", "index", "create", Flags.Layout, indexRef, string(multi_arch.LinuxAMD64.Digest), "--output", filePath).Exec()
 			MatchFile(filePath, multi_arch.CreatedIndex, DefaultTimeout)
+		})
+
+		It("should output created index to stdout", func() {
+			root := PrepareTempOCI(ImageRepo)
+			indexRef := LayoutRef(root, "output-to-stdout")
+			ORAS("manifest", "index", "create", Flags.Layout, indexRef, string(multi_arch.LinuxAMD64.Digest),
+				"--output", "-").MatchKeyWords("application/vnd.oci.image.index.v1+json").Exec()
 		})
 
 		It("should fail if given a reference that does not exist in the repo", func() {

--- a/test/e2e/suite/command/manifest_index.go
+++ b/test/e2e/suite/command/manifest_index.go
@@ -132,10 +132,10 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 
 		It("should output created index to file", func() {
-			testRepo := indexTestRepo("create", "export-manifest")
+			testRepo := indexTestRepo("create", "output-to-file")
 			CopyZOTRepo(ImageRepo, testRepo)
 			filePath := filepath.Join(GinkgoT().TempDir(), "createdIndex")
-			ORAS("manifest", "index", "create", RegistryRef(ZOTHost, testRepo, ""), string(multi_arch.LinuxAMD64.Digest), "--export-manifest", filePath).Exec()
+			ORAS("manifest", "index", "create", RegistryRef(ZOTHost, testRepo, ""), string(multi_arch.LinuxAMD64.Digest), "--output", filePath).Exec()
 			MatchFile(filePath, multi_arch.CreatedIndex, DefaultTimeout)
 		})
 
@@ -222,9 +222,9 @@ var _ = Describe("OCI image layout users:", func() {
 
 		It("should output created index to file", func() {
 			root := PrepareTempOCI(ImageRepo)
-			indexRef := LayoutRef(root, "export-manifest")
+			indexRef := LayoutRef(root, "output-to-file")
 			filePath := filepath.Join(GinkgoT().TempDir(), "createdIndex")
-			ORAS("manifest", "index", "create", Flags.Layout, indexRef, string(multi_arch.LinuxAMD64.Digest), "--export-manifest", filePath).Exec()
+			ORAS("manifest", "index", "create", Flags.Layout, indexRef, string(multi_arch.LinuxAMD64.Digest), "--output", filePath).Exec()
 			MatchFile(filePath, multi_arch.CreatedIndex, DefaultTimeout)
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

current output:
```
oras manifest index create myregistry.azurecr.io/test sha256:42c524c48e0672568dbd2842d3a0cb34a415347145ee9fe1c8abaf65e7455b46 --output - --pretty
Fetching sha256:42c524c48e0672568dbd2842d3a0cb34a415347145ee9fe1c8abaf65e7455b46
Fetched  sha256:42c524c48e0672568dbd2842d3a0cb34a415347145ee9fe1c8abaf65e7455b46
Packed   f16df862b7e3 application/vnd.oci.image.index.v1+json
Digest: sha256:f16df862b7e3d4f13c03d59655ed25a71a68e01e4aeec0d921d7310d6c67a360
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:42c524c48e0672568dbd2842d3a0cb34a415347145ee9fe1c8abaf65e7455b46",
      "size": 1239,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    }
  ]
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1053 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
