### PR TITLE
bump: tag and release ORAS CLI v1.3.0-rc.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.3.0-beta.4"
+	Version = "1.3.0-rc.1"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR proposes tagging and releasing `v1.3.0-rc.1` based on commit 39748a41ba2fede9788f018cfb0fcb951093adf5. Approval from at least 4 of the 6 owners listed below is required:

* [ ] @sajayantony
* [x] @shizhMSFT
* [ ] @stevelasker
* [x] @qweeah
* [x] @Wwwsylvia
* [x] @TerryHowe

Please approve on the **PR** or request changes (with reasoning).

Changelog: https://github.com/oras-project/oras/compare/v1.3.0-beta.4...39748a41ba2fede9788f018cfb0fcb951093adf5

---
# Draft Release Notes

## Feature Stability Updates

* Promote the following commands and flags from `Preview` to `Stable`:
  * `oras attach`
  * `oras attach --platform`
  * `oras pull --include-subject`
* Promote `oras resolve` from `Experimental` to `Preview`

## Bug Fixes

* Fix #1795, #1825: redundant blank lines in terminal output

## Other Changes

* Upgrade to Go `1.25.0`
* Update dependencies

## Detailed Commits

* bump: tag and release ORAS CLI v1.3.0-beta.4 by @Wwwsylvia in https://github.com/oras-project/oras/pull/1799
* build(deps): bump library/golang from 1.24.5-alpine to 1.24.6-alpine by @dependabot[bot] in https://github.com/oras-project/oras/pull/1804
* build(deps): bump golang.org/x/term from 0.33.0 to 0.34.0 by @dependabot[bot] in https://github.com/oras-project/oras/pull/1800
* chore: add Sylvia's GPG key by @Wwwsylvia in https://github.com/oras-project/oras/pull/1806
* build(deps): bump actions/checkout from 4 to 5 by @dependabot[bot] in https://github.com/oras-project/oras/pull/1814
* build(deps): bump github.com/onsi/ginkgo/v2 from 2.23.4 to 2.24.0 in /test/e2e by @dependabot[bot] in https://github.com/oras-project/oras/pull/1816
* build(go): upgrade to Go 1.25.0 by @Wwwsylvia in https://github.com/oras-project/oras/pull/1817
* chore: mark `--platform` flag of `oras attach` from preview to stable by @wangxiaoxuan273 in https://github.com/oras-project/oras/pull/1822
* chore: mark `oras resolve` from experimental to preview by @wangxiaoxuan273 in https://github.com/oras-project/oras/pull/1823
* chore: remove [Preview] label on `--include-subject` for `oras pull` by @Wwwsylvia in https://github.com/oras-project/oras/pull/1821
* chore(ux): remove [Preview] label for `oras attach` by @Wwwsylvia in https://github.com/oras-project/oras/pull/1824
* build(deps): bump github.com/onsi/ginkgo/v2 from 2.24.0 to 2.25.0 in /test/e2e by @dependabot[bot] in https://github.com/oras-project/oras/pull/1826
* fix: improve tty UX to avoid redundant blank by @wangxiaoxuan273 in https://github.com/oras-project/oras/pull/1827
* build(deps): bump github.com/onsi/ginkgo/v2 from 2.25.0 to 2.25.1 in /test/e2e by @dependabot[bot] in https://github.com/oras-project/oras/pull/1828
* build(deps): bump github.com/onsi/gomega from 1.38.0 to 1.38.1 in /test/e2e by @dependabot[bot] in https://github.com/oras-project/oras/pull/1829


**Full Changelog**: https://github.com/oras-project/oras/compare/v1.3.0-beta.4...v1.3.0-rc.1
