### PR TITLE
feat(cmd/cp): add oci-layout-path flag

### DIFF
--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -85,6 +85,7 @@ func (opts *Target) AnnotatedReference() string {
 func (opts *Target) applyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description string) {
 	flagPrefix, notePrefix := applyPrefix(prefix, description)
 	fs.BoolVarP(&opts.IsOCILayout, flagPrefix+"oci-layout", "", false, "set "+notePrefix+"target as an OCI image layout")
+	fs.StringVar(&opts.Path, flagPrefix+"oci-layout-path", "", "set the path for the "+notePrefix+"OCI image layout target")
 }
 
 // ApplyFlagsWithPrefix applies flags to a command flag set with a prefix string.
@@ -96,6 +97,10 @@ func (opts *Target) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 
 // Parse gets target options from user input.
 func (opts *Target) Parse(cmd *cobra.Command) error {
+	if err := oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), opts.flagPrefix+"oci-layout-path", opts.flagPrefix+"oci-layout"); err != nil {
+		return err
+	}
+
 	switch {
 	case opts.IsOCILayout:
 		opts.Type = TargetTypeOCILayout
@@ -103,6 +108,10 @@ func (opts *Target) Parse(cmd *cobra.Command) error {
 			return errors.New("custom header flags cannot be used on an OCI image layout target")
 		}
 		return opts.parseOCILayoutReference()
+	case opts.Path != "":
+		opts.Type = TargetTypeOCILayout
+		opts.Reference = opts.RawReference
+		return nil
 	default:
 		opts.Type = TargetTypeRemote
 		if ref, err := registry.ParseReference(opts.RawReference); err != nil {

--- a/test/e2e/internal/utils/const.go
+++ b/test/e2e/internal/utils/const.go
@@ -20,12 +20,16 @@ var (
 		Layout           string
 		FromLayout       string
 		ToLayout         string
+		FromLayoutPath   string
+		ToLayoutPath     string
 		DistributionSpec string
 		ImageSpec        string
 	}{
 		"--oci-layout",
 		"--from-oci-layout",
 		"--to-oci-layout",
+		"--from-oci-layout-path",
+		"--to-oci-layout-path",
 		"--distribution-spec",
 		"--image-spec",
 	}

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -441,7 +441,7 @@ var _ = Describe("OCI layout users:", func() {
 
 		It("should copy an image from a registry to an OCI image layout via digest", func() {
 			dstDir := GinkgoT().TempDir()
-			src := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
+			src := RegistryRef(ZOTHost, ImageRepo, foobar.Digest)
 			ORAS("cp", src, dstDir, "-v", Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()


### PR DESCRIPTION
**What this PR does / why we need it**:

The oci-layout can't be used when the image reference contains a slash ( see issue 1505). This PR introduces a new oci-layout-path that explicitly receives the path of the oci layout fixing the parsing ambiguity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1505

**Please check the following list**:
- [X]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [X]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

