### PR TITLE
bump: tag and release ORAS CLI v1.2.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.2.0"
+	Version = "1.2.1"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes to tag v1.2.1 based on a0228556766b6276010d8feb937af512e8a50808, commit changes to branch release-1.2 and release. At least 3 approvals are needed from the 5 owners.

Below is a summary of change notes since [v1.2.0](https://github.com/oras-project/oras/releases/tag/v1.2.0):

## Bug Fixes
- Fix https://github.com/oras-project/oras/issues/1436: `oras tag` no longer creates referrer tag.

## Other Changes
- Bump Golang to 1.23.4
- Update dependencies
- Enhance document


## Detailed Commits
* bump: golang version to fix CVE-2024-24790 and CVE-2024-34156 by @qweeah in https://github.com/oras-project/oras/pull/1562
* chore: bump golang and dependencies by @qweeah in https://github.com/oras-project/oras/pull/1564
* chore: backport main-branch fixes into release-1.2 branch by @qweeah in https://github.com/oras-project/oras/pull/1567
* docs: add experimental marks to examples by @qweeah in https://github.com/oras-project/oras/pull/1570

**Full Changelog**: https://github.com/oras-project/oras/compare/v1.2.0...release-1.2

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
