### PR TITLE
refactor!: deprecate --verbose and print all status output by default

### DIFF
--- a/cmd/oras/internal/command/logger.go
+++ b/cmd/oras/internal/command/logger.go
@@ -26,7 +26,7 @@ import (
 
 // GetLogger returns a new FieldLogger and an associated Context derived from command context.
 func GetLogger(cmd *cobra.Command, opts *option.Common) (context.Context, logrus.FieldLogger) {
-	ctx, logger := trace.NewLogger(cmd.Context(), opts.Debug, opts.Verbose)
+	ctx, logger := trace.NewLogger(cmd.Context(), opts.Debug)
 	cmd.SetContext(ctx)
 	return ctx, logger
 }

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -49,7 +49,7 @@ func NewTextPushHandler(printer *output.Printer, fetcher content.Fetcher) PushHa
 
 // OnFileLoading is called when a file is being prepared for upload.
 func (ph *TextPushHandler) OnFileLoading(name string) error {
-	return ph.printer.PrintVerbose("Preparing", name)
+	return ph.printer.PrintUnnamed("Preparing", name)
 }
 
 // OnEmptyArtifact is called when an empty artifact is being uploaded.

--- a/cmd/oras/internal/display/status/text.go
+++ b/cmd/oras/internal/display/status/text.go
@@ -49,7 +49,7 @@ func NewTextPushHandler(printer *output.Printer, fetcher content.Fetcher) PushHa
 
 // OnFileLoading is called when a file is being prepared for upload.
 func (ph *TextPushHandler) OnFileLoading(name string) error {
-	return ph.printer.PrintUnnamed("Preparing", name)
+	return ph.printer.PrintUntitled("Preparing", name)
 }
 
 // OnEmptyArtifact is called when an empty artifact is being uploaded.

--- a/cmd/oras/internal/display/status/text_test.go
+++ b/cmd/oras/internal/display/status/text_test.go
@@ -173,7 +173,7 @@ func TestTextPushHandler_OnFileLoading(t *testing.T) {
 	if ph.OnFileLoading("name") != nil {
 		t.Error("OnFileLoading() should not return an error")
 	}
-	validatePrinted(t, "")
+	validatePrinted(t, "Preparing name")
 }
 
 func TestTextPushHandler_PostCopy(t *testing.T) {

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -28,12 +28,15 @@ const NoTTYFlag = "no-tty"
 
 // Common option struct.
 type Common struct {
-	Debug   bool
-	Verbose bool // deprecated, the current default behavior is equivalent to verbose=true TODO: better doc
-	TTY     *os.File
+	Debug bool
+	// SuppressUntitled suppresses the status output for untitled blobs.
+	SuppressUntitled bool
+	TTY              *os.File
 	*output.Printer
-	noTTY            bool
-	SuppressUntitled bool // equivalent to verbose=false TODO: better doc
+	noTTY bool
+
+	// Verbose is deprecated. The default status output now behaves as if verbose=true.
+	Verbose bool
 }
 
 // ApplyFlags applies flags to a command flag set.
@@ -42,7 +45,7 @@ func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "[Deprecated] verbose output")
 	fs.BoolVarP(&opts.noTTY, NoTTYFlag, "", false, "[Preview] do not show progress output")
 
-	fs.MarkDeprecated("verbose", "and may be removed in a future release.") // TODO: remove -v in e2e test; test deprecation message
+	fs.MarkDeprecated("verbose", "and may be removed in a future release.") // TODO: test deprecation message
 }
 
 // Parse gets target options from user input.

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -35,7 +35,7 @@ type Common struct {
 	*output.Printer
 	noTTY bool
 
-	// Verbose is deprecated. The default status output now behaves as if verbose=true.
+	// Deprecated: Verbose is deprecated. Use SuppressUntitled instead (SuppressUntitled=false is equivalent to Verbose=true).
 	Verbose bool
 }
 

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -29,22 +29,25 @@ const NoTTYFlag = "no-tty"
 // Common option struct.
 type Common struct {
 	Debug   bool
-	Verbose bool
+	Verbose bool // deprecated, the current default behavior is equivalent to verbose=true
 	TTY     *os.File
 	*output.Printer
-	noTTY bool
+	noTTY           bool
+	SuppressUnnamed bool // equivalent to verbose=false
 }
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&opts.Debug, "debug", "d", false, "output debug logs (implies --no-tty)")
-	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose output")
+	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "[Deprecated] verbose output")
 	fs.BoolVarP(&opts.noTTY, NoTTYFlag, "", false, "[Preview] do not show progress output")
+
+	fs.MarkDeprecated("verbose", "and may be removed in a future release.") // TODO: e2e test
 }
 
 // Parse gets target options from user input.
 func (opts *Common) Parse(cmd *cobra.Command) error {
-	opts.Printer = output.NewPrinter(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.Verbose)
+	opts.Printer = output.NewPrinter(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.SuppressUnnamed)
 	// use STDERR as TTY output since STDOUT is reserved for pipeable output
 	return opts.parseTTY(os.Stderr)
 }

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -32,8 +32,8 @@ type Common struct {
 	Verbose bool // deprecated, the current default behavior is equivalent to verbose=true
 	TTY     *os.File
 	*output.Printer
-	noTTY           bool
-	SuppressUnnamed bool // equivalent to verbose=false
+	noTTY            bool
+	SuppressUntitled bool // equivalent to verbose=false
 }
 
 // ApplyFlags applies flags to a command flag set.
@@ -47,7 +47,7 @@ func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
 
 // Parse gets target options from user input.
 func (opts *Common) Parse(cmd *cobra.Command) error {
-	opts.Printer = output.NewPrinter(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.SuppressUnnamed)
+	opts.Printer = output.NewPrinter(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.SuppressUntitled)
 	// use STDERR as TTY output since STDOUT is reserved for pipeable output
 	return opts.parseTTY(os.Stderr)
 }

--- a/cmd/oras/internal/option/common.go
+++ b/cmd/oras/internal/option/common.go
@@ -29,11 +29,11 @@ const NoTTYFlag = "no-tty"
 // Common option struct.
 type Common struct {
 	Debug   bool
-	Verbose bool // deprecated, the current default behavior is equivalent to verbose=true
+	Verbose bool // deprecated, the current default behavior is equivalent to verbose=true TODO: better doc
 	TTY     *os.File
 	*output.Printer
 	noTTY            bool
-	SuppressUntitled bool // equivalent to verbose=false
+	SuppressUntitled bool // equivalent to verbose=false TODO: better doc
 }
 
 // ApplyFlags applies flags to a command flag set.
@@ -42,7 +42,7 @@ func (opts *Common) ApplyFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, "[Deprecated] verbose output")
 	fs.BoolVarP(&opts.noTTY, NoTTYFlag, "", false, "[Preview] do not show progress output")
 
-	fs.MarkDeprecated("verbose", "and may be removed in a future release.") // TODO: e2e test
+	fs.MarkDeprecated("verbose", "and may be removed in a future release.") // TODO: remove -v in e2e test; test deprecation message
 }
 
 // Parse gets target options from user input.

