### PR TITLE
fix: calls to close in tests unchecked

### DIFF
--- a/cmd/oras/internal/display/status/progress/messenger_test.go
+++ b/cmd/oras/internal/display/status/progress/messenger_test.go
@@ -32,7 +32,7 @@ func Test_messenger_Update(t *testing.T) {
 			progress.StateTransmitted:  "tested",
 		},
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
 		Size:      1234567890,
@@ -113,7 +113,7 @@ func Test_messenger_Fail(t *testing.T) {
 	m := &messenger{
 		update: make(chan statusUpdate, 1),
 	}
-	defer m.Close()
+	defer func() { _ = m.Close() }()
 	s := new(status)
 	errTest := errors.New("test error")
 
@@ -122,7 +122,7 @@ func Test_messenger_Fail(t *testing.T) {
 	}
 	update := <-m.update
 	update(s)
-	if s.err != errTest {
+	if !errors.Is(errTest, s.err) {
 		t.Errorf("messenger.Fail() = %v, want %v", s.err, errTest)
 	}
 }

--- a/cmd/oras/internal/option/pretty_test.go
+++ b/cmd/oras/internal/option/pretty_test.go
@@ -45,7 +45,7 @@ func TestPretty_Output(t *testing.T) {
 	if err != nil {
 		t.Fatal("error calling os.Create(), error =", err)
 	}
-	defer fp.Close()
+	defer func() { _ = fp.Close() }()
 
 	// test unprettified content
 	opts := Pretty{

--- a/internal/credential/store_test.go
+++ b/internal/credential/store_test.go
@@ -30,7 +30,7 @@ func TestNewStoreError(t *testing.T) {
 	if err != nil {
 		t.Errorf("error: cannot create file : %v", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	err = os.Chmod(filename, 000)
 	if err != nil {

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -65,7 +65,7 @@ func TestFile_PrepareManifestContent_fromStdin(t *testing.T) {
 	if err != nil {
 		t.Fatal("error calling os.Create(), error =", err)
 	}
-	defer tmpfile.Close()
+	defer func() { _ = tmpfile.Close() }()
 
 	if _, err := tmpfile.Write(content); err != nil {
 		t.Fatal("error calling Write(), error =", err)
@@ -189,7 +189,7 @@ func TestFile_PrepareBlobContent_fromStdin(t *testing.T) {
 	if err != nil {
 		t.Fatal("error calling os.Create(), error =", err)
 	}
-	defer tmpfile.Close()
+	defer func() { _ = tmpfile.Close() }()
 
 	if _, err := tmpfile.Write(content); err != nil {
 		t.Fatal("error calling Write(), error =", err)
@@ -211,7 +211,7 @@ func TestFile_PrepareBlobContent_fromStdin(t *testing.T) {
 
 	// test PrepareBlobContent with provided digest and size
 	gotDesc, gotRc, err := file.PrepareBlobContent("-", blobMediaType, string(dgst), size)
-	defer gotRc.Close()
+	defer func() { _ = gotRc.Close() }()
 	if err != nil {
 		t.Fatal("PrepareBlobContent() error=", err)
 	}

--- a/internal/progress/example_test.go
+++ b/internal/progress/example_test.go
@@ -47,7 +47,7 @@ func ExampleTrackReader() {
 	})
 	// Close takes no effect for TrackerFunc but should be called for general
 	// Tracker implementations.
-	defer tracker.Close()
+	defer func() { _ = tracker.Close() }()
 
 	// Wrap a reader of a random content generator with the progress tracker.
 	r := io.LimitReader(rand.Reader, total)

--- a/internal/progress/tracker_test.go
+++ b/internal/progress/tracker_test.go
@@ -360,8 +360,8 @@ func TestTrackReader(t *testing.T) {
 			return wantErr
 		})
 		pipeReader, pipeWriter := io.Pipe()
-		pipeReader.Close()
-		pipeWriter.Close()
+		_ = pipeReader.Close()
+		_ = pipeWriter.Close()
 		gotReader := TrackReader(tracker, pipeReader)
 
 		buf := make([]byte, bufSize)


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignore some error returns for tests to fix newer lint.
