### PR TITLE
bump: tag and release ORAS CLI v1.2.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.2.1"
+	Version = "1.2.2"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR proposes to tag `v1.2.2` based on 677529b4e7c38e3295e0883a2ee8a536e3a860f4, commit changes to branch `release-1.2` and release. At least 3 approvals are needed from the 5 owners.

Below is a summary of change notes since [v1.2.1](https://github.com/oras-project/oras/releases/tag/v1.2.1):

## Changes

- Minor security enhancements: address [CVE-2024-45337](https://github.com/advisories/GHSA-v778-237x-gjrc)

>[!NOTE]
> The `oras` CLI is not impacted by CVE-2024-45337 since `oras` is a client tool.

## Detailed Commits
* build(deps): bump golang.org/x/crypto from 0.26.0 to 0.31.0 by @Wwwsylvia in https://github.com/oras-project/oras/pull/1591

**Full Changelog**: https://github.com/oras-project/oras/compare/v1.2.1...677529b4e7c38e3295e0883a2ee8a536e3a860f4
