### PR TITLE
refactor: simplify manifest index metadata handler

### DIFF
--- a/cmd/oras/internal/display/metadata/discard.go
+++ b/cmd/oras/internal/display/metadata/discard.go
@@ -48,7 +48,7 @@ func (Discard) OnTagged(ocispec.Descriptor, string) error {
 }
 
 // OnIndexCreated implements ManifestIndexCreateHandler.
-func (Discard) OnIndexCreated(ocispec.Descriptor) {}
+func (Discard) OnIndexCreated(ocispec.Descriptor) error { return nil }
 
 // OnBlobPushed implements BlobPushHandler
 func (Discard) OnBlobPushed(target *option.Target) error {

--- a/cmd/oras/internal/display/metadata/interface.go
+++ b/cmd/oras/internal/display/metadata/interface.go
@@ -90,9 +90,8 @@ type ManifestPushHandler interface {
 // ManifestIndexCreateHandler handles metadata output for index create events.
 type ManifestIndexCreateHandler interface {
 	TaggedHandler
-	Renderer
 
-	OnIndexCreated(desc ocispec.Descriptor)
+	OnIndexCreated(desc ocispec.Descriptor) error
 }
 
 // ManifestIndexUpdateHandler handles metadata output for index update events.

--- a/cmd/oras/internal/display/metadata/text/manifest_index.go
+++ b/cmd/oras/internal/display/metadata/text/manifest_index.go
@@ -24,7 +24,6 @@ import (
 // ManifestIndexCreateHandler handles text metadata output for index create events.
 type ManifestIndexCreateHandler struct {
 	printer *output.Printer
-	root    ocispec.Descriptor
 }
 
 // NewManifestIndexCreateHandler returns a new handler for index create events.
@@ -40,11 +39,6 @@ func (h *ManifestIndexCreateHandler) OnTagged(_ ocispec.Descriptor, tag string) 
 }
 
 // OnIndexCreated implements ManifestIndexCreateHandler.
-func (h *ManifestIndexCreateHandler) OnIndexCreated(desc ocispec.Descriptor) {
-	h.root = desc
-}
-
-// Render implements ManifestIndexCreateHandler.
-func (h *ManifestIndexCreateHandler) Render() error {
-	return h.printer.Println("Digest:", h.root.Digest)
+func (h *ManifestIndexCreateHandler) OnIndexCreated(desc ocispec.Descriptor) error {
+	return h.printer.Println("Digest:", desc.Digest)
 }

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -137,8 +137,7 @@ func createIndex(cmd *cobra.Command, opts createOptions) error {
 			return err
 		}
 	}
-	displayMetadata.OnIndexCreated(desc)
-	return displayMetadata.Render()
+	return displayMetadata.OnIndexCreated(desc)
 }
 
 func fetchSourceManifests(ctx context.Context, displayStatus status.ManifestIndexCreateHandler, target oras.ReadOnlyTarget, sources []string) ([]ocispec.Descriptor, error) {

--- a/cmd/oras/root/manifest/index/update.go
+++ b/cmd/oras/root/manifest/index/update.go
@@ -151,8 +151,7 @@ func updateIndex(cmd *cobra.Command, opts updateOptions) error {
 			return err
 		}
 	}
-	displayMetadata.OnIndexCreated(desc)
-	return displayMetadata.Render()
+	return displayMetadata.OnIndexCreated(desc)
 }
 
 func fetchIndex(ctx context.Context, handler status.ManifestIndexUpdateHandler, target oras.ReadOnlyTarget, reference string) (ocispec.Index, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is kind of an example of why composition can be better than inheritance.
