### PR TITLE
feat: add platform option to push command

### DIFF
--- a/cmd/oras/internal/option/platform.go
+++ b/cmd/oras/internal/option/platform.go
@@ -40,7 +40,7 @@ func (opts *Platform) ApplyFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&opts.platform, "platform", "", "", opts.FlagDescription+" in the form of `os[/arch][/variant][:os_version]`")
 }
 
-// parse parses the input platform flag to an oci platform type.
+// Parse parses the input platform flag to an oci platform type.
 func (opts *Platform) Parse(*cobra.Command) error {
 	if opts.platform == "" {
 		return nil
@@ -72,4 +72,20 @@ func (opts *Platform) Parse(*cobra.Command) error {
 	}
 	opts.Platform = &p
 	return nil
+}
+
+// ArtifactPlatform option struct.
+type ArtifactPlatform struct {
+	Platform
+}
+
+// ApplyFlags applies flags to a command flag set.
+func (opts *ArtifactPlatform) ApplyFlags(fs *pflag.FlagSet) {
+	opts.FlagDescription = "set artifact platform"
+	fs.StringVarP(&opts.platform, "artifact-platform", "", "", "[Experimental] "+opts.FlagDescription+" in the form of `os[/arch][/variant][:os_version]`")
+}
+
+// Parse parses the input platform flag to an oci platform type.
+func (opts *ArtifactPlatform) Parse(cmd *cobra.Command) error {
+	return opts.Platform.Parse(cmd)
 }

--- a/test/e2e/internal/testdata/foobar/const.go
+++ b/test/e2e/internal/testdata/foobar/const.go
@@ -38,6 +38,21 @@ var (
 		Digest: "46b68ac1696c", Name: "application/vnd.unknown.config.v1+json",
 	}
 
+	PlatformConfigSize     = 38
+	PlatformConfigDigest   = digest.Digest("sha256:e94c0ba80a1157ffab5b5c6656fffc089c6446c7ed0604f3382910d1ef7dd40d")
+	PlatformConfigStateKey = match.StateKey{
+		Digest: "e94c0ba80a11", Name: "application/vnd.unknown.config.v1+json",
+	}
+
+	PlatformV10ConfigSize     = 38
+	PlatformV10ConfigDigest   = digest.Digest("sha256:e94c0ba80a1157ffab5b5c6656fffc089c6446c7ed0604f3382910d1ef7dd40d")
+	PlatformV10ConfigStateKey = match.StateKey{
+		Digest: "e94c0ba80a11", Name: "test/artifact+json",
+	}
+	PlatformV1DEfaultConfigStateKey = match.StateKey{
+		Digest: "e94c0ba80a11", Name: "application/vnd.unknown.config.v1+json",
+	}
+
 	FileBarName     = "foobar/bar"
 	FileBarStateKey = match.StateKey{Digest: "fcde2b2edba5", Name: FileLayerNames[2]}
 	FileStateKeys   = []match.StateKey{


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the platform option to the push command for example:
```
oras push --plain-http localhost:15000/oras:darwin,arm64  --artifact-platform darwin/arm64 --artifact-type 'application/vnd.oci.image.config.v1+json'  bin/darwin/arm64/oras:application/x-elf
```

Create the manifest for example:
```
oras manifest index create localhost:15000/oras:v1 sha256:ed3691788db69623790c46256dd11d8d6edc31be6e4762b53c74dfc3bb6792cf
```

The results
```
% oras manifest fetch --pretty localhost:15000/oras@sha256:c9e54542075ad502900d11b9b5d5bdb4b974ad580842515684d3fbb4849e2bb1
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "artifactType": "application/vnd.oci.image.config.v1+json",
  "config": {
    "mediaType": "application/vnd.unknown.config.v1+json",
    "digest": "sha256:e9302bbb2fb8f6c2df866d3c4e41917849442f89a575f36f43366a7279804f70",
    "size": 38
  },
  "layers": [
    {
      "mediaType": "application/x-elf",
      "digest": "sha256:69c16b8386b7949fe37ff2356296b6331c1e6d5fbbc3e616192cc10ece55ea8d",
      "size": 11673840,
      "annotations": {
        "org.opencontainers.image.title": "bin/darwin/amd64/oras"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2024-09-16T16:54:48Z"
  }
}
% oras manifest fetch-config --pretty localhost:15000/oras@sha256:c9e54542075ad502900d11b9b5d5bdb4b974ad580842515684d3fbb4849e2bb1
{
  "architecture": "amd64",
  "os": "darwin"
}
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Closes https://github.com/oras-project/oras/issues/1066
Partial https://github.com/oras-project/oras/issues/1053

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

