### PR TITLE
build(deps): bump oras-go to the latest commit which fixes the "compare and swap" error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	golang.org/x/sync v0.13.0
 	golang.org/x/term v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
-	oras.land/oras-go/v2 v2.5.1-0.20250221033735-cb6d75be7dd4
+	oras.land/oras-go/v2 v2.5.1-0.20250417082913-f7a6126986d9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -69,5 +69,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oras.land/oras-go/v2 v2.5.1-0.20250221033735-cb6d75be7dd4 h1:jlMeewI2WJwjGjhCDC5uQHAVOwyXypeMz7NUZiRhr+4=
-oras.land/oras-go/v2 v2.5.1-0.20250221033735-cb6d75be7dd4/go.mod h1:2UW9eta1+52EMtMRD2gottf9g5EZv9o3gkKfk1iedVw=
+oras.land/oras-go/v2 v2.5.1-0.20250417082913-f7a6126986d9 h1:CPJ9+nBd8nSmXXNIgDQGuAKnvMQSPscnbtFpX+SE1yE=
+oras.land/oras-go/v2 v2.5.1-0.20250417082913-f7a6126986d9/go.mod h1:8OzrtKaos0v08lrS7pCgdF8o16iUKLvXBiZWYfqzNLk=

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -303,7 +303,7 @@ var _ = Describe("Remote registry users:", func() {
 
 		It("should pack with image spec v1.0 when --config is used, --artifact-type is not used, and --image-spec set to auto", func() {
 			repo := pushTestRepo("config/without/artifact/type")
-			configType := "my/config/type"
+			configType := "my/config+type"
 			tempDir := PrepareTempFiles()
 
 			ORAS("push", RegistryRef(ZOTHost, repo, tag), "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), foobar.FileBarName).


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Bump `oras-go` to the latest commit [`f7a6126986d97f498be7b516ebf5478a49a6df86`](https://github.com/oras-project/oras-go/commit/f7a6126986d97f498be7b516ebf5478a49a6df86)
2. Fix an E2E test cases that used an invalid media type

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1659, fixes #1694, fixes #1695

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
