### PR TITLE
fix: bump `oras-go` to the latest commit which fixes the symlink issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	golang.org/x/sync v0.11.0
 	golang.org/x/term v0.29.0
 	gopkg.in/yaml.v3 v3.0.1
-	oras.land/oras-go/v2 v2.5.0
+	oras.land/oras-go/v2 v2.5.1-0.20250221033735-cb6d75be7dd4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -69,5 +69,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oras.land/oras-go/v2 v2.5.0 h1:o8Me9kLY74Vp5uw07QXPiitjsw7qNXi8Twd+19Zf02c=
-oras.land/oras-go/v2 v2.5.0/go.mod h1:z4eisnLP530vwIOUOJeBIj0aGI0L1C3d53atvCBqZHg=
+oras.land/oras-go/v2 v2.5.1-0.20250221033735-cb6d75be7dd4 h1:jlMeewI2WJwjGjhCDC5uQHAVOwyXypeMz7NUZiRhr+4=
+oras.land/oras-go/v2 v2.5.1-0.20250221033735-cb6d75be7dd4/go.mod h1:2UW9eta1+52EMtMRD2gottf9g5EZv9o3gkKfk1iedVw=


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the `oras-go` dependency to the latest commit [`cb6d75be7dd4a78f25fe9d00c76c0d15c4296da6`](https://github.com/oras-project/oras-go/commit/cb6d75be7dd4a78f25fe9d00c76c0d15c4296da6) which includes the bug fix for https://github.com/oras-project/oras-go/issues/865.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1593

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
