### PR TITLE
fix: bring back `--verbose` flag

### DIFF
--- a/cmd/oras/internal/option/verbose.go
+++ b/cmd/oras/internal/option/verbose.go
@@ -1,0 +1,25 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import "github.com/spf13/pflag"
+
+// AddDeprecatedVerboseFlag adds the deprecated verbose flag to a command
+func AddDeprecatedVerboseFlag(flags *pflag.FlagSet) {
+	// ignoring the variable of the verbose flag, since we will not use it
+	_ = flags.BoolP("verbose", "v", true, "verbose output")
+	_ = flags.MarkDeprecated("verbose", "and will be removed in a future release.")
+}

--- a/cmd/oras/internal/option/verbose.go
+++ b/cmd/oras/internal/option/verbose.go
@@ -20,6 +20,6 @@ import "github.com/spf13/pflag"
 // AddDeprecatedVerboseFlag adds the deprecated verbose flag to a command
 func AddDeprecatedVerboseFlag(flags *pflag.FlagSet) {
 	// ignoring the variable of the verbose flag, since we will not use it
-	_ = flags.BoolP("verbose", "v", true, "verbose output")
+	_ = flags.BoolP("verbose", "v", false, "verbose output")
 	_ = flags.MarkDeprecated("verbose", "and will be removed in a future release.")
 }

