### PR TITLE
chore(ux): improve oras backup error message

### DIFF
--- a/cmd/oras/root/backup.go
+++ b/cmd/oras/root/backup.go
@@ -167,7 +167,7 @@ func runBackup(cmd *cobra.Command, opts *backupOptions) error {
 		// test if the output file can be created and fail early if there is an issue
 		fp, err := os.OpenFile(opts.output, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
-			if fi, err := os.Stat(opts.output); err == nil && fi.IsDir() {
+			if fi, statErr := os.Stat(opts.output); statErr == nil && fi.IsDir() {
 				return &oerrors.Error{
 					Err:            fmt.Errorf("the output path %q already exists and is a directory", opts.output),
 					Recommendation: "To back up to a tar archive, please specify a different output file name or remove the existing directory.",

--- a/cmd/oras/root/backup.go
+++ b/cmd/oras/root/backup.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -165,11 +164,9 @@ func runBackup(cmd *cobra.Command, opts *backupOptions) error {
 	case outputFormatDir:
 		dstRoot = opts.output
 	case outputFormatTar:
-		// test if the output file can be created and fail early if there is an issue
 		fp, err := os.OpenFile(opts.output, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
-			var pe *fs.PathError
-			if errors.As(err, &pe) && errors.Is(pe.Err, syscall.EISDIR) {
+			if fi, err := os.Stat(opts.output); err == nil && fi.IsDir() {
 				return &oerrors.Error{
 					Err:            fmt.Errorf("the output path %q already exists and is a directory", opts.output),
 					Recommendation: "To back up to a tar archive, please specify a different output file name or remove the existing directory.",

--- a/cmd/oras/root/backup.go
+++ b/cmd/oras/root/backup.go
@@ -164,6 +164,7 @@ func runBackup(cmd *cobra.Command, opts *backupOptions) error {
 	case outputFormatDir:
 		dstRoot = opts.output
 	case outputFormatTar:
+		// test if the output file can be created and fail early if there is an issue
 		fp, err := os.OpenFile(opts.output, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			if fi, err := os.Stat(opts.output); err == nil && fi.IsDir() {

--- a/cmd/oras/root/backup.go
+++ b/cmd/oras/root/backup.go
@@ -171,7 +171,7 @@ func runBackup(cmd *cobra.Command, opts *backupOptions) error {
 			var pe *fs.PathError
 			if errors.As(err, &pe) && errors.Is(pe.Err, syscall.EISDIR) {
 				return &oerrors.Error{
-					Err:            fmt.Errorf("the output path %s already exists and is a directory: %w", opts.output, err),
+					Err:            fmt.Errorf("the output path %q already exists and is a directory", opts.output),
 					Recommendation: "To back up to a tar archive, please specify a different output file name or remove the existing directory.",
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the error message in `oras backup` for the case where the output path ends with `.tar` but is an existing directory.

**BEFORE**:

> Error: unable to create output file test.tar: open test.tar: is a directory

<img width="1092" height="55" alt="image" src="https://github.com/user-attachments/assets/6b3660e1-0e38-4647-a8ef-fd2fc59893fd" />

**AFTER**:

> Error: the output path test.tar already exists and is a directory: open test.tar: is a directory
> To back up to a tar archive, please specify a different output file name or remove the existing directory.

<img width="1506" height="86" alt="image" src="https://github.com/user-attachments/assets/b8b65ed8-590a-4e9c-927c-98052b6b2a9f" />



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1831

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
