### PR TITLE
fix(ut): fix flaky console tests

### DIFF
--- a/cmd/oras/internal/display/status/console/console_test.go
+++ b/cmd/oras/internal/display/status/console/console_test.go
@@ -43,11 +43,11 @@ func givenTestConsole(t *testing.T) (c Console, pty containerd.Console, tty *os.
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	c = &console{
-		Console: pty,
+	c, err = NewConsole(tty)
+	if err != nil {
+		t.Fatal(err)
 	}
-	return c, pty, tty
+	return
 }
 
 func validateSize(t *testing.T, gotWidth, gotHeight, wantWidth, wantHeight int) {
@@ -96,7 +96,7 @@ func TestConsole_NewRow(t *testing.T) {
 
 	c.NewRow()
 
-	err := testutils.MatchPty(pty, tty, "^[8\r\n^[7")
+	err := testutils.MatchPty(pty, tty, "\x1b8\r\n\x1b7")
 	if err != nil {
 		t.Fatalf("NewRow output error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestConsole_OutputTo(t *testing.T) {
 
 	c.OutputTo(1, "test string")
 
-	err := testutils.MatchPty(pty, tty, "^[8^[[1Ftest string^[[0m\r\n^[[0K")
+	err := testutils.MatchPty(pty, tty, "\x1b8\x1b[1Ftest string\x1b[0m\r\n\x1b[0K")
 	if err != nil {
 		t.Fatalf("OutputTo output error: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestConsole_Restore(t *testing.T) {
 
 	c.Restore()
 
-	err := testutils.MatchPty(pty, tty, "^[8^[[0G^[[2K^[[?25h")
+	err := testutils.MatchPty(pty, tty, "\x1b8\x1b[0G\x1b[2K\x1b[?25h")
 	if err != nil {
 		t.Fatalf("Restore output error: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestConsole_Save(t *testing.T) {
 
 	c.Save()
 
-	err := testutils.MatchPty(pty, tty, "^[[?25l^[7^[[0m")
+	err := testutils.MatchPty(pty, tty, "\x1b[?25l\x1b7\x1b[0m")
 	if err != nil {
 		t.Fatalf("Save output error: %v", err)
 	}

--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -50,8 +50,8 @@ func MatchPty(pty containerd.Console, device *os.File, expected ...string) error
 		defer wg.Done()
 		_, _ = io.Copy(&buffer, pty)
 	}()
-	wg.Wait()
 	device.Close()
+	wg.Wait()
 
 	return OrderedMatch(buffer.String(), expected...)
 }

--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -50,8 +50,8 @@ func MatchPty(pty containerd.Console, device *os.File, expected ...string) error
 		defer wg.Done()
 		_, _ = io.Copy(&buffer, pty)
 	}()
-	device.Close()
 	wg.Wait()
+	device.Close()
 
 	return OrderedMatch(buffer.String(), expected...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes flaky console unit tests. To reproduce the flaky tests, try
```bash
go test -count=1000 -run ^TestConsole_Save$ oras.land/oras/cmd/oras/internal/display/status/console
```
PTY output might be interrupted by unexpected error like ` console_test.go:134: Save output error: failed to find "^[[?25l^[7^[[0m" in ""`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1543

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
