### PR TITLE
refactor: rename Target AnnotatedReference method

### DIFF
--- a/cmd/oras/internal/display/metadata/text/attach.go
+++ b/cmd/oras/internal/display/metadata/text/attach.go
@@ -27,9 +27,9 @@ import (
 
 // AttachHandler handles text metadata output for attach events.
 type AttachHandler struct {
-	printer            *output.Printer
-	subjectRefByDigest string
-	root               ocispec.Descriptor
+	printer                 *output.Printer
+	subjectDisplayReference string
+	root                    ocispec.Descriptor
 }
 
 // NewAttachHandler returns a new handler for attach events.
@@ -43,18 +43,18 @@ func NewAttachHandler(printer *output.Printer) metadata.AttachHandler {
 func (ah *AttachHandler) OnAttached(target *option.Target, root ocispec.Descriptor, subject ocispec.Descriptor) {
 	ah.root = root
 	if strings.HasSuffix(target.RawReference, subject.Digest.String()) {
-		ah.subjectRefByDigest = target.AnnotatedReference()
+		ah.subjectDisplayReference = target.GetDisplayReference()
 	} else {
 		// use subject digest instead of tag
 		newTarget := *target
 		newTarget.RawReference = fmt.Sprintf("%s@%s", target.Path, subject.Digest)
-		ah.subjectRefByDigest = newTarget.AnnotatedReference()
+		ah.subjectDisplayReference = newTarget.GetDisplayReference()
 	}
 }
 
 // Render is called when the attach command is complete.
 func (ah *AttachHandler) Render() error {
-	err := ah.printer.Println("Attached to", ah.subjectRefByDigest)
+	err := ah.printer.Println("Attached to", ah.subjectDisplayReference)
 	if err != nil {
 		return err
 	}

--- a/cmd/oras/internal/display/metadata/text/blob_delete.go
+++ b/cmd/oras/internal/display/metadata/text/blob_delete.go
@@ -42,5 +42,5 @@ func (h *BlobDeleteHandler) OnBlobMissing() error {
 
 // OnBlobDeleted implements BlobDeleteHandler.
 func (h *BlobDeleteHandler) OnBlobDeleted() error {
-	return h.printer.Println("Deleted", h.target.AnnotatedReference())
+	return h.printer.Println("Deleted", h.target.GetDisplayReference())
 }

--- a/cmd/oras/internal/display/metadata/text/blob_push.go
+++ b/cmd/oras/internal/display/metadata/text/blob_push.go
@@ -38,7 +38,7 @@ func NewBlobPushHandler(printer *output.Printer, desc ocispec.Descriptor) metada
 
 // OnBlobPushed implements metadata.BlobPushHandler.
 func (h *BlobPushHandler) OnBlobPushed(target *option.Target) error {
-	return h.printer.Println("Pushed:", target.AnnotatedReference())
+	return h.printer.Println("Pushed:", target.GetDisplayReference())
 }
 
 // Render implements metadata.BlobPushHandler.

--- a/cmd/oras/internal/display/metadata/text/copy.go
+++ b/cmd/oras/internal/display/metadata/text/copy.go
@@ -48,5 +48,5 @@ func (h *CopyHandler) Render() error {
 // OnCopied implements metadata.CopyHandler.
 func (h *CopyHandler) OnCopied(target *option.BinaryTarget, desc ocispec.Descriptor) error {
 	h.desc = desc
-	return h.printer.Println("Copied", target.From.AnnotatedReference(), "=>", target.To.AnnotatedReference())
+	return h.printer.Println("Copied", target.From.GetDisplayReference(), "=>", target.To.GetDisplayReference())
 }

--- a/cmd/oras/internal/display/metadata/text/manifest_delete.go
+++ b/cmd/oras/internal/display/metadata/text/manifest_delete.go
@@ -40,5 +40,5 @@ func (h *ManifestDeleteHandler) OnManifestMissing() error {
 
 // OnManifestDeleted implements ManifestDeleteHandler.
 func (h *ManifestDeleteHandler) OnManifestDeleted() error {
-	return h.printer.Println("Deleted", h.target.AnnotatedReference())
+	return h.printer.Println("Deleted", h.target.GetDisplayReference())
 }

--- a/cmd/oras/internal/display/metadata/text/manifest_push.go
+++ b/cmd/oras/internal/display/metadata/text/manifest_push.go
@@ -45,7 +45,7 @@ func (h *ManifestPushHandler) OnTagged(_ ocispec.Descriptor, tag string) error {
 // OnManifestPushed implements metadata.ManifestPushHandler.
 func (h *ManifestPushHandler) OnManifestPushed(desc ocispec.Descriptor) error {
 	h.desc = desc
-	return h.printer.Println("Pushed:", h.target.AnnotatedReference())
+	return h.printer.Println("Pushed:", h.target.GetDisplayReference())
 }
 
 // Render implements metadata.ManifestPushHandler.

--- a/cmd/oras/internal/display/metadata/text/pull.go
+++ b/cmd/oras/internal/display/metadata/text/pull.go
@@ -61,7 +61,7 @@ func (ph *PullHandler) Render() error {
 		_ = ph.printer.Printf("Skipped pulling layers without file name in %q\n", ocispec.AnnotationTitle)
 		_ = ph.printer.Printf("Use 'oras copy %s --to-oci-layout <layout-dir>' to pull all layers.\n", ph.target.RawReference)
 	} else {
-		_ = ph.printer.Println("Pulled", ph.target.AnnotatedReference())
+		_ = ph.printer.Println("Pulled", ph.target.GetDisplayReference())
 		_ = ph.printer.Println("Digest:", ph.root.Digest)
 	}
 	return nil

--- a/cmd/oras/internal/display/metadata/text/push.go
+++ b/cmd/oras/internal/display/metadata/text/push.go
@@ -48,7 +48,7 @@ func (h *PushHandler) OnTagged(_ ocispec.Descriptor, tag string) error {
 // OnCopied is called after files are copied.
 func (h *PushHandler) OnCopied(opts *option.Target, root ocispec.Descriptor) error {
 	h.root = root
-	return h.printer.Println("Pushed", opts.AnnotatedReference())
+	return h.printer.Println("Pushed", opts.GetDisplayReference())
 }
 
 // Render implements PushHandler.

--- a/cmd/oras/internal/option/target.go
+++ b/cmd/oras/internal/option/target.go
@@ -67,8 +67,8 @@ func (target *Target) ApplyFlags(fs *pflag.FlagSet) {
 	target.Remote.ApplyFlags(fs)
 }
 
-// AnnotatedReference returns full printable reference.
-func (target *Target) AnnotatedReference() string {
+// GetDisplayReference returns full printable reference.
+func (target *Target) GetDisplayReference() string {
 	return fmt.Sprintf("[%s] %s", target.Type, target.RawReference)
 }
 

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -133,7 +133,7 @@ func createIndex(cmd *cobra.Command, opts createOptions) error {
 		return err
 	}
 	if opts.outputPath == "" {
-		if err := pushIndex(ctx, displayStatus, displayMetadata, target, desc, indexBytes, opts.Reference, opts.extraRefs, opts.AnnotatedReference()); err != nil {
+		if err := pushIndex(ctx, displayStatus, displayMetadata, target, desc, indexBytes, opts.Reference, opts.extraRefs, opts.GetDisplayReference()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Every time I see this method, I wonder what it does. This name makes it clear.
