### PR TITLE
fix: staticcheck fails for embedded member

### DIFF
--- a/cmd/oras/internal/option/confirmation_test.go
+++ b/cmd/oras/internal/option/confirmation_test.go
@@ -26,8 +26,8 @@ import (
 func TestConfirmation_ApplyFlags(t *testing.T) {
 	var test struct{ Confirmation }
 	ApplyFlags(&test, pflag.NewFlagSet("oras-test", pflag.ExitOnError))
-	if test.Confirmation.Force != false {
-		t.Fatalf("expecting Confirmed to be false but got: %v", test.Confirmation.Force)
+	if test.Force != false {
+		t.Fatalf("expecting Confirmed to be false but got: %v", test.Force)
 	}
 }
 

--- a/cmd/oras/internal/option/descriptor_test.go
+++ b/cmd/oras/internal/option/descriptor_test.go
@@ -28,8 +28,8 @@ import (
 func TestDescriptor_ApplyFlags(t *testing.T) {
 	var test struct{ Descriptor }
 	ApplyFlags(&test, pflag.NewFlagSet("oras-test", pflag.ExitOnError))
-	if test.Descriptor.OutputDescriptor != false {
-		t.Fatalf("expecting OutputDescriptor to be false but got: %v", test.Descriptor.OutputDescriptor)
+	if test.OutputDescriptor != false {
+		t.Fatalf("expecting OutputDescriptor to be false but got: %v", test.OutputDescriptor)
 	}
 }
 

--- a/cmd/oras/internal/option/platform_test.go
+++ b/cmd/oras/internal/option/platform_test.go
@@ -25,8 +25,8 @@ import (
 func TestPlatform_ApplyFlags(t *testing.T) {
 	var test struct{ Platform }
 	ApplyFlags(&test, pflag.NewFlagSet("oras-test", pflag.ExitOnError))
-	if test.Platform.platform != "" {
-		t.Fatalf("expecting platform to be empty but got: %v", test.Platform.platform)
+	if test.platform != "" {
+		t.Fatalf("expecting platform to be empty but got: %v", test.platform)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

These embedded members fail staticcheck for newest lint because the embedded member cannot be extracted. This PR is for tests only. There is another PR for non-tests.
