### PR TITLE
Enrich discover command tree output with additional data (Layers, data from Descriptor) - follow-up PR

### DIFF
--- a/cmd/oras/internal/display/handler.go
+++ b/cmd/oras/internal/display/handler.go
@@ -16,7 +16,9 @@ limitations under the License.
 package display
 
 import (
+	"context"
 	"io"
+	"oras.land/oras-go/v2"
 	"os"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -112,11 +114,11 @@ func NewPullHandler(printer *output.Printer, format option.Format, path string, 
 }
 
 // NewDiscoverHandler returns status and metadata handlers for discover command.
-func NewDiscoverHandler(out io.Writer, format option.Format, path string, rawReference string, desc ocispec.Descriptor, verbose bool, tty *os.File) (metadata.DiscoverHandler, error) {
+func NewDiscoverHandler(out io.Writer, format option.Format, path string, rawReference string, desc ocispec.Descriptor, verbose bool, dumpLayers bool, tty *os.File, context context.Context, target oras.ReadOnlyTarget, platform option.Platform) (metadata.DiscoverHandler, error) {
 	var handler metadata.DiscoverHandler
 	switch format.Type {
 	case option.FormatTypeTree.Name:
-		handler = tree.NewDiscoverHandler(out, path, desc, verbose, tty)
+		handler = tree.NewDiscoverHandler(out, path, desc, verbose, dumpLayers, tty, context, target, platform)
 	case option.FormatTypeTable.Name:
 		handler = table.NewDiscoverHandler(out, rawReference, desc, verbose)
 	case option.FormatTypeJSON.Name:

--- a/cmd/oras/internal/display/metadata/tree/discover.go
+++ b/cmd/oras/internal/display/metadata/tree/discover.go
@@ -16,37 +16,48 @@ limitations under the License.
 package tree
 
 import (
+	"cmp"
+	"context"
+	"encoding/json"
 	"fmt"
-	"io"
-	"os"
-	"strings"
-
 	"github.com/morikuni/aec"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gopkg.in/yaml.v3"
+	"io"
+	"oras.land/oras-go/v2"
 	"oras.land/oras/cmd/oras/internal/display/metadata"
+	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/tree"
+	"os"
+	"sort"
+	"strings"
 )
 
 var (
 	artifactTypeColor = aec.LightYellowF
 	digestColor       = aec.LightGreenF
 	annotationsColor  = aec.LightCyanF
+	descriptorColor   = aec.LightBlueF
+	layersColor       = aec.LightMagentaF
 )
 
 // discoverHandler handles json metadata output for discover events.
 type discoverHandler struct {
-	out     io.Writer
-	path    string
-	root    *tree.Node
-	nodes   map[digest.Digest]*tree.Node
-	verbose bool
-	tty     *os.File
+	out        io.Writer
+	path       string
+	root       *tree.Node
+	nodes      map[digest.Digest]*tree.Node
+	verbose    bool
+	dumpLayers bool
+	tty        *os.File
+	context    context.Context
+	target     oras.ReadOnlyTarget
+	platform   option.Platform
 }
 
 // NewDiscoverHandler creates a new handler for discover events.
-func NewDiscoverHandler(out io.Writer, path string, root ocispec.Descriptor, verbose bool, tty *os.File) metadata.DiscoverHandler {
+func NewDiscoverHandler(out io.Writer, path string, root ocispec.Descriptor, verbose bool, dumpLayers bool, tty *os.File, context context.Context, target oras.ReadOnlyTarget, platform option.Platform) metadata.DiscoverHandler {
 	rootDigest := fmt.Sprintf("%s@%s", path, root.Digest)
 	if tty != nil {
 		rootDigest = digestColor.Apply(rootDigest)
@@ -59,8 +70,12 @@ func NewDiscoverHandler(out io.Writer, path string, root ocispec.Descriptor, ver
 		nodes: map[digest.Digest]*tree.Node{
 			root.Digest: treeRoot,
 		},
-		verbose: verbose,
-		tty:     tty,
+		verbose:    verbose,
+		dumpLayers: dumpLayers,
+		tty:        tty,
+		context:    context,
+		target:     target,
+		platform:   platform,
 	}
 }
 
@@ -84,18 +99,30 @@ func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) err
 	referrerNode := node.AddPath(artifactType, dgst)
 
 	// add annotations to the referrer
-	if h.verbose && len(referrer.Annotations) > 0 {
-		annotationsTitle := "[annotations]"
+	if h.verbose {
+		descriptorTitle := "[descriptor]"
 		if h.tty != nil {
-			annotationsTitle = annotationsColor.Apply(annotationsTitle)
+			descriptorTitle = descriptorColor.Apply(descriptorTitle)
 		}
-		annotationsNode := referrerNode.Add(annotationsTitle)
-		for k, v := range referrer.Annotations {
-			bytes, err := yaml.Marshal(map[string]string{k: v})
-			if err != nil {
+		descriptorNode := referrerNode.Add(descriptorTitle)
+		descriptorNode.AddKV("Size", referrer.Size)
+		descriptorNode.AddKV("MediaType", referrer.MediaType)
+
+		if len(referrer.Annotations) > 0 {
+			annotationsTitle := "[annotations]"
+			if h.tty != nil {
+				annotationsTitle = annotationsColor.Apply(annotationsTitle)
+			}
+			annotationsNode := referrerNode.Add(annotationsTitle)
+			for k, v := range referrer.Annotations {
+				annotationsNode.AddKV(k, v)
+			}
+		}
+
+		if h.dumpLayers {
+			if err := addLayersInfo(referrer, referrerNode, h.context, h.target, h.platform, h.tty); err != nil {
 				return err
 			}
-			annotationsNode.AddPath(strings.TrimSpace(string(bytes)))
 		}
 	}
 	h.nodes[referrer.Digest] = referrerNode
@@ -105,4 +132,86 @@ func (h *discoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) err
 // Render implements metadata.DiscoverHandler.
 func (h *discoverHandler) Render() error {
 	return tree.NewPrinter(h.out).Print(h.root)
+}
+
+func sortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	return keys
+}
+
+func addLayersInfo(referrer ocispec.Descriptor, referrerNode *tree.Node, ctx context.Context, target oras.ReadOnlyTarget, platform option.Platform, tty *os.File) error {
+	layersTitle := "[layers]"
+	if tty != nil {
+		layersTitle = layersColor.Apply(layersTitle)
+	}
+
+	layersNode := tree.New(layersTitle)
+	if err := dumpLayers(referrer.Digest, layersNode, ctx, target, platform, tty); err != nil {
+		return err
+	} else {
+		referrerNode.AddNode(layersNode)
+	}
+	return nil
+}
+
+func dumpLayers(digest digest.Digest, node *tree.Node, ctx context.Context, target oras.ReadOnlyTarget, platform option.Platform, tty *os.File) error {
+	fetchOpts := oras.DefaultFetchBytesOptions
+	fetchOpts.TargetPlatform = platform.Platform
+	_, content, err := oras.FetchBytes(ctx, target, digest.String(), fetchOpts)
+	if err != nil {
+		return fmt.Errorf("failed to fetch the layers for %q: %w", digest.String(), err)
+	}
+
+	var jsonMap map[string]any
+	if err = json.Unmarshal(content, &jsonMap); err != nil {
+		return err
+	}
+
+	if layers, ok := jsonMap["layers"].([]interface{}); ok {
+		if len(layers) != 0 {
+			for idx, item := range layers {
+				layerNode := node.AddPath(fmt.Sprintf("Layer[%d]", idx))
+
+				if layer, ok := item.(map[string]interface{}); ok {
+
+					layerKeys := sortedKeys(layer)
+					for _, k := range layerKeys {
+						v := layer[k]
+						if k == "annotations" {
+							if annotationsMap, ok := v.(map[string]interface{}); ok {
+
+								if len(annotationsMap) > 0 {
+									annotationsTitle := "[annotations]"
+									if tty != nil {
+										annotationsTitle = annotationsColor.Apply(annotationsTitle)
+									}
+									annotationsNode := layerNode.AddPath(annotationsTitle)
+
+									annotationsMapKeys := sortedKeys(annotationsMap)
+									for _, k := range annotationsMapKeys {
+										v := annotationsMap[k]
+										annotationsNode.AddKV(k, v)
+									}
+								}
+							}
+						} else {
+							bytes, err := yaml.Marshal(map[string]interface{}{k: v})
+							if err != nil {
+								panic(err)
+							}
+							layerNode.AddPath(strings.TrimSpace(string(bytes)))
+						}
+					}
+				}
+			}
+			return nil
+		}
+	}
+	return nil
 }

--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -43,7 +43,8 @@ type discoverOptions struct {
 	artifactType string
 	depth        int
 	// Deprecated: verbose is deprecated and will be removed in the future.
-	verbose bool
+	verbose    bool
+	dumpLayers bool
 }
 
 func discoverCmd() *cobra.Command {
@@ -117,6 +118,7 @@ Example - Discover referrers of the manifest tagged 'v1' in an OCI image layout 
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
 	cmd.Flags().StringVarP(&opts.FormatFlag, "output", "o", "tree", "[Deprecated] format in which to display referrers (table, json, or tree).")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "display full metadata of referrers")
+	cmd.Flags().BoolVarP(&opts.dumpLayers, "dump-layers", "", true, "display full layers metadata of referrers")
 	cmd.Flags().IntVarP(&opts.depth, "depth", "", 0, "[Experimental] level of referrers to display, if unused shows referrers of all levels")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	opts.SetTypes(
@@ -149,7 +151,7 @@ func runDiscover(cmd *cobra.Command, opts *discoverOptions) error {
 		return err
 	}
 
-	handler, err := display.NewDiscoverHandler(opts.Printer, opts.Format, opts.Path, opts.RawReference, desc, opts.verbose, opts.TTY)
+	handler, err := display.NewDiscoverHandler(opts.Printer, opts.Format, opts.Path, opts.RawReference, desc, opts.verbose, opts.dumpLayers, opts.TTY, ctx, repo, opts.Platform)
 	if err != nil {
 		return err
 	}

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -16,7 +16,12 @@ limitations under the License.
 // Package tree pretty prints trees
 package tree
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
 
 // Node represents a tree node.
 type Node struct {
@@ -36,6 +41,22 @@ func (n *Node) Add(value any) *Node {
 	node := New(value)
 	n.Nodes = append(n.Nodes, node)
 	return node
+}
+
+// Add key/value node.
+func (n *Node) AddKV(key string, value any) *Node {
+	bytes, err := yaml.Marshal(map[string]any{key: value})
+	if err != nil {
+		panic(err)
+	}
+	node := n.AddPath(strings.TrimSpace(string(bytes)))
+	return node
+}
+
+// AddNode adds a leaf Node.
+func (n *Node) AddNode(node *Node) *Node {
+	n.Nodes = append(n.Nodes, node)
+	return n
 }
 
 // AddPath adds a chain of nodes.


### PR DESCRIPTION
Hi,
based on discussion we had at https://github.com/oras-project/oras/pull/1501 and recent changes in discover output, I have created new PR with similar changes.

I have added flag `dumpLayers` to configure if someone wants also dump layers info. Also I found out that with `dumpLayers=true` it is hard to test the functionality - ~~to mitigate it I am trying to integrate [testcontainers-go](https://golang.testcontainers.org/), to have end-to-end test for it~~ I found out e2e test are already present, now investigating them.

What do you think?

Thx

Ivos

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

Output looks like this:
```
localhost:8888/my-project/demo@sha256:2ba4f7a52e867178b04a84c53860d422f1d0fa566c8cd34cdbd2c1f42974f27d
└── foo/bar-baz
    ├── sha256:752a3ee73a5707ae7a298b8ed46f5fa8ca5902c04900a197c233c502e0a88a28
    │   ├── [descriptor]
    │   │   ├── Size: 802
    │   │   └── MediaType: application/vnd.oci.image.manifest.v1+json
    │   ├── [annotations]
    │   │   ├── created-by: Ivos
    │   │   └── org.opencontainers.image.created: "2025-04-26T16:04:19Z"
    │   └── [layers]
    │       └── Layer[0]
    │           ├── [annotations]
    │           │   └── org.opencontainers.image.title: C:\Users\bedla.czech\GolandProjects\trivy\result.json
    │           ├── digest: sha256:95340261766214250b2238f4a8055bbd8b9f5b6203a30ca6e0e59c9348d5c674
    │           ├── mediaType: application/vnd.cyclonedx+json
    │           └── size: 36449
    └── sha256:6b119f6c8d3f42021cbf343d8ab6ee7f38a630047d241c8ff3dafa843af03773
        ├── [descriptor]
        │   ├── Size: 802
        │   └── MediaType: application/vnd.oci.image.manifest.v1+json
        ├── [annotations]
        │   ├── created-by: Ivos
        │   └── org.opencontainers.image.created: "2025-04-26T16:30:28Z"
        └── [layers]
            └── Layer[0]
                ├── [annotations]
                │   └── org.opencontainers.image.title: C:\Users\bedla.czech\GolandProjects\trivy\result.json
                ├── digest: sha256:95340261766214250b2238f4a8055bbd8b9f5b6203a30ca6e0e59c9348d5c674
                ├── mediaType: application/vnd.cyclonedx+json
                └── size: 36449
```