--- a/cmd/oras/internal/output/print.go
+++ b/cmd/oras/internal/output/print.go
@@ -27,15 +27,15 @@ import (
 
 // Printer prints for status handlers.
 type Printer struct {
-	out             io.Writer
-	err             io.Writer
-	lock            sync.Mutex
-	suppressUnnamed bool
+	out              io.Writer
+	err              io.Writer
+	lock             sync.Mutex
+	suppressUntitled bool
 }
 
 // NewPrinter creates a new Printer.
-func NewPrinter(out io.Writer, err io.Writer, suppressUnnamed bool) *Printer {
-	return &Printer{out: out, err: err, suppressUnnamed: suppressUnnamed}
+func NewPrinter(out io.Writer, err io.Writer, suppressUntitled bool) *Printer {
+	return &Printer{out: out, err: err, suppressUntitled: suppressUntitled}
 }
 
 // Write implements the io.Writer interface.
@@ -71,9 +71,9 @@ func (p *Printer) Printf(format string, a ...any) error {
 	return nil
 }
 
-// PrintUnnamed prints unless suppressed.
-func (p *Printer) PrintUnnamed(a ...any) error {
-	if p.suppressUnnamed {
+// PrintUntitled prints unless suppressed.
+func (p *Printer) PrintUntitled(a ...any) error {
+	if p.suppressUntitled {
 		return nil
 	}
 	return p.Println(a...)
@@ -83,7 +83,7 @@ func (p *Printer) PrintUnnamed(a ...any) error {
 func (p *Printer) PrintStatus(desc ocispec.Descriptor, status string) error {
 	name, isTitle := descriptor.GetTitleOrMediaType(desc)
 	if !isTitle {
-		return p.PrintUnnamed(status, descriptor.ShortDigest(desc), name)
+		return p.PrintUntitled(status, descriptor.ShortDigest(desc), name)
 	}
 	return p.Println(status, descriptor.ShortDigest(desc), name)
 }

--- a/cmd/oras/internal/output/print.go
+++ b/cmd/oras/internal/output/print.go
@@ -27,15 +27,15 @@ import (
 
 // Printer prints for status handlers.
 type Printer struct {
-	out     io.Writer
-	err     io.Writer
-	verbose bool
-	lock    sync.Mutex
+	out             io.Writer
+	err             io.Writer
+	lock            sync.Mutex
+	suppressUnnamed bool
 }
 
 // NewPrinter creates a new Printer.
-func NewPrinter(out io.Writer, err io.Writer, verbose bool) *Printer {
-	return &Printer{out: out, err: err, verbose: verbose}
+func NewPrinter(out io.Writer, err io.Writer, suppressUnnamed bool) *Printer {
+	return &Printer{out: out, err: err, suppressUnnamed: suppressUnnamed}
 }
 
 // Write implements the io.Writer interface.
@@ -71,9 +71,9 @@ func (p *Printer) Printf(format string, a ...any) error {
 	return nil
 }
 
-// PrintVerbose prints when verbose is true.
-func (p *Printer) PrintVerbose(a ...any) error {
-	if !p.verbose {
+// PrintUnnamed prints unless suppressed.
+func (p *Printer) PrintUnnamed(a ...any) error {
+	if p.suppressUnnamed {
 		return nil
 	}
 	return p.Println(a...)
@@ -83,7 +83,7 @@ func (p *Printer) PrintVerbose(a ...any) error {
 func (p *Printer) PrintStatus(desc ocispec.Descriptor, status string) error {
 	name, isTitle := descriptor.GetTitleOrMediaType(desc)
 	if !isTitle {
-		return p.PrintVerbose(status, descriptor.ShortDigest(desc), name)
+		return p.PrintUnnamed(status, descriptor.ShortDigest(desc), name)
 	}
 	return p.Println(status, descriptor.ShortDigest(desc), name)
 }

--- a/cmd/oras/internal/output/print_test.go
+++ b/cmd/oras/internal/output/print_test.go
@@ -60,10 +60,10 @@ func TestPrinter_Println(t *testing.T) {
 	}
 }
 
-func TestPrinter_SuppressUnnamed(t *testing.T) {
+func TestPrinter_SuppressUntitled(t *testing.T) {
 	builder := &strings.Builder{}
-	suppressUnnamed := true
-	printer := NewPrinter(builder, os.Stderr, suppressUnnamed)
+	suppressUntitled := true
+	printer := NewPrinter(builder, os.Stderr, suppressUntitled)
 
 	expected := "normal\nthing one\n"
 	err := printer.Println("normal")
@@ -74,7 +74,7 @@ func TestPrinter_SuppressUnnamed(t *testing.T) {
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}
-	err = printer.PrintUnnamed("verbose")
+	err = printer.PrintUntitled("verbose")
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}
@@ -84,17 +84,17 @@ func TestPrinter_SuppressUnnamed(t *testing.T) {
 	}
 }
 
-func TestPrinter_PrintUnnamed(t *testing.T) {
+func TestPrinter_PrintUntitled(t *testing.T) {
 	builder := &strings.Builder{}
-	suppressUnnamed := false
-	printer := NewPrinter(builder, os.Stderr, suppressUnnamed)
+	suppressUntitled := false
+	printer := NewPrinter(builder, os.Stderr, suppressUntitled)
 
 	expected := "normal\nverbose\n"
 	err := printer.Println("normal")
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}
-	err = printer.PrintUnnamed("verbose")
+	err = printer.PrintUntitled("verbose")
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}

--- a/cmd/oras/internal/output/print_test.go
+++ b/cmd/oras/internal/output/print_test.go
@@ -60,9 +60,10 @@ func TestPrinter_Println(t *testing.T) {
 	}
 }
 
-func TestPrinter_PrintVerbose_noError(t *testing.T) {
+func TestPrinter_SuppressUnnamed(t *testing.T) {
 	builder := &strings.Builder{}
-	printer := NewPrinter(builder, os.Stderr, false)
+	suppressUnnamed := true
+	printer := NewPrinter(builder, os.Stderr, suppressUnnamed)
 
 	expected := "normal\nthing one\n"
 	err := printer.Println("normal")
@@ -73,7 +74,7 @@ func TestPrinter_PrintVerbose_noError(t *testing.T) {
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}
-	err = printer.PrintVerbose("verbose")
+	err = printer.PrintUnnamed("verbose")
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}
@@ -83,16 +84,17 @@ func TestPrinter_PrintVerbose_noError(t *testing.T) {
 	}
 }
 
-func TestPrinter_PrintVerbose(t *testing.T) {
+func TestPrinter_PrintUnnamed(t *testing.T) {
 	builder := &strings.Builder{}
-	printer := NewPrinter(builder, os.Stderr, true)
+	suppressUnnamed := false
+	printer := NewPrinter(builder, os.Stderr, suppressUnnamed)
 
 	expected := "normal\nverbose\n"
 	err := printer.Println("normal")
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}
-	err = printer.PrintVerbose("verbose")
+	err = printer.PrintUnnamed("verbose")
 	if err != nil {
 		t.Error("Expected no error got <" + err.Error() + ">")
 	}

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -87,7 +87,6 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 					return errors.New("`--size` must be provided if the blob is read from stdin")
 				}
 			}
-			// opts.SuppressUnnamed = opts.OutputDescriptor
 			opts.SuppressUntitled = opts.OutputDescriptor
 			return option.Parse(cmd, &opts)
 		},

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -88,7 +88,7 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 				}
 			}
 			// opts.SuppressUnnamed = opts.OutputDescriptor
-			opts.SuppressUnnamed = opts.OutputDescriptor
+			opts.SuppressUntitled = opts.OutputDescriptor
 			return option.Parse(cmd, &opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/oras/root/blob/push.go
+++ b/cmd/oras/root/blob/push.go
@@ -87,7 +87,8 @@ Example - Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 					return errors.New("`--size` must be provided if the blob is read from stdin")
 				}
 			}
-			opts.Verbose = opts.Verbose && !opts.OutputDescriptor
+			// opts.SuppressUnnamed = opts.OutputDescriptor
+			opts.SuppressUnnamed = opts.OutputDescriptor
 			return option.Parse(cmd, &opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -24,11 +24,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"oras.land/oras/cmd/oras/internal/display/status"
-	"oras.land/oras/cmd/oras/internal/output"
 	"os"
 	"strings"
 	"testing"
+
+	"oras.land/oras/cmd/oras/internal/display/status"
+	"oras.land/oras/cmd/oras/internal/output"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -129,11 +130,10 @@ func Test_doCopy(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
-	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
 	dst := memory.New()
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	printer := output.NewPrinter(builder, os.Stderr, false)
 	handler := status.NewTextCopyHandler(printer, dst)
 	// test
 	_, err = doCopy(context.Background(), handler, memStore, dst, &opts)
@@ -155,10 +155,9 @@ func Test_doCopy_skipped(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
-	opts.Verbose = true
 	opts.From.Reference = memDesc.Digest.String()
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	printer := output.NewPrinter(builder, os.Stderr, false)
 	handler := status.NewTextCopyHandler(printer, memStore)
 
 	// test
@@ -181,7 +180,6 @@ func Test_doCopy_mounted(t *testing.T) {
 	defer slave.Close()
 	var opts copyOptions
 	opts.TTY = slave
-	opts.Verbose = true
 	opts.From.Reference = manifestDigest
 	// mocked repositories
 	from, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, repoFrom))
@@ -195,7 +193,7 @@ func Test_doCopy_mounted(t *testing.T) {
 	}
 	to.PlainHTTP = true
 	builder := &strings.Builder{}
-	printer := output.NewPrinter(builder, os.Stderr, opts.Verbose)
+	printer := output.NewPrinter(builder, os.Stderr, false)
 	handler := status.NewTextCopyHandler(printer, to)
 
 	// test

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -96,7 +96,7 @@ Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag wit
 			refs := strings.Split(args[0], ",")
 			opts.RawReference = refs[0]
 			opts.extraRefs = refs[1:]
-			opts.SuppressUnnamed = opts.OutputDescriptor
+			opts.SuppressUntitled = opts.OutputDescriptor
 			return option.Parse(cmd, &opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/oras/root/manifest/push.go
+++ b/cmd/oras/root/manifest/push.go
@@ -96,7 +96,7 @@ Example - Push a manifest to an OCI image layout folder 'layout-dir' and tag wit
 			refs := strings.Split(args[0], ",")
 			opts.RawReference = refs[0]
 			opts.extraRefs = refs[1:]
-			opts.Verbose = opts.Verbose && !opts.OutputDescriptor
+			opts.SuppressUnnamed = opts.OutputDescriptor
 			return option.Parse(cmd, &opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -27,12 +27,10 @@ type contextKey int
 const loggerKey contextKey = iota
 
 // NewLogger returns a logger.
-func NewLogger(ctx context.Context, debug bool, verbose bool) (context.Context, logrus.FieldLogger) {
+func NewLogger(ctx context.Context, debug bool) (context.Context, logrus.FieldLogger) {
 	var logLevel logrus.Level
 	if debug {
 		logLevel = logrus.DebugLevel
-	} else if verbose {
-		logLevel = logrus.InfoLevel
 	} else {
 		logLevel = logrus.WarnLevel
 	}

--- a/test/e2e/suite/auth/auth.go
+++ b/test/e2e/suite/auth/auth.go
@@ -179,7 +179,7 @@ var _ = Describe("Common registry user", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, foobar.Tag)
 			dst := RegistryRef(ZOTHost, fmt.Sprintf("command/auth/%d/copy", GinkgoRandomSeed()), foobar.Tag)
 			foobarStates := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageConfigStateKey(oras.MediaTypeUnknownConfig))
-			ORAS("cp", src, dst, "-v", "--from-registry-config", LegacyConfigPath, "--to-registry-config", LegacyConfigPath).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst, "--from-registry-config", LegacyConfigPath, "--to-registry-config", LegacyConfigPath).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 		})
 	})
 })

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -236,7 +236,7 @@ var _ = Describe("1.1 registry users:", func() {
 				MatchContent(fmt.Sprintf(pushDescFmt, mediaType)).Exec()
 			ORAS("blob", "fetch", RegistryRef(ZOTHost, repo, pushDigest), "--output", "-").MatchContent(pushContent).Exec()
 
-			ORAS("blob", "push", RegistryRef(ZOTHost, repo, ""), blobPath, "-v").
+			ORAS("blob", "push", RegistryRef(ZOTHost, repo, ""), blobPath).
 				WithDescription("skip the pushing if the blob already exists in the target repo").
 				MatchKeyWords("Exists").Exec()
 		})
@@ -347,7 +347,7 @@ var _ = Describe("OCI image layout users:", func() {
 			// test
 			ORAS("blob", "push", Flags.Layout, LayoutRef(tmpRoot, pushDigest), blobPath, "--media-type", mediaType, "--descriptor").
 				MatchContent(fmt.Sprintf(pushDescFmt, mediaType)).Exec()
-			ORAS("blob", "push", Flags.Layout, LayoutRef(tmpRoot, pushDigest), blobPath, "-v").
+			ORAS("blob", "push", Flags.Layout, LayoutRef(tmpRoot, pushDigest), blobPath).
 				WithDescription("skip pushing if the blob already exists in the target repo").
 				MatchKeyWords("Exists").Exec()
 			// validate

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -121,7 +121,7 @@ var _ = Describe("1.1 registry users:", func() {
 		It("should copy an artifact with blob", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, blob.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("artifact-with-blob"), "copied")
-			ORAS("cp", src, dst, "-v").MatchStatus(blob.StateKeys, true, len(blob.StateKeys)).Exec()
+			ORAS("cp", src, dst).MatchStatus(blob.StateKeys, true, len(blob.StateKeys)).Exec()
 			CompareRef(src, dst)
 		})
 
@@ -137,34 +137,34 @@ var _ = Describe("1.1 registry users:", func() {
 		It("should copy an artifact with config", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, config.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("artifact-with-config"), "copied")
-			ORAS("cp", src, dst, "-v").MatchStatus(config.StateKeys, true, len(config.StateKeys)).Exec()
+			ORAS("cp", src, dst).MatchStatus(config.StateKeys, true, len(config.StateKeys)).Exec()
 		})
 
 		It("should copy index and its subject", func() {
 			stateKeys := append(ma.IndexStateKeys, index.ManifestStatusKey)
 			src := RegistryRef(ZOTHost, ArtifactRepo, index.ManifestDigest)
 			dst := RegistryRef(ZOTHost, cpTestRepo("index-with-subject"), "")
-			ORAS("cp", src, dst, "-v").MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", src, dst).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 		})
 
 		It("should copy an image to a new repository via tag", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("tag"), "copied")
-			ORAS("cp", src, dst, "-v").MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			CompareRef(src, dst)
 		})
 
 		It("should copy an image to a new repository via digest", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Digest)
 			dst := RegistryRef(ZOTHost, cpTestRepo("digest"), "copiedTag")
-			ORAS("cp", src, dst, "-v").MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			CompareRef(src, dst)
 		})
 
 		It("should copy an image to a new repository via tag without tagging", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("no-tagging"), foobar.Digest)
-			ORAS("cp", src, dst, "-v").MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			CompareRef(src, dst)
 		})
 
@@ -172,7 +172,7 @@ var _ = Describe("1.1 registry users:", func() {
 			stateKeys := append(append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageReferrerConfigStateKeys[0]), foobar.ImageReferrersStateKeys...)
 			src := RegistryRef(ZOTHost, ArtifactRepo, foobar.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("referrers"), foobar.Digest)
-			ORAS("cp", "-r", src, dst, "-v").MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", "-r", src, dst).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 			CompareRef(src, dst)
 		})
 
