### PR TITLE
chore: add SVG file to license checker ignoring list

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -37,6 +37,7 @@ header:
     - 'go.sum'
     - 'go.work'
     - '**/testdata/**'
+    - '**/*.svg'
 
   comment: on-failure
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to add SVG file to license checker ignoring list since this is graphic files instead of code. There is not necessary to add license check to SVG files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/oras-project/oras/issues/1619

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
