### PR TITLE
Enrich discover --verbose command tree output with additional data (Layers, data from Descriptor)

### DIFF
--- a/cmd/oras/internal/display/metadata/interface.go
+++ b/cmd/oras/internal/display/metadata/interface.go
@@ -16,7 +16,9 @@ limitations under the License.
 package metadata
 
 import (
+	"context"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
 	"oras.land/oras/cmd/oras/internal/option"
 )
 
@@ -39,7 +41,7 @@ type DiscoverHandler interface {
 	// discovery.
 	MultiLevelSupported() bool
 	// OnDiscovered is called after a referrer is discovered.
-	OnDiscovered(referrer, subject ocispec.Descriptor) error
+	OnDiscovered(referrer, subject ocispec.Descriptor, ctx context.Context, target oras.ReadOnlyTarget, platform option.Platform) error
 	// OnCompleted is called when referrer discovery is completed.
 	OnCompleted() error
 }

--- a/cmd/oras/internal/display/metadata/json/discover.go
+++ b/cmd/oras/internal/display/metadata/json/discover.go
@@ -16,8 +16,11 @@ limitations under the License.
 package json
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/option"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
@@ -49,7 +52,7 @@ func (h *discoverHandler) MultiLevelSupported() bool {
 }
 
 // OnDiscovered implements metadata.DiscoverHandler.
-func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) error {
+func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor, _ context.Context, _ oras.ReadOnlyTarget, _ option.Platform) error {
 	if !content.Equal(subject, h.root) {
 		return fmt.Errorf("unexpected subject descriptor: %v", subject)
 	}

--- a/cmd/oras/internal/display/metadata/table/discover.go
+++ b/cmd/oras/internal/display/metadata/table/discover.go
@@ -16,8 +16,11 @@ limitations under the License.
 package table
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/option"
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -51,7 +54,7 @@ func (h *discoverHandler) MultiLevelSupported() bool {
 }
 
 // OnDiscovered implements metadata.DiscoverHandler.
-func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) error {
+func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor, _ context.Context, _ oras.ReadOnlyTarget, _ option.Platform) error {
 	if !content.Equal(subject, h.root) {
 		return fmt.Errorf("unexpected subject descriptor: %v", subject)
 	}

--- a/cmd/oras/internal/display/metadata/template/discover.go
+++ b/cmd/oras/internal/display/metadata/template/discover.go
@@ -16,8 +16,11 @@ limitations under the License.
 package template
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/option"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
@@ -51,7 +54,7 @@ func (h *discoverHandler) MultiLevelSupported() bool {
 }
 
 // OnDiscovered implements metadata.DiscoverHandler.
-func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) error {
+func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor, _ context.Context, _ oras.ReadOnlyTarget, _ option.Platform) error {
 	if !content.Equal(subject, h.root) {
 		return fmt.Errorf("unexpected subject descriptor: %v", subject)
 	}

--- a/cmd/oras/internal/display/metadata/tree/discover.go
+++ b/cmd/oras/internal/display/metadata/tree/discover.go
@@ -16,13 +16,20 @@ limitations under the License.
 package tree
 
 import (
+	"cmp"
+	"context"
+	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"io"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/cmd/oras/internal/option"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"gopkg.in/yaml.v3"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
 	"oras.land/oras/internal/tree"
 )
@@ -56,7 +63,7 @@ func (h *discoverHandler) MultiLevelSupported() bool {
 }
 
 // OnDiscovered implements metadata.DiscoverHandler.
-func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) error {
+func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor, ctx context.Context, target oras.ReadOnlyTarget, platform option.Platform) error {
 	node, ok := h.nodes[subject.Digest]
 	if !ok {
 		return fmt.Errorf("unexpected subject descriptor: %v", subject)
@@ -66,16 +73,116 @@ func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) err
 	}
 	referrerNode := node.AddPath(referrer.ArtifactType, referrer.Digest)
 	if h.verbose {
-		for k, v := range referrer.Annotations {
-			bytes, err := yaml.Marshal(map[string]string{k: v})
-			if err != nil {
-				return err
-			}
-			referrerNode.AddPath(strings.TrimSpace(string(bytes)))
+		addDescriptorInfo(referrer, referrerNode)
+
+		if err := addAnnotationsInfo(referrer, referrerNode); err != nil {
+			return err
+		}
+
+		if err := addLayersInfo(referrer, referrerNode, ctx, target, platform); err != nil {
+			return err
 		}
 	}
 	h.nodes[referrer.Digest] = referrerNode
 	return nil
+}
+
+func addDescriptorInfo(referrer ocispec.Descriptor, referrerNode *tree.Node) {
+	descriptorNode := referrerNode.AddPath("Descriptor")
+	descriptorNode.AddPath(strings.TrimSpace("MediaType: " + referrer.MediaType))
+	descriptorNode.AddPath(strings.TrimSpace("Size: " + strconv.FormatInt(referrer.Size, 10)))
+}
+
+func addAnnotationsInfo(referrer ocispec.Descriptor, referrerNode *tree.Node) error {
+	if len(referrer.Annotations) != 0 {
+		annotationsNode := referrerNode.AddPath("Annotations")
+		annotationsKeys := sortedKeys(referrer.Annotations)
+		for _, k := range annotationsKeys {
+			v := referrer.Annotations[k]
+			bytes, err := yaml.Marshal(map[string]string{k: v})
+			if err != nil {
+				return err
+			}
+			annotationsNode.AddPath(strings.TrimSpace(string(bytes)))
+		}
+	}
+	return nil
+}
+
+func addLayersInfo(referrer ocispec.Descriptor, referrerNode *tree.Node, ctx context.Context, target oras.ReadOnlyTarget, platform option.Platform) error {
+	layersNode := tree.New("Layers")
+	layersDumped, ok := dumpLayers(referrer.Digest, layersNode, ctx, target, platform)
+	if ok != nil {
+		return ok
+	} else if layersDumped {
+		referrerNode.AddNode(layersNode)
+	}
+	return nil
+}
+
+func dumpLayers(digest digest.Digest, node *tree.Node, ctx context.Context, target oras.ReadOnlyTarget, platform option.Platform) (bool, error) {
+	fetchOpts := oras.DefaultFetchBytesOptions
+	fetchOpts.TargetPlatform = platform.Platform
+	_, content, err := oras.FetchBytes(ctx, target, digest.String(), fetchOpts)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch the content of %q: %w", "", err)
+	}
+
+	var jsonMap map[string]any
+	if err = json.Unmarshal(content, &jsonMap); err != nil {
+		return false, err
+	}
+
+	if layers, ok := jsonMap["layers"].([]interface{}); ok {
+		if len(layers) != 0 {
+			for idx, item := range layers {
+				layerNode := node.AddPath(fmt.Sprintf("Layer[%d]", idx))
+
+				if layer, ok := item.(map[string]interface{}); ok {
+
+					layerKeys := sortedKeys(layer)
+					for _, k := range layerKeys {
+						v := layer[k]
+						if k == "annotations" {
+							annotationsNode := layerNode.AddPath(k)
+							if annotationsMap, ok := v.(map[string]interface{}); ok {
+								annotationsMapKeys := sortedKeys(annotationsMap)
+								for _, k := range annotationsMapKeys {
+									v := annotationsMap[k]
+									bytes, err := yaml.Marshal(map[string]interface{}{k: v})
+									if err != nil {
+										continue
+									}
+									annotationsNode.AddPath(strings.TrimSpace(string(bytes)))
+								}
+							}
+						} else {
+							bytes, err := yaml.Marshal(map[string]interface{}{k: v})
+							if err != nil {
+								continue
+							}
+							layerNode.AddPath(strings.TrimSpace(string(bytes)))
+						}
+					}
+				}
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+
+}
+
+func sortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	return keys
 }
 
 // OnCompleted implements metadata.DiscoverHandler.

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -31,11 +31,17 @@ func New(value any) *Node {
 	}
 }
 
