### PR TITLE
fix(lint): ignore returns from test defer calls

### DIFF
--- a/cmd/oras/internal/display/metadata/tree/discover_test.go
+++ b/cmd/oras/internal/display/metadata/tree/discover_test.go
@@ -55,8 +55,8 @@ func TestDiscoverHandler_OnDiscovered(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create temporary file: %v", err)
 		}
-		defer os.Remove(tmp.Name())
-		defer tmp.Close()
+		defer func() { _ = os.Remove(tmp.Name()) }()
+		defer func() { _ = tmp.Close() }()
 
 		h := NewDiscoverHandler(&buf, path, subjectDesc, true, tmp)
 		if err := h.OnDiscovered(referrerDesc, subjectDesc); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Ignoring two test defer calls for lint
