### PR TITLE
refactor: ApplyFlags with prefix for Remote and Target

### DIFF
--- a/cmd/oras/internal/option/binary_target.go
+++ b/cmd/oras/internal/option/binary_target.go
@@ -48,8 +48,10 @@ func (target *BinaryTarget) EnableDistributionSpecFlag() {
 
 // ApplyFlags applies flags to a command flag set fs.
 func (target *BinaryTarget) ApplyFlags(fs *pflag.FlagSet) {
-	target.From.ApplyFlagsWithPrefix(fs, "from", "source")
-	target.To.ApplyFlagsWithPrefix(fs, "to", "destination")
+	target.From.setFlagDetails("from", "source")
+	target.From.ApplyFlags(fs)
+	target.To.setFlagDetails("to", "destination")
+	target.To.ApplyFlags(fs)
 	fs.StringArrayVarP(&target.resolveFlag, "resolve", "", nil, "base DNS rules formatted in `host:port:address[:address_port]` for --from-resolve and --to-resolve")
 }
 

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -87,15 +87,12 @@ func (remo *Remote) EnableDistributionSpecFlag() {
 // ApplyFlags applies flags to a command flag set.
 func (remo *Remote) ApplyFlags(fs *pflag.FlagSet) {
 	remo.ApplyFlagsWithPrefix(fs, "", "")
-	fs.BoolVar(&remo.secretFromStdin, passwordFromStdinFlag, false, "read password from stdin")
-	fs.BoolVar(&remo.secretFromStdin, identityTokenFromStdinFlag, false, "read identity token from stdin")
+	remo.applyStdinFlags(fs)
 }
 
-func applyPrefix(prefix, description string) (flagPrefix, notePrefix string) {
-	if prefix == "" {
-		return "", ""
-	}
-	return prefix + "-", description + " "
+func (remo *Remote) applyStdinFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&remo.secretFromStdin, passwordFromStdinFlag, false, "read password from stdin")
+	fs.BoolVar(&remo.secretFromStdin, identityTokenFromStdinFlag, false, "read identity token from stdin")
 }
 
 // ApplyFlagsWithPrefix applies flags to a command flag set with a prefix string.
@@ -105,32 +102,31 @@ func (remo *Remote) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description 
 		shortUser     string
 		shortPassword string
 		shortHeader   string
-		notePrefix    string
 	)
 	if prefix == "" {
 		shortUser, shortPassword = "u", "p"
 		shortHeader = "H"
 	}
-	remo.flagPrefix, notePrefix = applyPrefix(prefix, description)
+	remo.flagPrefix = prefix
 
 	if remo.applyDistributionSpec {
 		remo.DistributionSpec.ApplyFlagsWithPrefix(fs, prefix, description)
 	}
-	fs.StringVarP(&remo.Username, remo.flagPrefix+usernameFlag, shortUser, "", notePrefix+"registry username")
-	fs.StringVarP(&remo.Secret, remo.flagPrefix+passwordFlag, shortPassword, "", notePrefix+"registry password or identity token")
-	fs.StringVar(&remo.Secret, remo.flagPrefix+identityTokenFlag, "", notePrefix+"registry identity token")
-	fs.BoolVar(&remo.Insecure, remo.flagPrefix+"insecure", false, "allow connections to "+notePrefix+"SSL registry without certs")
+	fs.StringVarP(&remo.Username, remo.flagPrefix+usernameFlag, shortUser, "", description+"registry username")
+	fs.StringVarP(&remo.Secret, remo.flagPrefix+passwordFlag, shortPassword, "", description+"registry password or identity token")
+	fs.StringVar(&remo.Secret, remo.flagPrefix+identityTokenFlag, "", description+"registry identity token")
+	fs.BoolVar(&remo.Insecure, remo.flagPrefix+"insecure", false, "allow connections to "+description+"SSL registry without certs")
 	plainHTTPFlagName := remo.flagPrefix + "plain-http"
-	plainHTTP := fs.Bool(plainHTTPFlagName, false, "allow insecure connections to "+notePrefix+"registry without SSL check")
+	plainHTTP := fs.Bool(plainHTTPFlagName, false, "allow insecure connections to "+description+"registry without SSL check")
 	remo.plainHTTP = func() (bool, bool) {
 		return *plainHTTP, fs.Changed(plainHTTPFlagName)
 	}
