### PR TITLE
chore(ux): update colors for oras discover tree view

### DIFF
--- a/cmd/oras/internal/display/metadata/tree/discover.go
+++ b/cmd/oras/internal/display/metadata/tree/discover.go
@@ -31,8 +31,8 @@ import (
 
 var (
 	artifactTypeColor = aec.LightYellowF
-	digestColor       = aec.LightGreenF
-	annotationsColor  = aec.LightCyanF
+	digestColor       = aec.GreenF
+	annotationsColor  = aec.LightBlackF
 )
 
 // discoverHandler handles json metadata output for discover events.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the colors of digests and the `[annotation]` nodes in the `oras discover` tree view to improve readability.

**BEFORE**:
<img width="2533" height="1043" alt="image" src="https://github.com/user-attachments/assets/f1c0aab9-e5be-4047-adf1-b43db1ee99b7" />

<img width="1708" height="960" alt="image" src="https://github.com/user-attachments/assets/f5371e7d-c975-455d-a2a8-fe217d8f4d25" />


**AFTER**:
<img width="2544" height="1038" alt="image" src="https://github.com/user-attachments/assets/9c69e47c-551e-4cf8-83de-e00fc75fced8" />

<img width="1706" height="959" alt="image" src="https://github.com/user-attachments/assets/97b55293-44a4-4bdf-bc85-a04f4c611420" />

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1772 

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
