### PR TITLE
fix: staticcheck lint failures of embedded member

### DIFF
--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -59,7 +59,7 @@ func NewConsole(f *os.File) (Console, error) {
 // GetHeightWidth returns the width and height of the console.
 // If the console size cannot be determined, returns a default value of 80x10.
 func (c *console) GetHeightWidth() (height, width int) {
-	windowSize, err := c.Console.Size()
+	windowSize, err := c.Size()
 	if err != nil {
 		return MinHeight, MinWidth
 	}

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -112,7 +112,7 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
 	}
 
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
-	cmd.Flags().StringVarP(&opts.Format.FormatFlag, "output", "o", "tree", "[Deprecated] format in which to display referrers (table, json, or tree).")
+	cmd.Flags().StringVarP(&opts.FormatFlag, "output", "o", "tree", "[Deprecated] format in which to display referrers (table, json, or tree).")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "display full metadata of referrers")
 	cmd.Flags().IntVarP(&opts.depth, "depth", "", 0, "[Experimental] level of referrers to display, if unused shows referrers of all levels")
 	opts.SetTypes(

--- a/cmd/oras/root/login.go
+++ b/cmd/oras/root/login.go
@@ -112,7 +112,7 @@ func runLogin(cmd *cobra.Command, opts loginOptions) (err error) {
 	if err != nil {
 		return err
 	}
-	remote, err := opts.Remote.NewRegistry(opts.Hostname, opts.Common, logger)
+	remote, err := opts.NewRegistry(opts.Hostname, opts.Common, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -249,9 +249,9 @@ func runPush(cmd *cobra.Command, opts *pushOptions) error {
 	}
 	copyOptions := oras.DefaultCopyOptions
 	copyOptions.Concurrency = opts.concurrency
-	copyOptions.CopyGraphOptions.OnCopySkipped = statusHandler.OnCopySkipped
-	copyOptions.CopyGraphOptions.PreCopy = statusHandler.PreCopy
-	copyOptions.CopyGraphOptions.PostCopy = statusHandler.PostCopy
+	copyOptions.OnCopySkipped = statusHandler.OnCopySkipped
+	copyOptions.PreCopy = statusHandler.PreCopy
+	copyOptions.PostCopy = statusHandler.PostCopy
 	copyWithScopeHint := func(root ocispec.Descriptor) error {
 		// add both pull and push scope hints for dst repository
 		// to save potential push-scope token requests during copy

--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -74,7 +74,7 @@ Example - List the repositories under the registry that include values lexically
 
 func listRepository(cmd *cobra.Command, opts *repositoryOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
-	reg, err := opts.Remote.NewRegistry(opts.hostname, opts.Common, logger)
+	reg, err := opts.NewRegistry(opts.hostname, opts.Common, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Newer lint fails on these embedded struct members reference.