@@ -181,7 +181,7 @@ var _ = Describe("1.1 registry users:", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, ma.Tag)
 			dstRepo := cpTestRepo("index-referrers")
 			dst := RegistryRef(ZOTHost, dstRepo, "copiedTag")
-			ORAS("cp", src, dst, "-r", "-v").
+			ORAS("cp", src, dst, "-r").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.Digest).
 				Exec()
@@ -200,7 +200,7 @@ var _ = Describe("1.1 registry users:", func() {
 			dstRepo := cpTestRepo("index-referrers-concurrent")
 			dst := RegistryRef(ZOTHost, dstRepo, "copiedTag")
 			// test
-			ORAS("cp", src, dst, "-r", "-v", "--concurrency", "0").
+			ORAS("cp", src, dst, "-r", "--concurrency", "0").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.Digest).
 				Exec()
@@ -217,7 +217,7 @@ var _ = Describe("1.1 registry users:", func() {
 			dstRepo := cpTestRepo("empty-index")
 			dst := RegistryRef(ZOTHost, dstRepo, "copiedTag")
 			// test
-			ORAS("cp", src, dst, "-r", "-v", "--concurrency", "0").Exec()
+			ORAS("cp", src, dst, "-r", "--concurrency", "0").Exec()
 			// validate
 			CompareRef(RegistryRef(ZOTHost, ImageRepo, ma.EmptyTag), dst)
 		})
@@ -227,7 +227,7 @@ var _ = Describe("1.1 registry users:", func() {
 			src := RegistryRef(ZOTHost, ArtifactRepo, ma.Tag)
 			dstRepo := cpTestRepo("index-referrers-digest")
 			dst := RegistryRef(ZOTHost, dstRepo, ma.Digest)
-			ORAS("cp", src, dst, "-r", "-v").
+			ORAS("cp", src, dst, "-r").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.Digest).
 				Exec()
@@ -243,7 +243,7 @@ var _ = Describe("1.1 registry users:", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, ma.Tag)
 			dst := RegistryRef(ZOTHost, cpTestRepo("platform-tag"), "copiedTag")
 
-			ORAS("cp", src, dst, "--platform", "linux/amd64", "-v").
+			ORAS("cp", src, dst, "--platform", "linux/amd64").
 				MatchStatus(ma.LinuxAMD64StateKeys, true, len(ma.LinuxAMD64StateKeys)).
 				MatchKeyWords("Digest: " + ma.LinuxAMD64.Digest.String()).
 				Exec()
@@ -254,7 +254,7 @@ var _ = Describe("1.1 registry users:", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, ma.Digest)
 			dstRepo := cpTestRepo("platform-digest")
 			dst := RegistryRef(ZOTHost, dstRepo, "")
-			ORAS("cp", src, dst, "--platform", "linux/amd64", "-v").
+			ORAS("cp", src, dst, "--platform", "linux/amd64").
 				MatchStatus(ma.LinuxAMD64StateKeys, true, len(ma.LinuxAMD64StateKeys)).
 				MatchKeyWords("Digest: " + ma.LinuxAMD64.Digest.String()).
 				Exec()
@@ -267,7 +267,7 @@ var _ = Describe("1.1 registry users:", func() {
 			dstRepo := cpTestRepo("platform-referrers")
 			dst := RegistryRef(ZOTHost, dstRepo, "copiedTag")
 			digest := ma.LinuxAMD64.Digest.String()
-			ORAS("cp", src, dst, "-r", "--platform", "linux/amd64", "-v").
+			ORAS("cp", src, dst, "-r", "--platform", "linux/amd64").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + digest).
 				Exec()
@@ -285,7 +285,7 @@ var _ = Describe("1.1 registry users:", func() {
 			dstRepo := cpTestRepo("platform-referrers-no-tag")
 			dst := RegistryRef(ZOTHost, dstRepo, "")
 			digest := ma.LinuxAMD64.Digest.String()
-			ORAS("cp", src, dst, "-r", "--platform", "linux/amd64", "-v").
+			ORAS("cp", src, dst, "-r", "--platform", "linux/amd64").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + digest).
 				Exec()
@@ -302,7 +302,7 @@ var _ = Describe("1.1 registry users:", func() {
 			tags := []string{"tag1", "tag2", "tag3"}
 			dstRepo := cpTestRepo("multi-tagging")
 			dst := RegistryRef(ZOTHost, dstRepo, "")
-			ORAS("cp", src, dst+":"+strings.Join(tags, ","), "-v").MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst+":"+strings.Join(tags, ",")).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			for _, tag := range tags {
 				dst := RegistryRef(ZOTHost, dstRepo, tag)
 				CompareRef(src, dst)
@@ -317,7 +317,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 			repo := cpTestRepo("1.0-mount")
 			src := RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag)
 			dst := RegistryRef(FallbackHost, repo, "")
-			out := ORAS("cp", src, dst, "-v").Exec()
+			out := ORAS("cp", src, dst).Exec()
 			Expect(out).Should(gbytes.Say("Mounted fcde2b2edba5 bar"))
 			CompareRef(src, RegistryRef(FallbackHost, repo, foobar.Digest))
 		})
@@ -327,7 +327,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 			stateKeys := append(append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageReferrerConfigStateKeys[0]), foobar.ImageReferrersStateKeys...)
 			src := RegistryRef(ZOTHost, ArtifactRepo, foobar.SignatureImageReferrer.Digest.String())
 			dst := RegistryRef(FallbackHost, repo, "")
-			ORAS("cp", "-r", src, dst, "-v").MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", "-r", src, dst).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 			CompareRef(src, RegistryRef(FallbackHost, repo, foobar.SignatureImageReferrer.Digest.String()))
 			ORAS("discover", "-o", "tree", RegistryRef(FallbackHost, repo, foobar.Digest)).
 				WithDescription("discover referrer via subject").MatchKeyWords(foobar.SignatureImageReferrer.Digest.String(), foobar.SBOMImageReferrer.Digest.String()).Exec()
@@ -337,7 +337,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 			stateKeys := append(append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageReferrerConfigStateKeys[0]), foobar.ImageReferrersStateKeys...)
 			src := RegistryRef(FallbackHost, ArtifactRepo, foobar.SBOMImageReferrer.Digest.String())
 			dst := RegistryRef(ZOTHost, repo, "")
-			ORAS("cp", "-r", src, dst, "-v").MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", "-r", src, dst).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 			CompareRef(src, RegistryRef(ZOTHost, repo, foobar.SBOMImageReferrer.Digest.String()))
 			ORAS("discover", "-o", "tree", RegistryRef(ZOTHost, repo, foobar.Digest)).
 				WithDescription("discover referrer via subject").MatchKeyWords(foobar.SignatureImageReferrer.Digest.String(), foobar.SBOMImageReferrer.Digest.String()).Exec()
@@ -346,7 +346,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 		It("should copy an image from a fallback registry to an OCI image layout via digest", func() {
 			dstDir := GinkgoT().TempDir()
 			src := RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag)
-			ORAS("cp", src, dstDir, "-v", Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dstDir, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", LayoutRef(dstDir, foobar.Digest), Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -360,7 +360,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), layoutDir, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", src, dst, "-v", Flags.FromLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst, Flags.FromLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -377,7 +377,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 			ORAS("cp", RegistryRef(ZOTHost, ArtifactRepo, ma.Tag), src, Flags.ToLayout, "-r").Exec()
 			ORAS("cp", RegistryRef(ZOTHost, ArtifactRepo, ma.Tag), src, Flags.ToLayout, "-r", "--platform", "linux/amd64").Exec()
 			// test
-			ORAS("cp", src, Flags.FromLayout, dst, "-r", "-v", "--platform", "linux/amd64").
+			ORAS("cp", src, Flags.FromLayout, dst, "-r", "--platform", "linux/amd64").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.LinuxAMD64.Digest.String()).
 				Exec()
@@ -403,7 +403,7 @@ var _ = Describe("OCI layout users:", func() {
 		It("should copy an image from a registry to an OCI image layout via tag", func() {
 			dst := LayoutRef(GinkgoT().TempDir(), "copied")
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
-			ORAS("cp", src, dst, "-v", Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -417,7 +417,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), src, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", src, dst, "-v", Flags.FromLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst, Flags.FromLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -432,7 +432,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), src, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", src, dst, "-v", Flags.FromLayout, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst, Flags.FromLayout, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -442,7 +442,7 @@ var _ = Describe("OCI layout users:", func() {
 		It("should copy an image from a registry to an OCI image layout via digest", func() {
 			dstDir := GinkgoT().TempDir()
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Digest)
-			ORAS("cp", src, dstDir, "-v", Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dstDir, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", LayoutRef(dstDir, foobar.Digest), Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -456,7 +456,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), layoutDir, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", src, dst, "-v", Flags.FromLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dst, Flags.FromLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -471,7 +471,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), srcDir, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", src, toDir, "-v", Flags.FromLayout, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, toDir, Flags.FromLayout, Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -483,7 +483,7 @@ var _ = Describe("OCI layout users:", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
 			tags := []string{"tag1", "tag2", "tag3"}
 			// test
-			ORAS("cp", src, dstDir+":"+strings.Join(tags, ","), "-v", Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, dstDir+":"+strings.Join(tags, ","), Flags.ToLayout).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			for _, tag := range tags {
@@ -497,7 +497,7 @@ var _ = Describe("OCI layout users:", func() {
 			dst := LayoutRef(GinkgoT().TempDir(), "copied")
 			src := RegistryRef(ZOTHost, ArtifactRepo, foobar.Tag)
 			// test
-			ORAS("cp", "-r", src, dst, "-v", Flags.ToLayout).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", "-r", src, dst, Flags.ToLayout).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -509,7 +509,7 @@ var _ = Describe("OCI layout users:", func() {
 			toDir := GinkgoT().TempDir()
 			src := RegistryRef(ZOTHost, ArtifactRepo, foobar.Digest)
 			// test
-			ORAS("cp", "-r", src, toDir, "-v", Flags.ToLayout).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", "-r", src, toDir, Flags.ToLayout).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", LayoutRef(toDir, foobar.Digest), Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -522,7 +522,7 @@ var _ = Describe("OCI layout users:", func() {
 			toDir := GinkgoT().TempDir()
 			dst := LayoutRef(toDir, "copied")
 			// test
-			ORAS("cp", src, Flags.ToLayout, dst, "-r", "-v").
+			ORAS("cp", src, Flags.ToLayout, dst, "-r").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.Digest).
 				Exec()
@@ -551,7 +551,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ArtifactRepo, ma.Tag), src, Flags.ToLayout, "-r").Exec()
 			// test
-			ORAS("cp", src, Flags.FromLayout, dst, "-r", "-v").
+			ORAS("cp", src, Flags.FromLayout, dst, "-r").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.Digest).
 				Exec()
@@ -582,7 +582,7 @@ var _ = Describe("OCI layout users:", func() {
 			ORAS("cp", RegistryRef(ZOTHost, ArtifactRepo, ma.Tag), src, Flags.ToLayout, "-r").Exec()
 			ORAS("cp", RegistryRef(ZOTHost, ArtifactRepo, ma.Tag), src, Flags.ToLayout, "-r", "--platform", "linux/amd64").Exec()
 			// test
-			ORAS("cp", src, Flags.FromLayout, dst, "-r", "-v", "--platform", "linux/amd64").
+			ORAS("cp", src, Flags.FromLayout, dst, "-r", "--platform", "linux/amd64").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.LinuxAMD64.Digest.String()).
 				Exec()
@@ -607,7 +607,7 @@ var _ = Describe("OCI layout users:", func() {
 			toDir := GinkgoT().TempDir()
 			dst := LayoutRef(toDir, "copied")
 			// test
-			ORAS("cp", src, Flags.ToLayout, dst, "-r", "-v", "--platform", "linux/amd64").
+			ORAS("cp", src, Flags.ToLayout, dst, "-r", "--platform", "linux/amd64").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				MatchKeyWords("Digest: " + ma.LinuxAMD64.Digest.String()).
 				Exec()
@@ -633,7 +633,7 @@ var _ = Describe("OCI layout users:", func() {
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
 			ref := "copied"
 			dst := LayoutRef(layoutDir, ref)
-			ORAS("cp", src, ref, "-v", Flags.ToLayoutPath, layoutDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, ref, Flags.ToLayoutPath, layoutDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -648,7 +648,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), src, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", ref, dst, "-v", Flags.FromLayoutPath, layoutDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", ref, dst, Flags.FromLayoutPath, layoutDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -665,7 +665,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), src, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", srcRef, dstRef, "-v", Flags.FromLayoutPath, srcDir, Flags.ToLayoutPath, toDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", srcRef, dstRef, Flags.FromLayoutPath, srcDir, Flags.ToLayoutPath, toDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -675,7 +675,7 @@ var _ = Describe("OCI layout users:", func() {
 		It("should copy an image from a registry to an OCI image layout via digest using --oci-layout-path", func() {
 			dstDir := GinkgoT().TempDir()
 			src := RegistryRef(ZOTHost, ImageRepo, foobar.Digest)
-			ORAS("cp", src, foobar.Digest, "-v", Flags.ToLayoutPath, dstDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", src, foobar.Digest, Flags.ToLayoutPath, dstDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", LayoutRef(dstDir, foobar.Digest), Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -689,7 +689,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), layoutDir, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", foobar.Digest, dst, "-v", Flags.FromLayoutPath, layoutDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", foobar.Digest, dst, Flags.FromLayoutPath, layoutDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -704,7 +704,7 @@ var _ = Describe("OCI layout users:", func() {
 			// prepare
 			ORAS("cp", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), srcDir, Flags.ToLayout).Exec()
 			// test
-			ORAS("cp", foobar.Digest, foobar.Digest, "-v", Flags.FromLayoutPath, srcDir, Flags.ToLayoutPath, toDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
+			ORAS("cp", foobar.Digest, foobar.Digest, Flags.FromLayoutPath, srcDir, Flags.ToLayoutPath, toDir).MatchStatus(foobarStates, true, len(foobarStates)).Exec()
 			// validate
 			srcManifest := ORAS("manifest", "fetch", src, Flags.Layout).WithDescription("fetch from source to validate").Exec().Out.Contents()
 			dstManifest := ORAS("manifest", "fetch", dst, Flags.Layout).WithDescription("fetch from destination to validate").Exec().Out.Contents()
@@ -719,7 +719,7 @@ var _ = Describe("OCI image spec v1.1.0-rc2 artifact users:", func() {
 		digest := foobar.SBOMArtifactReferrer.Digest.String()
 		src := RegistryRef(Host, ArtifactRepo, digest)
 		dst := RegistryRef(Host, cpTestRepo("referrers"), digest)
-		ORAS("cp", "-r", src, dst, "-v").MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+		ORAS("cp", "-r", src, dst).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 		CompareRef(src, dst)
 	})
 })

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -47,6 +47,19 @@ var _ = Describe("ORAS beginners:", func() {
 			MatchDefaultFlagValue("format", "text", "pull")
 		})
 
+		It("should not show --verbose in help doc", func() {
+			out := ORAS("pull", "--help").MatchKeyWords(ExampleDesc).Exec().Out
+			gomega.Expect(out).ShouldNot(gbytes.Say("--verbose"))
+		})
+
+		It("should show deprecation message for --verbose", func() {
+			tempDir := PrepareTempFiles()
+			ref := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
+			ORAS("pull", ref, "--verbose").
+				WithWorkDir(tempDir).
+				MatchErrKeyWords("Flag --verbose has been deprecated")
+		})
+
 		hintMsg := func(reference string) string {
 			return fmt.Sprintf("Skipped pulling layers without file name in \"org.opencontainers.image.title\"\nUse 'oras copy %s --to-oci-layout <layout-dir>' to pull all layers.\n", reference)
 		}

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -37,7 +37,7 @@ import (
 )
 
 var _ = Describe("ORAS beginners:", func() {
-	When("running pull command", Focus, func() {
+	When("running pull command", func() {
 		It("should show help description with feature flags", func() {
 			out := ORAS("pull", "--help").MatchKeyWords(ExampleDesc).Exec().Out
 			gomega.Expect(out).Should(gbytes.Say("--include-subject\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
@@ -53,12 +53,7 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should show hint for unnamed layer", func() {
 			tempDir := PrepareTempFiles()
 			ref := RegistryRef(ZOTHost, ArtifactRepo, unnamed.Tag)
-			// stateKeys := []match.StateKey{
-			// 	{Digest: "977c6cf8e8ae", Name: "application/vnd.oci.image.manifest.v1+json"},
-			// 	{Digest: "2c26b46b68ff", Name: "application/vnd.oci.image.layer.v1.tar"},
-			// }
 			out := ORAS("pull", ref).WithWorkDir(tempDir).Exec().Out
-			// MatchStatus(stateKeys, true, len(stateKeys)).Exec().Out
 			gomega.Expect(out).Should(gbytes.Say(hintMsg(ref)))
 		})
 

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -37,7 +37,7 @@ import (
 )
 
 var _ = Describe("ORAS beginners:", func() {
-	When("running pull command", func() {
+	When("running pull command", Focus, func() {
 		It("should show help description with feature flags", func() {
 			out := ORAS("pull", "--help").MatchKeyWords(ExampleDesc).Exec().Out
 			gomega.Expect(out).Should(gbytes.Say("--include-subject\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
@@ -53,9 +53,13 @@ var _ = Describe("ORAS beginners:", func() {
 		It("should show hint for unnamed layer", func() {
 			tempDir := PrepareTempFiles()
 			ref := RegistryRef(ZOTHost, ArtifactRepo, unnamed.Tag)
-			ORAS("pull", ref).
-				WithWorkDir(tempDir).
-				MatchContent(hintMsg(ref)).Exec()
+			// stateKeys := []match.StateKey{
+			// 	{Digest: "977c6cf8e8ae", Name: "application/vnd.oci.image.manifest.v1+json"},
+			// 	{Digest: "2c26b46b68ff", Name: "application/vnd.oci.image.layer.v1.tar"},
+			// }
+			out := ORAS("pull", ref).WithWorkDir(tempDir).Exec().Out
+			// MatchStatus(stateKeys, true, len(stateKeys)).Exec().Out
+			gomega.Expect(out).Should(gbytes.Say(hintMsg(ref)))
 		})
 
 		It("should not show hint for unnamed config blob", func() {

--- a/test/e2e/suite/command/pull.go
+++ b/test/e2e/suite/command/pull.go
@@ -183,7 +183,7 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 			pullRoot := "pulled"
 			tempDir := PrepareTempFiles()
 			stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageConfigStateKey(configName))
-			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "-v", "--config", configName, "-o", pullRoot).
+			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--config", configName, "-o", pullRoot).
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				WithWorkDir(tempDir).Exec()
 			// check config
@@ -199,7 +199,7 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 					WithWorkDir(tempDir).Exec()
 			}
 
-			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "-v", "-o", pullRoot, "--keep-old-files").
+			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "-o", pullRoot, "--keep-old-files").
 				ExpectFailure().
 				WithDescription("fail if overwrite old files are disabled")
 		})
@@ -208,7 +208,7 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 			pullRoot := "pulled"
 			tempDir := PrepareTempFiles()
 			stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey)
-			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "-v", "--config", fmt.Sprintf("%s:%s", configName, "???"), "-o", pullRoot).
+			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--config", fmt.Sprintf("%s:%s", configName, "???"), "-o", pullRoot).
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				WithWorkDir(tempDir).Exec()
 			// check config
@@ -228,7 +228,7 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 				foobar.ManifestStateKey),
 				foobar.ImageReferrersStateKeys...,
 			)
-			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, foobar.SignatureImageReferrer.Digest.String()), "-v", "--include-subject").
+			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, foobar.SignatureImageReferrer.Digest.String()), "--include-subject").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				WithWorkDir(tempDir).Exec()
 		})
@@ -274,19 +274,19 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 		})
 
 		It("should pull specific platform", func() {
-			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, "multi"), "--platform", "linux/amd64", "-v", "-o", GinkgoT().TempDir()).
+			ORAS("pull", RegistryRef(ZOTHost, ImageRepo, "multi"), "--platform", "linux/amd64", "-o", GinkgoT().TempDir()).
 				MatchStatus(multi_arch.LinuxAMD64StateKeys, true, len(multi_arch.LinuxAMD64StateKeys)).Exec()
 		})
 
 		It("should pull an artifact with blob", func() {
 			pullRoot := GinkgoT().TempDir()
-			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, blob.Tag), "-v", "-o", pullRoot).Exec()
+			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, blob.Tag), "-o", pullRoot).Exec()
 			Expect(filepath.Join(pullRoot, multi_arch.LayerName)).Should(BeAnExistingFile())
 		})
 
 		It("should pull an artifact with config", func() {
 			pullRoot := GinkgoT().TempDir()
-			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, config.Tag), "-v", "-o", pullRoot).Exec()
+			ORAS("pull", RegistryRef(ZOTHost, ArtifactRepo, config.Tag), "-o", pullRoot).Exec()
 			Expect(filepath.Join(pullRoot, multi_arch.LayerName)).Should(BeAnExistingFile())
 		})
 
@@ -295,7 +295,7 @@ var _ = Describe("OCI spec 1.1 registry users:", func() {
 			stateKeys := append(append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageReferrerConfigStateKeys[0]), foobar.ImageReferrersStateKeys...)
 			src := RegistryRef(ZOTHost, ArtifactRepo, foobar.SignatureImageReferrer.Digest.String())
 			dst := RegistryRef(FallbackHost, repo, "")
-			ORAS("cp", "-r", src, dst, "-v").MatchStatus(stateKeys, true, len(stateKeys)).Exec()
+			ORAS("cp", "-r", src, dst).MatchStatus(stateKeys, true, len(stateKeys)).Exec()
 			CompareRef(src, RegistryRef(FallbackHost, repo, foobar.SignatureImageReferrer.Digest.String()))
 			ORAS("discover", "-o", "tree", RegistryRef(FallbackHost, repo, foobar.Digest)).
 				WithDescription("discover referrer via subject").MatchKeyWords(foobar.SignatureImageReferrer.Digest.String(), foobar.SBOMImageReferrer.Digest.String()).Exec()
@@ -309,7 +309,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 		configName := "test.config"
 		tempDir := PrepareTempFiles()
 		stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageConfigStateKey(configName))
-		ORAS("pull", RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), "-v", "--config", configName, "-o", pullRoot).
+		ORAS("pull", RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), "--config", configName, "-o", pullRoot).
 			MatchStatus(stateKeys, true, len(stateKeys)).
 			WithWorkDir(tempDir).Exec()
 		// check config
@@ -325,7 +325,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 				WithWorkDir(tempDir).Exec()
 		}
 
-		ORAS("pull", RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), "-v", "-o", pullRoot, "--keep-old-files").
+		ORAS("pull", RegistryRef(FallbackHost, ArtifactRepo, foobar.Tag), "-o", pullRoot, "--keep-old-files").
 			ExpectFailure().
 			WithDescription("fail if overwrite old files are disabled")
 	})
@@ -337,7 +337,7 @@ var _ = Describe("OCI spec 1.0 registry users:", func() {
 			foobar.ManifestStateKey),
 			foobar.ImageReferrersStateKeys...,
 		)
-		ORAS("pull", RegistryRef(FallbackHost, ArtifactRepo, foobar.SignatureImageReferrer.Digest.String()), "-v", "--include-subject").
+		ORAS("pull", RegistryRef(FallbackHost, ArtifactRepo, foobar.SignatureImageReferrer.Digest.String()), "--include-subject").
 			MatchStatus(stateKeys, true, len(stateKeys)).
 			WithWorkDir(tempDir).Exec()
 	})
@@ -352,7 +352,7 @@ var _ = Describe("OCI image layout users:", func() {
 			pullRoot := "pulled"
 			root := PrepareTempOCI(ImageRepo)
 			stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageConfigStateKey(configName))
-			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.Tag), "-v", "--config", configName, "-o", pullRoot).
+			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.Tag), "--config", configName, "-o", pullRoot).
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				WithWorkDir(root).Exec()
 			// check config
@@ -368,7 +368,7 @@ var _ = Describe("OCI image layout users:", func() {
 					WithWorkDir(root).Exec()
 			}
 
-			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.Tag), "-v", "-o", pullRoot, "--keep-old-files").
+			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.Tag), "-o", pullRoot, "--keep-old-files").
 				ExpectFailure().
 				WithDescription("fail if overwrite old files are disabled")
 		})
