### PR TITLE
fix: validate that Target implements oerrors interface

### DIFF
--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -48,7 +48,6 @@ const (
 
 // Target struct contains flags and arguments specifying one registry or image
 // layout.
-// Target implements oerrors.Handler interface.
 type Target struct {
 	Remote
 	RawReference string
@@ -61,6 +60,9 @@ type Target struct {
 
 	IsOCILayout bool
 }
+
+// Make sure Target implements oerrors interface.
+var _ oerrors.Modifier = &Target{}
 
 // ApplyFlags applies flags to a command flag set for unary target
 func (target *Target) ApplyFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The comment was incorrect and add compile time check for the implementation.
