### PR TITLE
chore(ux): remove [Preview] label for `oras attach`

### DIFF
--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -53,10 +53,8 @@ func attachCmd() *cobra.Command {
 	var opts attachOptions
 	cmd := &cobra.Command{
 		Use:   "attach [flags] --artifact-type=<type> <name>{:<tag>|@<digest>} {<file>[:<layer_media_type>]|--annotation <key>=<value>} [...]",
-		Short: "[Preview] Attach files to an existing artifact",
-		Long: `[Preview] Attach files to an existing artifact
-
-** This command is in preview and under development. **
+		Short: "Attach files to an existing artifact",
+		Long: `Attach files to an existing artifact
 
 Example - Attach file 'hi.txt' with artifact type 'doc/example' to manifest 'hello:v1' in registry 'localhost:5000':
   oras attach --artifact-type doc/example localhost:5000/hello:v1 hi.txt

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -38,10 +38,8 @@ func attachTestRepo(text string) string {
 
 var _ = Describe("ORAS beginners:", func() {
 	When("running attach command", func() {
-		RunAndShowPreviewInHelp([]string{"attach"})
-
 		It("should show preview and help doc", func() {
-			out := ORAS("attach", "--help").MatchKeyWords(feature.Preview.Mark+" Attach", feature.Preview.Description, ExampleDesc).Exec().Out
+			out := ORAS("attach", "--help").Exec().Out
 			gomega.Expect(out).Should(gbytes.Say("--distribution-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the [Preview] label for the `oras attach` command. This means to promote this flag from preview level to stable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1813

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