@@ -377,7 +377,7 @@ var _ = Describe("OCI image layout users:", func() {
 			pullRoot := "pulled"
 			root := PrepareTempOCI(ImageRepo)
 			stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey)
-			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.Tag), "-v", "--config", fmt.Sprintf("%s:%s", configName, "???"), "-o", pullRoot).
+			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.Tag), "--config", fmt.Sprintf("%s:%s", configName, "???"), "-o", pullRoot).
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				WithWorkDir(root).Exec()
 			// check config
@@ -397,14 +397,14 @@ var _ = Describe("OCI image layout users:", func() {
 				foobar.ManifestStateKey),
 				foobar.ImageReferrersStateKeys...,
 			)
-			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.SignatureImageReferrer.Digest.String()), "-v", "--include-subject").
+			ORAS("pull", Flags.Layout, LayoutRef(root, foobar.SignatureImageReferrer.Digest.String()), "--include-subject").
 				MatchStatus(stateKeys, true, len(stateKeys)).
 				WithWorkDir(root).Exec()
 		})
 
 		It("should pull specific platform", func() {
 			root := PrepareTempOCI(ImageRepo)
-			ORAS("pull", Flags.Layout, LayoutRef(root, multi_arch.Tag), "--platform", "linux/amd64", "-v", "-o", root).
+			ORAS("pull", Flags.Layout, LayoutRef(root, multi_arch.Tag), "--platform", "linux/amd64", "-o", root).
 				MatchStatus(multi_arch.LinuxAMD64StateKeys, true, len(multi_arch.LinuxAMD64StateKeys)).Exec()
 		})
 	})
