### PR TITLE
fix: packer decode json lint failure

### DIFF
--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -114,12 +114,16 @@ func (opts *Packer) parseAnnotations(cmd *cobra.Command) error {
 	return nil
 }
 
-// decodeJSON decodes a json file v to filename.
+// decodeJSON decodes file contents into json.
 func decodeJSON(filename string, v interface{}) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	return json.NewDecoder(file).Decode(v)
+	err = json.NewDecoder(file).Decode(v)
+	if err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempt to fix options packer decode json lint failure with tests.
