### PR TITLE
docs(spec): artifactType in multi-platform index manifests

### DIFF
--- a/docs/proposals/multi-arch-image-mgmt.md
+++ b/docs/proposals/multi-arch-image-mgmt.md
@@ -226,6 +226,9 @@ oras manifest index create localhost:5000/hello:tag1,tag2,tag3 linux-amd64 linux
 # Create and push an index with annotations:
 oras manifest index create localhost:5000/hello:v1 linux-amd64 --annotation "key=val"
 
+# Create an index with a specified artifact type:
+oras manifest index create --artifact-type="application/vnd.example+type" localhost:5000/hello linux-amd64
+
 # Create an index and push to an OCI image layout folder 'layout-dir' and tag with 'v1':
 oras manifest index create layout-dir:v1 linux-amd64 sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9 --oci-layout
 
@@ -257,6 +260,12 @@ oras manifest index update --output index.json localhost:5000/hello:v2 --add v2-
 
 # Update an index and output the index to stdout, auto push will be disabled:
 oras manifest index update --output - --pretty localhost:5000/hello:v2 --remove sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
+
+# Update an index to use a different artifact type:
+oras manifest index update localhost:5000/hello:v1 --artifact-type="application/vnd.example+type"
+
+# Update an index to remove any existing artifact type:
+oras manifest index update localhost:5000/hello:v1 --artifact-type=""
 ```
 
 ### View a multi-arch image 
@@ -270,6 +279,35 @@ Usage:
 Aliases:
   fetch, get, show
 ```
+
+## Index manifest structure
+
+The `oras manifest index` family of commands manipulates index manifests as described in [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/v1.1.1/image-index.md).
+
+The image index properties defined in that specification are populated as follows:
+
+- `schemaVersion`: always set to `2`, as the specification requires.
+- `mediaType`: always set to `"application/vnd.oci.image.index.v1+json"` to distinguish from other manifest types, as the specification requires.
+- `artifactType`: set to the value provided in argument to the `--artifact-type` option if present and non-empty, or omitted otherwise.
+- `manifests`: an array of descriptors describing each of the child manifests selected by tag or digest on the `oras manifest index create` command line, or subsequently added using options like `oras manifest index update --add`.
+
+    The descriptor for each child manifest is populated as follows:
+
+    - `mediaType`: set to match the `mediaType` property of the associated manifest.
+    - `artifactType`: set to match the `artifactType` property of the associated manifest, if any.
+
+      If the associated manifest was also created using ORAS, this property would've been set using the `--artifact-type` option when running an earlier command such as `oras push`.
+    - `digest`: set to a blob digest of the associated manifest.
+    - `size`: set to the size of the blob containing the associated manifest, in bytes.
+    - `platform`: describes a specific platform specified in the associated manifest.
+
+      If the associated manifest was also created using ORAS, the information used to populate this property would've been set using the `--artifact-platform` option when running an earlier command such as `oras push`.
+
+      `oras push` currently uses an experimental, ORAS-specific annotation scheme to store the target platform information as part of an image manifest. A general-purpose alternative is currently under discussion in [opencontainers/image-spec#1216](https://github.com/opencontainers/image-spec/issues/1216) and may be adopted in a later version of this specification.
+
+    No other descriptor properties are included.
+- `subject`: always omitted.
+- `annotations`: populated based on the `--annotation` command line option, if present.
 
 ## Investigation on other client tools and industry
 


### PR DESCRIPTION
This extends the previously-accepted proposal with two additional features related to the artifactType manifest property:

- Both of the "oras manifest index" subcommands support an --artifact-type option, similar to that used with "oras push" today, that directly specifies an "artifactType" value to include in the index manifest.
- The descriptors for the child manifests automatically include an artifactType property matching that in the child manifest, if any.

These extensions allow using ORAS to create index manifests for systems that use index-level artifactType to quickly reject artifacts that appear to be intended for use by other unrelated software, such as trying to use a multi-platform container image as an OpenTofu provider plugin.

In order to describe the proposal comprehensively I've added a new section describing what values these commands write into each of the properties of the generated index manifests. Since there was previously no direct documentation of that, this changeset also retroactively documents some behavior resulting from the original proposal that is not directly related to the treatment of `artifactType`. I tried to make that correctly reflect the behavior in the current experimental implementation, but of course I would be happy to correct any errors I've made.

**What this PR does / why we need it**: This proposal change aims to formalize what was previously discussed in https://github.com/oras-project/oras/issues/1670.

There are no code changes in this pull request.

I am contributing this change on behalf of the [OpenTofu](https://opentofu.org/) project.