@@ -416,7 +416,7 @@ var _ = Describe("OCI image spec v1.1.0-rc2 artifact users:", func() {
 		configName := "test.config"
 		tempDir := PrepareTempFiles()
 		stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageConfigStateKey(configName))
-		ORAS("pull", RegistryRef(Host, ImageRepo, foobar.Tag), "-v", "--config", configName, "-o", pullRoot).
+		ORAS("pull", RegistryRef(Host, ImageRepo, foobar.Tag), "--config", configName, "-o", pullRoot).
 			MatchStatus(stateKeys, true, len(stateKeys)).
 			WithWorkDir(tempDir).Exec()
 		// check config
@@ -432,7 +432,7 @@ var _ = Describe("OCI image spec v1.1.0-rc2 artifact users:", func() {
 				WithWorkDir(tempDir).Exec()
 		}
 
-		ORAS("pull", RegistryRef(Host, ImageRepo, foobar.Tag), "-v", "-o", pullRoot, "--keep-old-files").
+		ORAS("pull", RegistryRef(Host, ImageRepo, foobar.Tag), "-o", pullRoot, "--keep-old-files").
 			ExpectFailure().
 			WithDescription("fail if overwrite old files are disabled")
 	})
@@ -444,7 +444,7 @@ var _ = Describe("OCI image spec v1.1.0-rc2 artifact users:", func() {
 			foobar.ManifestStateKey),
 			foobar.ArtifactReferrerStateKeys...,
 		)
