### PR TITLE
chore(e2e): set go bin path

### DIFF
--- a/test/e2e/scripts/prepare.sh
+++ b/test/e2e/scripts/prepare.sh
@@ -35,6 +35,7 @@ echo " === installing ginkgo  === "
 repo_root=$(realpath --canonicalize-existing ${repo_root})
 cwd=$(pwd)
 cd ${repo_root}/test/e2e && go install github.com/onsi/ginkgo/v2/ginkgo@latest
+export PATH=$(go env GOPATH)/bin:$PATH
 trap "cd $cwd" EXIT
 
 # start registries


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a command to set golang binary path to ensure ginkgo always viable during e2e testing.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
