### PR TITLE
refactor: split a run and main function so defers Execute

### DIFF
--- a/cmd/oras/main.go
+++ b/cmd/oras/main.go
@@ -23,10 +23,14 @@ import (
 	"oras.land/oras/cmd/oras/root"
 )
 
-func main() {
+func run() error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
-	if err := root.New().ExecuteContext(ctx); err != nil {
+	return root.New().ExecuteContext(ctx)
+}
+
+func main() {
+	if err := run(); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: So the `defer cancel()` runs. Go won't run defers if `os.Exit()` is called, so in the case of an error the context cancelation will not run. See https://go.dev/play/p/0AIokfnVk0m for an example. Probably not a big deal, but something I noticed poking around the source code while exploring oras and thought I would send this small PR.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test? Nope
- [ ]  Does this change require a documentation update? No
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? No
- [ ]  Do all new files have an appropriate license header? n/a