-		ORAS("pull", RegistryRef(Host, ArtifactRepo, foobar.SignatureArtifactReferrer.Digest.String()), "-v", "--include-subject").
+		ORAS("pull", RegistryRef(Host, ArtifactRepo, foobar.SignatureArtifactReferrer.Digest.String()), "--include-subject").
 			MatchStatus(stateKeys, true, len(stateKeys)).
 			WithWorkDir(tempDir).Exec()
 	})

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -143,7 +143,7 @@ var _ = Describe("Remote registry users:", func() {
 			tempDir := PrepareTempFiles()
 			ref := RegistryRef(ZOTHost, repo, tag)
 
-			ORAS("push", ref, foobar.FileBarName, "-v").
+			ORAS("push", ref, foobar.FileBarName).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 
@@ -159,7 +159,7 @@ var _ = Describe("Remote registry users:", func() {
 			ref := RegistryRef(ZOTHost, repo, tag)
 			absBarName := filepath.Join(PrepareTempFiles(), foobar.FileBarName)
 
-			ORAS("push", ref, absBarName, "-v", "--disable-path-validation").
+			ORAS("push", ref, absBarName, "--disable-path-validation").
 				Exec()
 
 			// validate
@@ -181,7 +181,7 @@ var _ = Describe("Remote registry users:", func() {
 			ref := RegistryRef(ZOTHost, repo, tag)
 			absBarName := filepath.Join(PrepareTempFiles(), foobar.FileBarName)
 			// test
-			ORAS("push", ref, absBarName, "-v").
+			ORAS("push", ref, absBarName).
 				MatchErrKeyWords("--disable-path-validation").
 				ExpectFailure().
 				Exec()
@@ -192,7 +192,7 @@ var _ = Describe("Remote registry users:", func() {
 			tempDir := PrepareTempFiles()
 			extraTag := "2e2"
 
-			ORAS("push", fmt.Sprintf("%s,%s", RegistryRef(ZOTHost, repo, tag), extraTag), foobar.FileBarName, "-v", "--format", "go-template={{range .referenceAsTags}}{{println .}}{{end}}").
+			ORAS("push", fmt.Sprintf("%s,%s", RegistryRef(ZOTHost, repo, tag), extraTag), foobar.FileBarName, "--format", "go-template={{range .referenceAsTags}}{{println .}}{{end}}").
 				MatchContent(fmt.Sprintf("%s\n%s\n", RegistryRef(ZOTHost, repo, extraTag), RegistryRef(ZOTHost, repo, tag))).
 				WithWorkDir(tempDir).Exec()
 
@@ -212,7 +212,7 @@ var _ = Describe("Remote registry users:", func() {
 			tempDir := PrepareTempFiles()
 			extraTag := "2e2"
 
-			out := ORAS("push", fmt.Sprintf("%s,%s", RegistryRef(ZOTHost, repo, tag), extraTag), foobar.FileBarName, "-v", "--format", "json").
+			out := ORAS("push", fmt.Sprintf("%s,%s", RegistryRef(ZOTHost, repo, tag), extraTag), foobar.FileBarName, "--format", "json").
 				WithWorkDir(tempDir).
 				Exec().Out.Contents()
 			Expect(json.Unmarshal(out, &struct{}{})).ShouldNot(HaveOccurred())
@@ -222,7 +222,7 @@ var _ = Describe("Remote registry users:", func() {
 			repo := pushTestRepo("layer-mediatype")
 			layerType := "layer/type"
 			tempDir := PrepareTempFiles()
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName+":"+layerType, "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName+":"+layerType).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -237,7 +237,7 @@ var _ = Describe("Remote registry users:", func() {
 			layerType := "layer/type"
 			tempDir := PrepareTempFiles()
 			exportPath := "packed.json"
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName+":"+layerType, "-v", "--export-manifest", exportPath).
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName+":"+layerType, "--export-manifest", exportPath).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -249,7 +249,7 @@ var _ = Describe("Remote registry users:", func() {
 			repo := pushTestRepo("config")
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", foobar.FileConfigName, foobar.FileBarName, "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", foobar.FileConfigName, foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					foobar.FileConfigStateKey,
 					foobar.FileBarStateKey,
@@ -271,7 +271,7 @@ var _ = Describe("Remote registry users:", func() {
 			configType := "my/config/type"
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName, "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					{Digest: foobar.FileConfigStateKey.Digest, Name: configType},
 					foobar.FileBarStateKey,
@@ -294,7 +294,7 @@ var _ = Describe("Remote registry users:", func() {
 			configType := "config/type"
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName, "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					{Digest: foobar.FileConfigStateKey.Digest, Name: configType},
 					foobar.FileBarStateKey,
@@ -317,7 +317,7 @@ var _ = Describe("Remote registry users:", func() {
 			value := "image-anno-value"
 			tempDir := PrepareTempFiles()
 			// test
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "-v", "--annotation", fmt.Sprintf("%s=%s", key, value)).
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--annotation", fmt.Sprintf("%s=%s", key, value)).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -331,7 +331,7 @@ var _ = Describe("Remote registry users:", func() {
 			repo := pushTestRepo("file-annotation")
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "-v", "--annotation-file", "foobar/annotation.json", "--config", foobar.FileConfigName).
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--annotation-file", "foobar/annotation.json", "--config", foobar.FileConfigName).
 				MatchStatus(statusKeys, true, 1).
 				WithWorkDir(tempDir).Exec()
 
@@ -356,7 +356,7 @@ var _ = Describe("Remote registry users:", func() {
 			annotationValue := "value"
 
 			// test
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), "-a", fmt.Sprintf("%s=%s", annotationKey, annotationValue), "-v", "--artifact-type", artifactType).
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "-a", fmt.Sprintf("%s=%s", annotationKey, annotationValue), "--artifact-type", artifactType).
 				MatchStatus([]match.StateKey{artifact.DefaultConfigStateKey}, true, 1).
 				WithWorkDir(tempDir).Exec()
 
@@ -414,7 +414,7 @@ var _ = Describe("Remote registry users:", func() {
 			repo := pushTestRepo("artifact-with-blob")
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName).
 				MatchStatus([]match.StateKey{foobar.FileBarStateKey, artifact.DefaultConfigStateKey}, true, 2).
 				WithWorkDir(tempDir).Exec()
 
@@ -431,7 +431,7 @@ var _ = Describe("Remote registry users:", func() {
 			repo := pushTestRepo("print-artifact-type-v1-1")
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "-v", "--image-spec", "v1.1").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--image-spec", "v1.1").
 				MatchKeyWords("ArtifactType: ", "application/vnd.unknown.artifact.v1").
 				WithWorkDir(tempDir).Exec()
 		})
@@ -441,7 +441,7 @@ var _ = Describe("Remote registry users:", func() {
 			configType := "config/type"
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName, "-v", "--image-spec", "v1.0").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName, "--image-spec", "v1.0").
 				MatchKeyWords("ArtifactType: ", configType).
 				WithWorkDir(tempDir).Exec()
 		})
@@ -450,7 +450,7 @@ var _ = Describe("Remote registry users:", func() {
 			repo := pushTestRepo("v1.1-artifact")
 			tempDir := PrepareTempFiles()
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "-v", "--image-spec", "v1.1").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--image-spec", "v1.1").
 				MatchStatus([]match.StateKey{foobar.FileBarStateKey, artifact.DefaultConfigStateKey}, true, 2).
 				WithWorkDir(tempDir).Exec()
 
@@ -468,7 +468,7 @@ var _ = Describe("Remote registry users:", func() {
 			tempDir := PrepareTempFiles()
 			configType := "test/config+json"
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType)).
 				MatchStatus([]match.StateKey{
 					foobar.FileBarStateKey,
 					{Digest: foobar.FileConfigStateKey.Digest, Name: configType},
@@ -491,7 +491,7 @@ var _ = Describe("Remote registry users:", func() {
 			artifactType := "test/artifact+json"
 			configType := "test/config+json"
 
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--artifact-type", artifactType, "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), "-v").
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), foobar.FileBarName, "--artifact-type", artifactType, "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType)).
 				MatchStatus([]match.StateKey{
 					foobar.FileBarStateKey,
 					{Digest: foobar.FileConfigStateKey.Digest, Name: configType},
@@ -522,7 +522,7 @@ var _ = Describe("OCI image layout users:", func() {
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
 			// test
-			ORAS("push", Flags.Layout, ref, foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, ref, foobar.FileBarName).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -537,7 +537,7 @@ var _ = Describe("OCI image layout users:", func() {
 			ref := LayoutRef(tempDir, tag)
 			extraTag := "2e2"
 
-			ORAS("push", Flags.Layout, fmt.Sprintf("%s,%s", ref, extraTag), foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, fmt.Sprintf("%s,%s", ref, extraTag), foobar.FileBarName).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 
@@ -556,7 +556,7 @@ var _ = Describe("OCI image layout users:", func() {
 			layerType := "layer.type"
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", Flags.Layout, ref, foobar.FileBarName+":"+layerType, "-v").
+			ORAS("push", Flags.Layout, ref, foobar.FileBarName+":"+layerType).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -571,7 +571,7 @@ var _ = Describe("OCI image layout users:", func() {
 			layerType := "layer.type"
 			exportPath := "packed.json"
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", ref, Flags.Layout, foobar.FileBarName+":"+layerType, "-v", "--export-manifest", exportPath).
+			ORAS("push", ref, Flags.Layout, foobar.FileBarName+":"+layerType, "--export-manifest", exportPath).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -582,7 +582,7 @@ var _ = Describe("OCI image layout users:", func() {
 		It("should push files with customized config file", func() {
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", Flags.Layout, ref, "--config", foobar.FileConfigName, foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, ref, "--config", foobar.FileConfigName, foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					foobar.FileConfigStateKey,
 					foobar.FileBarStateKey,
@@ -603,7 +603,7 @@ var _ = Describe("OCI image layout users:", func() {
 			configType := "config/type"
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", Flags.Layout, ref, "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, ref, "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					{Digest: foobar.FileConfigStateKey.Digest, Name: configType},
 					foobar.FileBarStateKey,
@@ -623,7 +623,7 @@ var _ = Describe("OCI image layout users:", func() {
 		It("should push files with platform", func() {
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", Flags.Layout, ref, "--artifact-platform", "darwin/arm64", foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, ref, "--artifact-platform", "darwin/arm64", foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					foobar.PlatformConfigStateKey,
 					foobar.FileBarStateKey,
@@ -647,7 +647,7 @@ var _ = Describe("OCI image layout users:", func() {
 		It("should fail to customize config mediaType when baking config blob with platform for v1.0", func() {
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", Flags.Layout, ref, "--image-spec", "v1.0", "--artifact-type", "test/artifact+json", "--artifact-platform", "darwin/arm64", foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, ref, "--image-spec", "v1.0", "--artifact-type", "test/artifact+json", "--artifact-platform", "darwin/arm64", foobar.FileBarName).
 				ExpectFailure().
 				Exec()
 		})
@@ -655,7 +655,7 @@ var _ = Describe("OCI image layout users:", func() {
 		It("should push files with platform with no artifactType for v1.0", func() {
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
-			ORAS("push", Flags.Layout, ref, "--image-spec", "v1.0", "--artifact-platform", "darwin/arm64", foobar.FileBarName, "-v").
+			ORAS("push", Flags.Layout, ref, "--image-spec", "v1.0", "--artifact-platform", "darwin/arm64", foobar.FileBarName).
 				MatchStatus([]match.StateKey{
 					foobar.PlatformV1DEfaultConfigStateKey,
 					foobar.FileBarStateKey,
@@ -678,7 +678,7 @@ var _ = Describe("OCI image layout users:", func() {
 			key := "image-anno-key"
 			value := "image-anno-value"
 			// test
-			ORAS("push", Flags.Layout, ref, foobar.FileBarName, "-v", "--annotation", fmt.Sprintf("%s=%s", key, value)).
+			ORAS("push", Flags.Layout, ref, foobar.FileBarName, "--annotation", fmt.Sprintf("%s=%s", key, value)).
 				MatchStatus(statusKeys, true, len(statusKeys)).
 				WithWorkDir(tempDir).Exec()
 			// validate
@@ -692,7 +692,7 @@ var _ = Describe("OCI image layout users:", func() {
 			tempDir := PrepareTempFiles()
 			ref := LayoutRef(tempDir, tag)
 			// test
-			ORAS("push", ref, Flags.Layout, foobar.FileBarName, "-v", "--annotation-file", "foobar/annotation.json", "--config", foobar.FileConfigName).
+			ORAS("push", ref, Flags.Layout, foobar.FileBarName, "--annotation-file", "foobar/annotation.json", "--config", foobar.FileConfigName).
 				MatchStatus(statusKeys, true, 1).
 				WithWorkDir(tempDir).Exec()
 

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -45,6 +45,21 @@ var _ = Describe("ORAS beginners:", func() {
 			MatchDefaultFlagValue("format", "text", "push")
 		})
 
+		It("should not show --verbose in help doc", func() {
+			out := ORAS("push", "--help").MatchKeyWords(ExampleDesc).Exec().Out
+			gomega.Expect(out).ShouldNot(gbytes.Say("--verbose"))
+		})
+
+		It("should show deprecation message for --verbose", func() {
+			repo := pushTestRepo("test-verbose")
+			tag := "e2e"
+			tempDir := PrepareTempFiles()
+
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--verbose").
+				WithWorkDir(tempDir).
+				MatchErrKeyWords("Flag --verbose has been deprecated")
+		})
+
 		It("should fail and show detailed error description if no argument provided", func() {
 			err := ORAS("push").ExpectFailure().Exec().Err
 			gomega.Expect(err).Should(gbytes.Say("Error"))

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -134,12 +134,12 @@ var _ = Describe("1.1 registry users:", func() {
 				WithDescription("prepare: copy tag with different digest").
 				Exec()
 			// test
-			viaTag := ORAS("repo", "tags", "-v", RegistryRef(ZOTHost, repo, foobar.Tag)).
+			viaTag := ORAS("repo", "tags", RegistryRef(ZOTHost, repo, foobar.Tag)).
 				MatchKeyWords(tags...).
 				MatchErrKeyWords(feature.Experimental.Mark, foobar.Digest).Exec().Out
 			Expect(viaTag).ShouldNot(gbytes.Say(multi_arch.Tag))
 
-			viaDigest := ORAS("repo", "tags", "-v", RegistryRef(ZOTHost, repo, foobar.Digest)).
+			viaDigest := ORAS("repo", "tags", RegistryRef(ZOTHost, repo, foobar.Digest)).
 				MatchKeyWords(tags...).
 				MatchErrKeyWords(feature.Experimental.Mark, foobar.Digest).Exec().Out
 			Expect(viaDigest).ShouldNot(gbytes.Say(multi_arch.Tag))
@@ -189,12 +189,12 @@ var _ = Describe("OCI image layout users:", func() {
 			tags := []string{foobar.Tag, "bax", "bay", "baz"}
 			root := prepare(ImageRepo, foobar.Tag, tags...)
 			// test
-			viaTag := ORAS("repo", "tags", "-v", LayoutRef(root, foobar.Tag), Flags.Layout).
+			viaTag := ORAS("repo", "tags", LayoutRef(root, foobar.Tag), Flags.Layout).
 				WithDescription("via tag").
 				MatchKeyWords(tags...).
 				MatchErrKeyWords(feature.Experimental.Mark, foobar.Digest).Exec().Out
 			Expect(viaTag).ShouldNot(gbytes.Say(multi_arch.Tag))
-			viaDigest := ORAS("repo", "tags", "-v", LayoutRef(root, foobar.Digest), Flags.Layout).
+			viaDigest := ORAS("repo", "tags", LayoutRef(root, foobar.Digest), Flags.Layout).
 				WithDescription("via digest").
 				MatchKeyWords(tags...).
 				MatchErrKeyWords(feature.Experimental.Mark, foobar.Digest).Exec().Out

--- a/test/e2e/suite/command/resolve_host.go
+++ b/test/e2e/suite/command/resolve_host.go
@@ -126,7 +126,7 @@ var _ = Describe("1.1 registry users:", func() {
 			It("should copy an image with source resolve DNS rules", func() {
 				repo := testRepo("cp/from")
 				dst := RegistryRef(Host, repo, "copied")
-				ORAS(append([]string{"cp", RegistryRef(mockedHost, ImageRepo, foobar.Tag), dst, "-v"}, from...)...).
+				ORAS(append([]string{"cp", RegistryRef(mockedHost, ImageRepo, foobar.Tag), dst}, from...)...).
 					MatchStatus(foobarStates, true, len(foobarStates)).
 					Exec()
 				CompareRef(RegistryRef(Host, ImageRepo, foobar.Tag), dst)
@@ -136,7 +136,7 @@ var _ = Describe("1.1 registry users:", func() {
 				src := RegistryRef(Host, ImageRepo, foobar.Tag)
 				repo := testRepo("cp/to")
 				tag := "copied"
-				ORAS(append([]string{"cp", src, RegistryRef(mockedHost, repo, tag), "-v"}, to...)...).
+				ORAS(append([]string{"cp", src, RegistryRef(mockedHost, repo, tag)}, to...)...).
 					MatchStatus(foobarStates, true, len(foobarStates)).
 					Exec()
 				CompareRef(src, RegistryRef(Host, repo, tag))
@@ -147,7 +147,7 @@ var _ = Describe("1.1 registry users:", func() {
 				repo := testRepo("cp/base")
 				tag := "copied"
 				flags := append(to[2:], "--resolve", unary[1]) //hack to chop the destination flags off
-				ORAS(append([]string{"cp", src, RegistryRef(mockedHost, repo, tag), "-v"}, flags...)...).
+				ORAS(append([]string{"cp", src, RegistryRef(mockedHost, repo, tag)}, flags...)...).
 					MatchStatus(foobarStates, true, len(foobarStates)).
 					Exec()
 				CompareRef(src, RegistryRef(Host, repo, tag))
@@ -157,7 +157,7 @@ var _ = Describe("1.1 registry users:", func() {
 				repo := testRepo("cp/override")
 				tag := "copied"
 				flags := append(append(to, from...), "--resolve", mockedHost+":80:1.1.1.1:5000")
-				ORAS(append([]string{"cp", RegistryRef(mockedHost, ImageRepo, foobar.Tag), RegistryRef(mockedHost, repo, tag), "-v"}, flags...)...).
+				ORAS(append([]string{"cp", RegistryRef(mockedHost, ImageRepo, foobar.Tag), RegistryRef(mockedHost, repo, tag)}, flags...)...).
 					MatchStatus(foobarStates, true, len(foobarStates)).
 					Exec()
 				CompareRef(RegistryRef(Host, ImageRepo, foobar.Tag), RegistryRef(Host, repo, tag))
@@ -215,7 +215,7 @@ var _ = Describe("1.1 registry users:", func() {
 				tempDir := PrepareTempFiles()
 				stateKeys := append(foobar.ImageLayerStateKeys, foobar.ManifestStateKey, foobar.ImageConfigStateKey(configName))
 				// test
-				ORAS(append([]string{"pull", RegistryRef(mockedHost, ImageRepo, foobar.Tag), "-v", "--config", configName, "-o", pullRoot}, unary...)...).
+				ORAS(append([]string{"pull", RegistryRef(mockedHost, ImageRepo, foobar.Tag), "--config", configName, "-o", pullRoot}, unary...)...).
 					MatchStatus(stateKeys, true, len(stateKeys)).
 					WithWorkDir(tempDir).Exec()
 				// validate config and layers
@@ -235,7 +235,7 @@ var _ = Describe("1.1 registry users:", func() {
 			It("should push files without customized media types", func() {
 				repo := testRepo("push")
 				tempDir := PrepareTempFiles()
-				ORAS(append([]string{"push", RegistryRef(mockedHost, repo, foobar.Tag), "-v"}, append(foobar.FileLayerNames, unary...)...)...).
+				ORAS(append([]string{"push", RegistryRef(mockedHost, repo, foobar.Tag)}, append(foobar.FileLayerNames, unary...)...)...).
 					MatchStatus(foobar.FileStateKeys, true, len(foobar.FileStateKeys)).
 					WithWorkDir(tempDir).Exec()
 			})

--- a/test/e2e/suite/scenario/oci_artifact.go
+++ b/test/e2e/suite/scenario/oci_artifact.go
@@ -37,7 +37,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 		pulledManifest := "packed.json"
 		pullRoot := "pulled"
 		It("should push and pull an artifact", func() {
-			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--artifact-type", "test/artifact", foobar.FileLayerNames[0], foobar.FileLayerNames[1], foobar.FileLayerNames[2], "-v", "--export-manifest", pulledManifest).
+			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--artifact-type", "test/artifact", foobar.FileLayerNames[0], foobar.FileLayerNames[1], foobar.FileLayerNames[2], "--export-manifest", pulledManifest).
 				MatchStatus(foobar.FileStateKeys, true, 3).
 				WithWorkDir(tempDir).
 				WithDescription("push with manifest exported").Exec()
@@ -45,7 +45,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 			fetched := ORAS("manifest", "fetch", RegistryRef(ZOTHost, repo, tag)).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 
-			ORAS("pull", RegistryRef(ZOTHost, repo, tag), "-v", "-o", pullRoot).
+			ORAS("pull", RegistryRef(ZOTHost, repo, tag), "-o", pullRoot).
 				MatchStatus(foobar.FileStateKeys, true, 3).
 				WithWorkDir(tempDir).
 				WithDescription("pull artFiles with config").Exec()
@@ -59,7 +59,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 
 		It("should attach and pull an artifact", func() {
 			subject := RegistryRef(ZOTHost, repo, tag)
-			ORAS("attach", subject, "--artifact-type", "test/artifact1", fmt.Sprint(foobar.AttachFileName, ":", foobar.AttachFileMedia), "-v", "--export-manifest", pulledManifest).
+			ORAS("attach", subject, "--artifact-type", "test/artifact1", fmt.Sprint(foobar.AttachFileName, ":", foobar.AttachFileMedia), "--export-manifest", pulledManifest).
 				MatchStatus([]match.StateKey{foobar.AttachFileStateKey}, true, 1).
 				WithWorkDir(tempDir).
 				WithDescription("attach with manifest exported").Exec()
@@ -68,7 +68,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 			fetched := ORAS("manifest", "fetch", ref).MatchKeyWords(foobar.AttachFileMedia).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 
-			ORAS("pull", ref, "-v", "-o", pullRoot).
+			ORAS("pull", ref, "-o", pullRoot).
 				MatchStatus([]match.StateKey{foobar.AttachFileStateKey}, true, 1).
 				WithWorkDir(tempDir).
 				WithDescription("pull attached artifact").Exec()
@@ -76,7 +76,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 				WithWorkDir(tempDir).
 				WithDescription("download identical file " + foobar.AttachFileName).Exec()
 
-			ORAS("attach", subject, "--artifact-type", "test/artifact2", fmt.Sprint(foobar.AttachFileName, ":", foobar.AttachFileMedia), "-v", "--export-manifest", pulledManifest).
+			ORAS("attach", subject, "--artifact-type", "test/artifact2", fmt.Sprint(foobar.AttachFileName, ":", foobar.AttachFileMedia), "--export-manifest", pulledManifest).
 				MatchStatus([]match.StateKey{foobar.AttachFileStateKey}, true, 1).
 				WithWorkDir(tempDir).
 				WithDescription("attach again with manifest exported").Exec()
@@ -85,7 +85,7 @@ var _ = Describe("OCI artifact users:", Ordered, func() {
 			fetched = ORAS("manifest", "fetch", ref).MatchKeyWords(foobar.AttachFileMedia).Exec()
 			MatchFile(filepath.Join(tempDir, pulledManifest), string(fetched.Out.Contents()), DefaultTimeout)
 
-			ORAS("pull", ref, "-v", "-o", pullRoot, "--include-subject").
+			ORAS("pull", ref, "-o", pullRoot, "--include-subject").
 				MatchStatus(append(foobar.FileStateKeys, foobar.AttachFileStateKey), true, 4).
 				WithWorkDir(tempDir).
 				WithDescription("pull attached artifact and subject").Exec()

--- a/test/e2e/suite/scenario/oci_image.go
+++ b/test/e2e/suite/scenario/oci_image.go
@@ -36,7 +36,7 @@ var _ = Describe("OCI image user:", Ordered, func() {
 
 		It("should push and pull an image", func() {
 			manifestName := "packed.json"
-			ORAS("push", RegistryRef(Host, repo, tag), "--config", files[0], files[1], files[2], files[3], "-v", "--export-manifest", manifestName).
+			ORAS("push", RegistryRef(Host, repo, tag), "--config", files[0], files[1], files[2], files[3], "--export-manifest", manifestName).
 				MatchStatus(statusKeys, true, 4).
 				WithWorkDir(tempDir).
 				WithDescription("push files with manifest exported").Exec()
@@ -46,7 +46,7 @@ var _ = Describe("OCI image user:", Ordered, func() {
 			MatchFile(filepath.Join(tempDir, manifestName), string(fetched), DefaultTimeout)
 
 			pullRoot := "pulled"
-			ORAS("pull", RegistryRef(Host, repo, tag), "-v", "--config", files[0], "-o", pullRoot).
+			ORAS("pull", RegistryRef(Host, repo, tag), "--config", files[0], "-o", pullRoot).
 				MatchStatus(statusKeys, true, 3).
 				WithWorkDir(tempDir).
 				WithDescription("pull files with config").Exec()


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Print a deprecation message if the `--verbose` flag is used
2. Hide the `--verbose` flag in help docs
3. Print status output for untitled blobs by default
4. Refactor internal types
5. Update the corresponding tests
---

**This PR is still WIP, pending items:**

- Adding more e2e tests
- Testing manually

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1533

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
