### PR TITLE
fix: update --add should add plain descriptor

### DIFF
--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -153,8 +153,7 @@ func fetchSourceManifests(ctx context.Context, target oras.ReadOnlyTarget, opts 
 			return nil, fmt.Errorf("%s is not a manifest", source)
 		}
 		opts.Println(status.IndexPromptFetched, source)
-		desc, err = enrichDescriptor(ctx, target, desc, content)
-		if err != nil {
+		if desc, err = enrichDescriptor(ctx, target, desc, content); err != nil {
 			return nil, err
 		}
 		resolved = append(resolved, desc)

--- a/cmd/oras/root/manifest/index/update.go
+++ b/cmd/oras/root/manifest/index/update.go
@@ -181,6 +181,7 @@ func addManifests(ctx context.Context, manifests []ocispec.Descriptor, target or
 			return nil, fmt.Errorf("%s is not a manifest", manifestRef)
 		}
 		printUpdateStatus(status.IndexPromptFetched, manifestRef, string(desc.Digest), opts.Printer)
+		desc = descriptor.Plain(desc)
 		if descriptor.IsImageManifest(desc) {
 			desc.Platform, err = getPlatform(ctx, target, content)
 			if err != nil {

--- a/cmd/oras/root/manifest/index/update.go
+++ b/cmd/oras/root/manifest/index/update.go
@@ -181,8 +181,7 @@ func addManifests(ctx context.Context, manifests []ocispec.Descriptor, target or
 			return nil, fmt.Errorf("%s is not a manifest", manifestRef)
 		}
 		printUpdateStatus(status.IndexPromptFetched, manifestRef, string(desc.Digest), opts.Printer)
-		desc, err = enrichDescriptor(ctx, target, desc, content)
-		if err != nil {
+		if desc, err = enrichDescriptor(ctx, target, desc, content); err != nil {
 			return nil, err
 		}
 		manifests = append(manifests, desc)

--- a/cmd/oras/root/manifest/index/update.go
+++ b/cmd/oras/root/manifest/index/update.go
@@ -181,12 +181,9 @@ func addManifests(ctx context.Context, manifests []ocispec.Descriptor, target or
 			return nil, fmt.Errorf("%s is not a manifest", manifestRef)
 		}
 		printUpdateStatus(status.IndexPromptFetched, manifestRef, string(desc.Digest), opts.Printer)
-		desc = descriptor.Plain(desc)
-		if descriptor.IsImageManifest(desc) {
-			desc.Platform, err = getPlatform(ctx, target, content)
-			if err != nil {
-				return nil, err
-			}
+		desc, err = enrichDescriptor(ctx, target, desc, content)
+		if err != nil {
+			return nil, err
 		}
 		manifests = append(manifests, desc)
 		printUpdateStatus(status.IndexPromptAdded, manifestRef, string(desc.Digest), opts.Printer)


### PR DESCRIPTION
**What this PR does / why we need it**:

`oras manifest index update --add` now adds the original manifest descriptor, and which may include the annotations. The command should add the plain descriptor.

`oras manifest index update --merge` still adds the original manifest descriptors. The annotations may be meaningful under merge scenarios.