-// Add adds a leaf node.
+// Add adds a leaf node with value.
 func (n *Node) Add(value any) *Node {
 	node := New(value)
 	n.Nodes = append(n.Nodes, node)
 	return node
+}
+
+// AddNode adds a leaf Node.
+func (n *Node) AddNode(node *Node) *Node {
+	n.Nodes = append(n.Nodes, node)
+	return n
 }
 
 // AddPath adds a chain of nodes.


### PR DESCRIPTION
WIP

Hi,
when I was investigating why Trivy does not see SBOMs attached to Harbor Images (it was because old Harbor v2.10.2 was malformes `ArtifactType` of attached SBOM JSON. It always override to `application/vnd.oci.empty.v1+json`. In latest version of Harbor it is fixed), I found out that it is good to see (at that time only in debugger) some additional data about Images.
What helped me, was to see `MediaType` from `Descriptor`, and `MediaType` from Layers.

What do you think about those additions to `--verbose` mode of `discover` command?

Thank you

Ivos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->


Output looks like this:

```
localhost:8888/my-project/demo@sha256:901cf8eb9b8b4be961247fdfdcc87471b06461357a44fb05e60401b9f78670b9
└── application/vnd.cyclonedx+json
    └── sha256:23dbde23c33a226959ea7733abeed67922069d3c0a93a8d88589e6c478539817
        ├── Descriptor
        │   ├── MediaType: application/vnd.oci.image.manifest.v1+json
        │   └── Size: 821
        ├── Annotations
        │   ├── created-by: Ivos
        │   └── org.opencontainers.image.created: "2024-09-16T07:03:43Z"
        └── Layers
            └── Layer[0]
                ├── annotations
                │   └── org.opencontainers.image.title: C:\Users\bedla.czech\GolandProjects\trivy\result.json
                ├── digest: sha256:95340261766214250b2238f4a8055bbd8b9f5b6203a30ca6e0e59c9348d5c674
                ├── mediaType: application/vnd.cyclonedx+json
                └── size: 36449
```