### PR TITLE
fix(docs): remove a discover example with -v

### DIFF
--- a/cmd/oras/root/discover.go
+++ b/cmd/oras/root/discover.go
@@ -73,9 +73,6 @@ Example - [Experimental] Discover referrers and format output with Go template:
 Example - [Experimental] Discover only direct referrers, displayed in json view:
   oras discover localhost:5000/hello:v1 --format json --depth 1
 
-Example - Discover all the referrers of manifest with annotations, displayed in a tree view:
-  oras discover -v localhost:5000/hello:v1
-
 Example - Discover referrers with type 'test-artifact' of manifest 'hello:v1' in registry 'localhost:5000':
   oras discover --artifact-type test-artifact localhost:5000/hello:v1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`-v` has been deprecated for `oras discover` and there should not be related examples anymore

![image](https://github.com/user-attachments/assets/1ac17dfc-2a49-4b85-bc34-61f82b243d39)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
