### PR TITLE
test: exclude incompatible test Go OSes

### DIFF
--- a/cmd/oras/internal/display/status/console/console_test.go
+++ b/cmd/oras/internal/display/status/console/console_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/display/status/track/target_test.go
+++ b/cmd/oras/internal/display/status/track/target_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/display/status/tty_console_test.go
+++ b/cmd/oras/internal/display/status/tty_console_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/internal/option/terminal_test.go
+++ b/cmd/oras/internal/option/terminal_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/blob/fetch_test.go
+++ b/cmd/oras/root/blob/fetch_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/blob/push_test.go
+++ b/cmd/oras/root/blob/push_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.

--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -1,4 +1,4 @@
-//go:build freebsd || linux || netbsd || openbsd || solaris
+//go:build !windows && !darwin
 
 /*
 Copyright The ORAS Authors.


### PR DESCRIPTION
**What this PR does / why we need it**:

Exclude operating systems that are broken for these tests rather include operating systems we do not technically support