--- a/cmd/oras/root/blob/delete.go
+++ b/cmd/oras/root/blob/delete.go
@@ -37,6 +37,8 @@ type deleteBlobOptions struct {
 	option.Descriptor
 	option.Pretty
 	option.Target
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func deleteCmd() *cobra.Command {
@@ -69,6 +71,8 @@ Example - Delete a blob and print its descriptor:
 		},
 	}
 
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/blob/delete.go
+++ b/cmd/oras/root/blob/delete.go
@@ -37,8 +37,6 @@ type deleteBlobOptions struct {
 	option.Descriptor
 	option.Pretty
 	option.Target
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func deleteCmd() *cobra.Command {
@@ -71,8 +69,7 @@ Example - Delete a blob and print its descriptor:
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/blob/fetch.go
+++ b/cmd/oras/root/blob/fetch.go
@@ -94,7 +94,7 @@ Example - Fetch and print a blob from OCI image layout archive file 'layout.tar'
 	}
 
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "output file `path`, use - for stdout")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/blob/fetch.go
+++ b/cmd/oras/root/blob/fetch.go
@@ -42,8 +42,6 @@ type fetchBlobOptions struct {
 	option.Target
 
 	outputPath string
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func fetchCmd() *cobra.Command {
@@ -94,8 +92,7 @@ Example - Fetch and print a blob from OCI image layout archive file 'layout.tar'
 	}
 
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "output file `path`, use - for stdout")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/blob/fetch.go
+++ b/cmd/oras/root/blob/fetch.go
@@ -42,6 +42,8 @@ type fetchBlobOptions struct {
 	option.Target
 
 	outputPath string
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func fetchCmd() *cobra.Command {
@@ -92,6 +94,8 @@ Example - Fetch and print a blob from OCI image layout archive file 'layout.tar'
 	}
 
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "output file `path`, use - for stdout")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -37,8 +37,6 @@ type loginOptions struct {
 	option.Common
 	option.Remote
 	Hostname string
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func loginCmd() *cobra.Command {
@@ -75,8 +73,7 @@ Example - Log in with username and password in an interactive terminal and no TL
 			return runLogin(cmd, opts)
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)
 }

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -37,6 +37,8 @@ type loginOptions struct {
 	option.Common
 	option.Remote
 	Hostname string
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func loginCmd() *cobra.Command {
@@ -73,6 +75,8 @@ Example - Log in with username and password in an interactive terminal and no TL
 			return runLogin(cmd, opts)
 		},
 	}
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)
 }

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -75,7 +75,7 @@ Example - Log in with username and password in an interactive terminal and no TL
 			return runLogin(cmd, opts)
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -74,7 +74,7 @@ Example - Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -37,6 +37,8 @@ type deleteOptions struct {
 	option.Descriptor
 	option.Pretty
 	option.Target
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func deleteCmd() *cobra.Command {
@@ -72,6 +74,8 @@ Example - Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614
 		},
 	}
 
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -37,8 +37,6 @@ type deleteOptions struct {
 	option.Descriptor
 	option.Pretty
 	option.Target
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func deleteCmd() *cobra.Command {
@@ -74,10 +72,9 @@ Example - Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	opts.EnableDistributionSpecFlag()
 	option.ApplyFlags(&opts, cmd.Flags())
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }
 

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -40,8 +40,6 @@ type fetchOptions struct {
 
 	mediaTypes []string
 	outputPath string
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func fetchCmd() *cobra.Command {
@@ -108,8 +106,7 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 		option.FormatTypeJSON.WithUsage("Print in prettified JSON format"),
 		option.FormatTypeGoTemplate.WithUsage("Print using the given Go template"),
 	)
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -40,6 +40,8 @@ type fetchOptions struct {
 
 	mediaTypes []string
 	outputPath string
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func fetchCmd() *cobra.Command {
@@ -106,6 +108,8 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 		option.FormatTypeJSON.WithUsage("Print in prettified JSON format"),
 		option.FormatTypeGoTemplate.WithUsage("Print using the given Go template"),
 	)
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/manifest/fetch.go
+++ b/cmd/oras/root/manifest/fetch.go
@@ -108,7 +108,7 @@ Example - Fetch raw manifest from an OCI layout archive file 'layout.tar':
 		option.FormatTypeJSON.WithUsage("Print in prettified JSON format"),
 		option.FormatTypeGoTemplate.WithUsage("Print using the given Go template"),
 	)
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/manifest/fetch_config.go
+++ b/cmd/oras/root/manifest/fetch_config.go
@@ -42,8 +42,6 @@ type fetchConfigOptions struct {
 	option.Target
 
 	outputPath string
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func fetchConfigCmd() *cobra.Command {
@@ -86,8 +84,7 @@ Example - Fetch and print the prettified descriptor of the config:
 	}
 
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "file `path` to write the fetched config to, use - for stdout")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/manifest/fetch_config.go
+++ b/cmd/oras/root/manifest/fetch_config.go
@@ -42,6 +42,8 @@ type fetchConfigOptions struct {
 	option.Target
 
 	outputPath string
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func fetchConfigCmd() *cobra.Command {
@@ -84,6 +86,8 @@ Example - Fetch and print the prettified descriptor of the config:
 	}
 
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "file `path` to write the fetched config to, use - for stdout")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/manifest/fetch_config.go
+++ b/cmd/oras/root/manifest/fetch_config.go
@@ -86,7 +86,7 @@ Example - Fetch and print the prettified descriptor of the config:
 	}
 
 	cmd.Flags().StringVarP(&opts.outputPath, "output", "o", "", "file `path` to write the fetched config to, use - for stdout")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -34,8 +34,6 @@ type repositoryOptions struct {
 	hostname  string
 	namespace string
 	last      string
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func listCmd() *cobra.Command {
@@ -69,8 +67,7 @@ Example - List the repositories under the registry that include values lexically
 	}
 
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the repository specified by `last`")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)
 }

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -69,7 +69,7 @@ Example - List the repositories under the registry that include values lexically
 	}
 
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the repository specified by `last`")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -34,6 +34,8 @@ type repositoryOptions struct {
 	hostname  string
 	namespace string
 	last      string
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func listCmd() *cobra.Command {
@@ -67,6 +69,8 @@ Example - List the repositories under the registry that include values lexically
 	}
 
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the repository specified by `last`")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Remote)
 }

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -33,8 +33,6 @@ type showTagsOptions struct {
 
 	last             string
 	excludeDigestTag bool
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func showTagsCmd() *cobra.Command {
@@ -77,8 +75,7 @@ Example - [Experimental] Show tags associated with a digest:
 	}
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the tag specified by `last`")
 	cmd.Flags().BoolVar(&opts.excludeDigestTag, "exclude-digest-tags", false, "[Preview] exclude all digest-like tags such as 'sha256-aaaa...'")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -77,7 +77,7 @@ Example - [Experimental] Show tags associated with a digest:
 	}
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the tag specified by `last`")
 	cmd.Flags().BoolVar(&opts.excludeDigestTag, "exclude-digest-tags", false, "[Preview] exclude all digest-like tags such as 'sha256-aaaa...'")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/repo/tags.go
