### PR TITLE
docs: add Sylvia Lei as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @sajayantony @shizhMSFT @stevelasker @qweeah @TerryHowe
+* @sajayantony @shizhMSFT @stevelasker @qweeah @Wwwsylvia @TerryHowe

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,7 @@
 
 Maintainers:
 - Billy Zha (@qweeah)
+- Sylvia Lei (@Wwwsylvia)
 - Terry Howe (@TerryHowe)
 
 [Owners](OWNERS.md) are also maintainers.


### PR DESCRIPTION
Nominate Sylvia Lei (@Wwwsylvia) as a maintainer of the `oras` repository.

Sylvia has contributed and merged `5` PRs and reviewed `19` PRs during the last half a year (180 days). Since Sylvia is the major maintainer of the `oras-go` repository, she will address the issues in the CLI in a quicker way and reflect in the `oras-go` development holistically.