-	fs.StringVar(&remo.CACertFilePath, remo.flagPrefix+caFileFlag, "", "server certificate authority file for the remote "+notePrefix+"registry")
-	fs.StringVarP(&remo.CertFilePath, remo.flagPrefix+certFileFlag, "", "", "client certificate file for the remote "+notePrefix+"registry")
-	fs.StringVarP(&remo.KeyFilePath, remo.flagPrefix+keyFileFlag, "", "", "client private key file for the remote "+notePrefix+"registry")
-	fs.StringArrayVar(&remo.resolveFlag, remo.flagPrefix+"resolve", nil, "customized DNS for "+notePrefix+"registry, formatted in `host:port:address[:address_port]`")
-	fs.StringArrayVar(&remo.Configs, remo.flagPrefix+"registry-config", nil, "`path` of the authentication file for "+notePrefix+"registry")
-	fs.StringArrayVarP(&remo.headerFlags, remo.flagPrefix+"header", shortHeader, nil, "add custom headers to "+notePrefix+"requests")
+	fs.StringVar(&remo.CACertFilePath, remo.flagPrefix+caFileFlag, "", "server certificate authority file for the remote "+description+"registry")
+	fs.StringVarP(&remo.CertFilePath, remo.flagPrefix+certFileFlag, "", "", "client certificate file for the remote "+description+"registry")
+	fs.StringVarP(&remo.KeyFilePath, remo.flagPrefix+keyFileFlag, "", "", "client private key file for the remote "+description+"registry")
+	fs.StringArrayVar(&remo.resolveFlag, remo.flagPrefix+"resolve", nil, "customized DNS for "+description+"registry, formatted in `host:port:address[:address_port]`")
+	fs.StringArrayVar(&remo.Configs, remo.flagPrefix+"registry-config", nil, "`path` of the authentication file for "+description+"registry")
+	fs.StringArrayVarP(&remo.headerFlags, remo.flagPrefix+"header", shortHeader, nil, "add custom headers to "+description+"requests")
 }
 
 // CheckStdinConflict checks if PasswordFromStdin or IdentityTokenFromStdin of a

--- a/cmd/oras/internal/option/spec.go
+++ b/cmd/oras/internal/option/spec.go
@@ -133,6 +133,5 @@ func (ds *DistributionSpec) String() string {
 
 // ApplyFlagsWithPrefix applies flags to a command flag set with a prefix string.
 func (ds *DistributionSpec) ApplyFlagsWithPrefix(fs *pflag.FlagSet, prefix, description string) {
-	flagPrefix, notePrefix := applyPrefix(prefix, description)
-	fs.Var(ds, flagPrefix+"distribution-spec", fmt.Sprintf("[Preview] set OCI distribution spec version and API option for %starget. Options: %s", notePrefix, ds.Options()))
+	fs.Var(ds, prefix+"distribution-spec", fmt.Sprintf("[Preview] set OCI distribution spec version and API option for %starget. Options: %s", description, ds.Options()))
 }

--- a/cmd/oras/internal/option/target_test.go
+++ b/cmd/oras/internal/option/target_test.go
@@ -75,6 +75,25 @@ func TestTarget_Parse_oci_and_oci_path(t *testing.T) {
 
 }
 
+func TestTarget_Parse_to_oci_and_oci_path(t *testing.T) {
+	opts := Target{}
+	cmd := &cobra.Command{}
+	opts.setFlagDetails("to", "destination")
+	opts.ApplyFlags(cmd.Flags())
+	cmd.SetArgs([]string{"--to-oci-layout", "foo", "--to-oci-layout-path", "foo"})
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("cmd.Execute() error = %v", err)
+	}
+	err := opts.Parse(cmd)
+	if err == nil {
+		t.Errorf("expect Target.Parse() to fail but not")
+	}
+	if !strings.Contains(err.Error(), "cannot be used at the same time") {
+		t.Errorf("expect error message to contain 'cannot be used at the same time' but not")
+	}
+
+}
+
 func TestTarget_Parse_remote(t *testing.T) {
 	opts := Target{
 		RawReference: "mocked/test",


### PR DESCRIPTION
**What this PR does / why we need it**:

It kind of looks like this Target/Remote code was in the middle of some refactor that was never completed. This doesn't address all the issues, but it does clean up flag/prefix/description handling a bit.