+++ b/cmd/oras/root/repo/tags.go
@@ -33,6 +33,8 @@ type showTagsOptions struct {
 
 	last             string
 	excludeDigestTag bool
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func showTagsCmd() *cobra.Command {
@@ -75,6 +77,8 @@ Example - [Experimental] Show tags associated with a digest:
 	}
 	cmd.Flags().StringVar(&opts.last, "last", "", "start after the tag specified by `last`")
 	cmd.Flags().BoolVar(&opts.excludeDigestTag, "exclude-digest-tags", false, "[Preview] exclude all digest-like tags such as 'sha256-aaaa...'")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -33,6 +33,8 @@ type resolveOptions struct {
 	option.Target
 
 	fullRef bool
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func resolveCmd() *cobra.Command {
@@ -58,6 +60,8 @@ Example - Resolve digest of the target artifact:
 	}
 
 	cmd.Flags().BoolVarP(&opts.fullRef, "full-reference", "l", false, "print the full artifact reference with digest")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -33,8 +33,6 @@ type resolveOptions struct {
 	option.Target
 
 	fullRef bool
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func resolveCmd() *cobra.Command {
@@ -60,8 +58,7 @@ Example - Resolve digest of the target artifact:
 	}
 
 	cmd.Flags().BoolVarP(&opts.fullRef, "full-reference", "l", false, "print the full artifact reference with digest")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/cmd/oras/root/resolve.go
+++ b/cmd/oras/root/resolve.go
@@ -60,7 +60,7 @@ Example - Resolve digest of the target artifact:
 	}
 
 	cmd.Flags().BoolVarP(&opts.fullRef, "full-reference", "l", false, "print the full artifact reference with digest")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	option.ApplyFlags(&opts, cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -38,6 +38,8 @@ type tagOptions struct {
 
 	concurrency int
 	targetRefs  []string
+	// Deprecated: verbose is deprecated and will be removed in the future.
+	verbose bool
 }
 
 func tagCmd() *cobra.Command {
@@ -96,6 +98,8 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 	option.ApplyFlags(&opts, cmd.Flags())
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	return oerrors.Command(cmd, &opts.Target)
 }
 

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -96,6 +96,7 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 	option.ApplyFlags(&opts, cmd.Flags())
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
+	option.AddDeprecatedVerboseFlag(cmd.Flags())
 	return oerrors.Command(cmd, &opts.Target)
 }
 

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -38,8 +38,6 @@ type tagOptions struct {
 
 	concurrency int
 	targetRefs  []string
-	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
 }
 
 func tagCmd() *cobra.Command {
@@ -98,8 +96,6 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 	option.ApplyFlags(&opts, cmd.Flags())
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
-	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	return oerrors.Command(cmd, &opts.Target)
 }
 

--- a/cmd/oras/root/tag.go
+++ b/cmd/oras/root/tag.go
@@ -98,7 +98,7 @@ Example - Tag the manifest 'v1.0.1' to 'v1.0.2' in an OCI image layout folder 'l
 
 	option.ApplyFlags(&opts, cmd.Flags())
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "verbose output")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	return oerrors.Command(cmd, &opts.Target)
 }

--- a/test/e2e/suite/auth/auth.go
+++ b/test/e2e/suite/auth/auth.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"oras.land/oras-go/v2"
+	"oras.land/oras/test/e2e/internal/testdata/feature"
 	"oras.land/oras/test/e2e/internal/testdata/foobar"
 	. "oras.land/oras/test/e2e/internal/utils"
 )
