### PR TITLE
fix(tests): fix packer test that failed on Windows

### DIFF
--- a/cmd/oras/internal/option/packer_test.go
+++ b/cmd/oras/internal/option/packer_test.go
@@ -169,7 +169,7 @@ func TestPacker_decodeJSON(t *testing.T) {
 
 	path := "nonexistent-file.json"
 	err := decodeJSON(path, &annotation.Annotations)
-	if err == nil || err.Error() != "open nonexistent-file.json: no such file or directory" {
+	if !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the test `TestPacker_decodeJSON` which fails on Windows with the following message:

> --- FAIL: TestPacker_decodeJSON (0.00s)
>     packer_test.go:173: unexpected error: open nonexistent-file.json: The system cannot find the file specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
