### PR TITLE
refactor: use iter for cleaner code

### DIFF
--- a/cmd/oras/internal/option/applier.go
+++ b/cmd/oras/internal/option/applier.go
@@ -29,8 +29,7 @@ type FlagApplier interface {
 // NOTE: The option argument need to be a pointer to the options, so its value
 // becomes addressable.
 func ApplyFlags(optsPtr interface{}, target *pflag.FlagSet) {
-	_ = rangeFields(optsPtr, func(fa FlagApplier) error {
-		fa.ApplyFlags(target)
-		return nil
-	})
+	for applier := range fields[FlagApplier](optsPtr) {
+		applier.ApplyFlags(target)
+	}
 }

--- a/cmd/oras/internal/option/applier.go
+++ b/cmd/oras/internal/option/applier.go
@@ -28,7 +28,7 @@ type FlagApplier interface {
 // target flag set.
 // NOTE: The option argument need to be a pointer to the options, so its value
 // becomes addressable.
-func ApplyFlags(optsPtr interface{}, target *pflag.FlagSet) {
+func ApplyFlags(optsPtr any, target *pflag.FlagSet) {
 	for applier := range fields[FlagApplier](optsPtr) {
 		applier.ApplyFlags(target)
 	}

--- a/cmd/oras/internal/option/parser.go
+++ b/cmd/oras/internal/option/parser.go
@@ -38,8 +38,8 @@ func Parse(cmd *cobra.Command, optsPtr any) error {
 	return nil
 }
 
-// fields goes through all fields of ptr, optionally run fn if a field is
-// public AND typed T.
+// fields goes through all fields of ptr, optionally run fn if a field is public
+// AND typed T.
 func fields[T any](ptr any) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		v := reflect.ValueOf(ptr).Elem()

--- a/cmd/oras/internal/option/parser.go
+++ b/cmd/oras/internal/option/parser.go
@@ -16,6 +16,7 @@ limitations under the License.
 package option
 
 import (
+	"iter"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -29,25 +30,29 @@ type FlagParser interface {
 // Parse parses applicable fields of the passed-in option pointer and returns
 // error during parsing.
 func Parse(cmd *cobra.Command, optsPtr interface{}) error {
-	return rangeFields(optsPtr, func(fp FlagParser) error {
-		return fp.Parse(cmd)
-	})
+	for parser := range fields[FlagParser](optsPtr) {
+		if err := parser.Parse(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// rangeFields goes through all fields of ptr, optionally run fn if a field is
+// fields goes through all fields of ptr, optionally run fn if a field is
 // public AND typed T.
-func rangeFields[T any](ptr any, fn func(T) error) error {
-	v := reflect.ValueOf(ptr).Elem()
-	for i := 0; i < v.NumField(); i++ {
-		f := v.Field(i)
-		if f.CanSet() {
-			iface := f.Addr().Interface()
-			if opts, ok := iface.(T); ok {
-				if err := fn(opts); err != nil {
-					return err
+func fields[T any](ptr any) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		v := reflect.ValueOf(ptr).Elem()
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if f.CanSet() {
+				iface := f.Addr().Interface()
+				if opts, ok := iface.(T); ok {
+					if !yield(opts) {
+						return
+					}
 				}
 			}
 		}
 	}
-	return nil
 }

--- a/cmd/oras/internal/option/parser.go
+++ b/cmd/oras/internal/option/parser.go
@@ -43,7 +43,7 @@ func Parse(cmd *cobra.Command, optsPtr any) error {
 func fields[T any](ptr any) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		v := reflect.ValueOf(ptr).Elem()
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			f := v.Field(i)
 			if f.CanSet() {
 				if opts, ok := f.Addr().Interface().(T); ok {

--- a/cmd/oras/internal/option/parser.go
+++ b/cmd/oras/internal/option/parser.go
@@ -29,7 +29,7 @@ type FlagParser interface {
 
 // Parse parses applicable fields of the passed-in option pointer and returns
 // error during parsing.
-func Parse(cmd *cobra.Command, optsPtr interface{}) error {
+func Parse(cmd *cobra.Command, optsPtr any) error {
 	for parser := range fields[FlagParser](optsPtr) {
 		if err := parser.Parse(cmd); err != nil {
 			return err

--- a/cmd/oras/internal/option/parser.go
+++ b/cmd/oras/internal/option/parser.go
@@ -38,8 +38,8 @@ func Parse(cmd *cobra.Command, optsPtr any) error {
 	return nil
 }
 
-// fields goes through all fields of ptr, optionally run fn if a field is public
-// AND typed T.
+// fields returns an iterator that yields all fields of the given struct that
+// implement the given interface.
 func fields[T any](ptr any) iter.Seq[T] {
 	return func(yield func(T) bool) {
 		v := reflect.ValueOf(ptr).Elem()

--- a/cmd/oras/internal/option/parser.go
+++ b/cmd/oras/internal/option/parser.go
@@ -46,8 +46,7 @@ func fields[T any](ptr any) iter.Seq[T] {
 		for i := 0; i < v.NumField(); i++ {
 			f := v.Field(i)
 			if f.CanSet() {
-				iface := f.Addr().Interface()
-				if opts, ok := iface.(T); ok {
+				if opts, ok := f.Addr().Interface().(T); ok {
 					if !yield(opts) {
 						return
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactor code for better readability, leveraging the new `iter` package.