@@ -90,6 +91,11 @@ var _ = Describe("Common registry user", func() {
 				WithTimeOut(20*time.Second).
 				MatchContent("Login Succeeded\n").
 				MatchErrKeyWords("WARNING", "Using --password via the CLI is insecure", "Use --password-stdin").Exec()
+		})
+
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("login", ZOTHost, "-u", Username, "-p", Password, "--registry-config", filepath.Join(GinkgoT().TempDir(), tmpConfigName), "--verbose").
+				MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
 		})
 
 		It("should show detailed error description if no argument provided", func() {

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -252,6 +252,13 @@ var _ = Describe("1.1 registry users:", func() {
 				MatchKeyWords("Missing", toDeleteRef).
 				Exec()
 		})
+
+		It("should show deprecation message when running with --verbose flag", func() {
+			dstRepo := fmt.Sprintf(repoFmt, "delete", "blob-delete-verbose")
+			CopyZOTRepo(BlobRepo, dstRepo)
+			toDeleteRef := RegistryRef(ZOTHost, dstRepo, foobar.FooBlobDigest)
+			ORAS("blob", "delete", toDeleteRef, "--verbose").MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
 	})
 	When("running `blob push`", func() {
 		It("should push a blob from a file and output the descriptor with specific media-type", func() {

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -296,7 +296,7 @@ var _ = Describe("1.1 registry users:", func() {
 				MatchContent(foobar.FooBlobContent).Exec()
 		})
 		It("should show deprecation message when running with --verbose flag", func() {
-			ORAS("blob", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.FooBlobDigest), "--verbose").
+			ORAS("blob", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.FooBlobDigest), "--descriptor", "--verbose").
 				MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
 		})
 		It("should fetch blob content and output to a file", func() {

--- a/test/e2e/suite/command/blob.go
+++ b/test/e2e/suite/command/blob.go
@@ -295,6 +295,10 @@ var _ = Describe("1.1 registry users:", func() {
 			ORAS("blob", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.FooBlobDigest), "--output", "-").
 				MatchContent(foobar.FooBlobContent).Exec()
 		})
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("blob", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.FooBlobDigest), "--verbose").
+				MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
 		It("should fetch blob content and output to a file", func() {
 			tempDir := GinkgoT().TempDir()
 			contentPath := filepath.Join(tempDir, "fetched")

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -451,6 +451,11 @@ var _ = Describe("1.1 registry users:", func() {
 				MatchContent("{}").Exec()
 		})
 
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("manifest", "fetch-config", RegistryRef(ZOTHost, ImageRepo, foobar.Tag)).
+				MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
+
 		It("should fetch a config descriptor via a tag", func() {
 			ORAS("manifest", "fetch-config", "--descriptor", RegistryRef(ZOTHost, ImageRepo, foobar.Tag)).
 				MatchContent(foobar.ImageConfigDesc).Exec()

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -486,6 +486,13 @@ var _ = Describe("1.1 registry users:", func() {
 			validateTag(RegistryRef(ZOTHost, dstRepo, ""), tempTag, true)
 		})
 
+		It("should show deprecation message when running with --verbose flag", func() {
+			dstRepo := fmt.Sprintf(repoFmt, "delete", "verbose-flag")
+			prepare(RegistryRef(ZOTHost, ImageRepo, foobar.Tag), RegistryRef(ZOTHost, dstRepo, tempTag))
+			ORAS("manifest", "delete", RegistryRef(ZOTHost, dstRepo, tempTag), "--verbose").
+				MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
+
 		It("should do confirmed deletion via flag", func() {
 			dstRepo := fmt.Sprintf(repoFmt, "delete", "confirm-flag")
 			prepare(RegistryRef(ZOTHost, ImageRepo, foobar.Tag), RegistryRef(ZOTHost, dstRepo, tempTag))

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -134,6 +134,10 @@ var _ = Describe("ORAS beginners:", func() {
 				MatchDefaultFlagValue("format", "text", "manifest", "fetch")
 			})
 
+			It("should show deprecation message when running with --verbose flag", func() {
+				ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--verbose").MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+			})
+
 			It("should fail and show detailed error description if no argument provided", func() {
 				err := ORAS("manifest", "fetch").ExpectFailure().Exec().Err
 				gomega.Expect(err).Should(gbytes.Say("Error"))

--- a/test/e2e/suite/command/manifest.go
+++ b/test/e2e/suite/command/manifest.go
@@ -452,7 +452,7 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 
 		It("should show deprecation message when running with --verbose flag", func() {
-			ORAS("manifest", "fetch-config", RegistryRef(ZOTHost, ImageRepo, foobar.Tag)).
+			ORAS("manifest", "fetch-config", RegistryRef(ZOTHost, ImageRepo, foobar.Tag), "--verbose").
 				MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
 		})
 

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -94,7 +94,7 @@ var _ = Describe("1.1 registry users:", func() {
 			ORAS("repo", "ls", RegistryRef(ZOTHost, Namespace, "")).MatchKeyWords(ImageRepo[len(Namespace)+1:]).Exec()
 		})
 		It("should show deprecation message when running with --verbose flag", func() {
-			ORAS("repo", "ls", RegistryRef(ZOTHost, Namespace, "--verbose")).MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+			ORAS("repository", "list", ZOTHost, "--verbose").MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
 		})
 
 		It("should not list repositories without a fully matched namespace", func() {
@@ -122,7 +122,9 @@ var _ = Describe("1.1 registry users:", func() {
 		})
 		It("should list tags via short command", func() {
 			ORAS("repo", "tags", repoRef).MatchKeyWords(multi_arch.Tag, foobar.Tag).Exec()
-
+		})
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("repo", "tags", repoRef, "--verbose").MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
 		})
 
 		It("Should list out tags associated to the provided reference", func() {

--- a/test/e2e/suite/command/repo.go
+++ b/test/e2e/suite/command/repo.go
@@ -93,6 +93,9 @@ var _ = Describe("1.1 registry users:", func() {
 		It("should list repositories under provided namespace", func() {
 			ORAS("repo", "ls", RegistryRef(ZOTHost, Namespace, "")).MatchKeyWords(ImageRepo[len(Namespace)+1:]).Exec()
 		})
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("repo", "ls", RegistryRef(ZOTHost, Namespace, "--verbose")).MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
 
 		It("should not list repositories without a fully matched namespace", func() {
 			repo := "command-draft/images"

--- a/test/e2e/suite/command/resolve.go
+++ b/test/e2e/suite/command/resolve.go
@@ -78,6 +78,9 @@ var _ = Describe("Common registry user", func() {
 			out := ORAS("digest", "-l", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag)).Exec().Out
 			gomega.Expect(out).To(gbytes.Say(fmt.Sprintf("%s/%s@%s", ZOTHost, ImageRepo, multi_arch.Digest)))
 		})
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("resolve", RegistryRef(ZOTHost, ImageRepo, multi_arch.Digest), "--verbose").MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
 		It("should resolve with a fully qualified reference for a platform", func() {
 			out := ORAS("resolve", "--full-reference", "--platform", "linux/amd64", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag)).Exec().Out
 			gomega.Expect(out).To(gbytes.Say(fmt.Sprintf("%s/%s@%s", ZOTHost, ImageRepo, multi_arch.LinuxAMD64.Digest)))

--- a/test/e2e/suite/command/tag.go
+++ b/test/e2e/suite/command/tag.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"oras.land/oras/test/e2e/internal/testdata/feature"
 	"oras.land/oras/test/e2e/internal/testdata/foobar"
 	"oras.land/oras/test/e2e/internal/testdata/multi_arch"
 	. "oras.land/oras/test/e2e/internal/utils"
@@ -68,6 +69,9 @@ func tagAndValidate(reg string, repo string, tagOrDigest string, digestText stri
 
 var _ = Describe("1.1 registry users:", func() {
 	When("running `tag`", func() {
+		It("should show deprecation message when running with --verbose flag", func() {
+			ORAS("tag", RegistryRef(ZOTHost, ImageRepo, multi_arch.Tag), "latest", "--verbose").MatchErrKeyWords(feature.DeprecationMessageVerboseFlag).Exec()
+		})
 		It("should add a tag to an existent manifest when providing tag reference", func() {
 			tagAndValidate(ZOTHost, ImageRepo, multi_arch.Tag, multi_arch.Digest, "tag-via-tag")
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR brings back the `--verbose` flag to the following commands and mark it as deprecated.

oras blob delete
oras blob fetch
oras login
oras manifest delete
oras manifest fetch
oras manifest fetch-config
oras repo ls
oras repo tags
oras resolve
oras tag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1640 

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
