### PR TITLE
chore: convert console output to creack/pty

### DIFF
--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -36,19 +36,11 @@ const (
 
 // Console is a wrapper around PTY and ANSI escape codes.
 type Console interface {
-	Write(p []byte) (n int, err error)
-	Size() (*WinSize, error)
 	GetHeightWidth() (height, width int)
 	Save()
 	NewRow()
 	OutputTo(upCnt uint, str string)
 	Restore()
-}
-
-// WinSize represents the size of a terminal window.
-type WinSize struct {
-	Height uint16
-	Width  uint16
 }
 
 type console struct {
@@ -63,61 +55,52 @@ func NewConsole(f *os.File) (Console, error) {
 	return &console{file: f}, nil
 }
 
-// Write writes data to the console.
-func (c *console) Write(p []byte) (n int, err error) {
+// write writes data to the console.
+func (c *console) write(p []byte) (n int, err error) {
 	return c.file.Write(p)
-}
-
-// Size returns the size of the console.
-func (c *console) Size() (*WinSize, error) {
-	rows, cols, err := pty.Getsize(c.file)
-	if err != nil {
-		return nil, err
-	}
-	return &WinSize{Height: uint16(rows), Width: uint16(cols)}, nil
 }
 
 // GetHeightWidth returns the width and height of the console.
 // If the console size cannot be determined, returns a default value of 80x10.
 func (c *console) GetHeightWidth() (height, width int) {
-	windowSize, err := c.Size()
+	rows, cols, err := pty.Getsize(c.file)
 	if err != nil {
 		return MinHeight, MinWidth
 	}
-	if windowSize.Height < MinHeight {
-		windowSize.Height = MinHeight
+	if rows < MinHeight {
+		rows = MinHeight
 	}
-	if windowSize.Width < MinWidth {
-		windowSize.Width = MinWidth
+	if cols < MinWidth {
+		cols = MinWidth
 	}
-	return int(windowSize.Height), int(windowSize.Width)
+	return rows, cols
 }
 
 // Save saves the current cursor position.
 func (c *console) Save() {
-	_, _ = c.Write([]byte(aec.Hide.Apply(Save)))
+	_, _ = c.write([]byte(aec.Hide.Apply(Save)))
 }
 
 // NewRow allocates a horizontal space to the output area with scroll if needed.
 func (c *console) NewRow() {
-	_, _ = c.Write([]byte(Restore))
-	_, _ = c.Write([]byte("\n"))
-	_, _ = c.Write([]byte(Save))
+	_, _ = c.write([]byte(Restore))
+	_, _ = c.write([]byte("\n"))
+	_, _ = c.write([]byte(Save))
 }
 
 // OutputTo outputs a string to a specific line.
 func (c *console) OutputTo(upCnt uint, str string) {
-	_, _ = c.Write([]byte(Restore))
-	_, _ = c.Write([]byte(aec.PreviousLine(upCnt).Apply(str)))
-	_, _ = c.Write([]byte("\n"))
-	_, _ = c.Write([]byte(aec.EraseLine(aec.EraseModes.Tail).String()))
+	_, _ = c.write([]byte(Restore))
+	_, _ = c.write([]byte(aec.PreviousLine(upCnt).Apply(str)))
+	_, _ = c.write([]byte("\n"))
+	_, _ = c.write([]byte(aec.EraseLine(aec.EraseModes.Tail).String()))
 }
 
 // Restore restores the saved cursor position.
 func (c *console) Restore() {
 	// cannot use aec.Restore since DEC has better compatibility than SCO
-	_, _ = c.Write([]byte(Restore))
-	_, _ = c.Write([]byte(aec.Column(0).
+	_, _ = c.write([]byte(Restore))
+	_, _ = c.write([]byte(aec.Column(0).
 		With(aec.EraseLine(aec.EraseModes.All)).
 		With(aec.Show).String()))
 }

--- a/cmd/oras/internal/display/status/console/console_test.go
+++ b/cmd/oras/internal/display/status/console/console_test.go
@@ -21,31 +21,32 @@ import (
 	"os"
 	"testing"
 
-	containerd "github.com/containerd/console"
+	"github.com/creack/pty"
 	"oras.land/oras/internal/testutils"
 )
 
-func givenConsole(t *testing.T) (c Console, pty containerd.Console) {
+func givenConsole(t *testing.T) (c Console, ptmx *os.File) {
 	t.Helper()
-	pty, _, err := containerd.NewPty()
+	ptmx, pts, err := pty.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() { _ = pts.Close() }()
 
 	c = &console{
-		Console: pty,
+		file: ptmx,
 	}
-	return c, pty
+	return c, ptmx
 }
 
-func givenTestConsole(t *testing.T) (c Console, pty containerd.Console, tty *os.File) {
+func givenTestConsole(t *testing.T) (c Console, ptmx *os.File, pts *os.File) {
 	t.Helper()
 	var err error
-	pty, tty, err = testutils.NewPty()
+	ptmx, pts, err = testutils.NewPty()
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err = NewConsole(tty)
+	c, err = NewConsole(pts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,68 +71,73 @@ func TestNewConsole(t *testing.T) {
 }
 
 func TestConsole_GetHeightWidth(t *testing.T) {
-	c, pty := givenConsole(t)
+	c, ptmx := givenConsole(t)
+	defer func() { _ = ptmx.Close() }()
 
 	// minimal width and height
 	gotHeight, gotWidth := c.GetHeightWidth()
 	validateSize(t, gotWidth, gotHeight, MinWidth, MinHeight)
 
 	// zero width
-	_ = pty.Resize(containerd.WinSize{Width: 0, Height: MinHeight})
+	_ = pty.Setsize(ptmx, &pty.Winsize{Rows: MinHeight, Cols: 0})
 	gotHeight, gotWidth = c.GetHeightWidth()
 	validateSize(t, gotWidth, gotHeight, MinWidth, MinHeight)
 
 	// zero height
-	_ = pty.Resize(containerd.WinSize{Width: MinWidth, Height: 0})
+	_ = pty.Setsize(ptmx, &pty.Winsize{Rows: 0, Cols: MinWidth})
 	gotHeight, gotWidth = c.GetHeightWidth()
 	validateSize(t, gotWidth, gotHeight, MinWidth, MinHeight)
 
-	// valid zero and height
-	_ = pty.Resize(containerd.WinSize{Width: 200, Height: 100})
+	// valid width and height
+	_ = pty.Setsize(ptmx, &pty.Winsize{Rows: 100, Cols: 200})
 	gotHeight, gotWidth = c.GetHeightWidth()
 	validateSize(t, gotWidth, gotHeight, 200, 100)
 
 }
 
 func TestConsole_NewRow(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
+	c, ptmx, pts := givenTestConsole(t)
+	defer func() { _ = ptmx.Close() }()
 
 	c.NewRow()
 
-	err := testutils.MatchPty(pty, tty, "\x1b8\r\n\x1b7")
+	err := testutils.MatchPty(ptmx, pts, "\x1b8\r\n\x1b7")
 	if err != nil {
 		t.Fatalf("NewRow output error: %v", err)
 	}
 }
 
 func TestConsole_OutputTo(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
+	c, ptmx, pts := givenTestConsole(t)
+	defer func() { _ = ptmx.Close() }()
 
 	c.OutputTo(1, "test string")
 
-	err := testutils.MatchPty(pty, tty, "\x1b8\x1b[1Ftest string\x1b[0m\r\n\x1b[0K")
+	err := testutils.MatchPty(ptmx, pts, "\x1b8\x1b[1Ftest string\x1b[0m\r\n\x1b[0K")
 	if err != nil {
 		t.Fatalf("OutputTo output error: %v", err)
 	}
 }
 
 func TestConsole_Restore(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
+	c, ptmx, pts := givenTestConsole(t)
+	defer func() { _ = ptmx.Close() }()
 
 	c.Restore()
 
-	err := testutils.MatchPty(pty, tty, "\x1b8\x1b[0G\x1b[2K\x1b[?25h")
+	err := testutils.MatchPty(ptmx, pts, "\x1b8\x1b[0G\x1b[2K\x1b[?25h")
 	if err != nil {
 		t.Fatalf("Restore output error: %v", err)
 	}
 }
 
 func TestConsole_Save(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
+	c, ptmx, pts := givenTestConsole(t)
+	defer func() { _ = ptmx.Close() }()
 
 	c.Save()
 
-	err := testutils.MatchPty(pty, tty, "\x1b[?25l\x1b7\x1b[0m")
+	err := testutils.MatchPty(ptmx, pts, "\x1b[?25l\x1b7\x1b[0m")
 	if err != nil {
 		t.Fatalf("Save output error: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/containerd/console v1.0.5
+	github.com/creack/pty v1.1.24
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
-github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
-github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -60,7 +60,6 @@ golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX
 golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
 golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=

--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -1,4 +1,4 @@
-//go:build !windows && !darwin
+//go:build !windows
 
 /*
 Copyright The ORAS Authors.
@@ -31,11 +31,7 @@ import (
 // NewPty creates a new pty pair for testing, caller is responsible for closing
 // the returned files if err is not nil.
 func NewPty() (*os.File, *os.File, error) {
-	ptmx, pts, err := pty.Open()
-	if err != nil {
-		return nil, nil, err
-	}
-	return ptmx, pts, nil
+	return pty.Open()
 }
 
 // MatchPty checks that the output matches the expected strings in specified


### PR DESCRIPTION
**What this PR does / why we need it**:
The https://github.com/containerd/console we are using is pretty much a dead project. There has been a ticket about mac failures for over a year and no action over there other than bug fixes. The project is small time:
<img width="319" height="71" alt="Screenshot 2025-09-10 at 6 10 00 PM" src="https://github.com/user-attachments/assets/2ee0c58f-3167-46e6-b066-40f72d0b9643" />

The creack/pty project is a lot more active:
<img width="342" height="60" alt="Screenshot 2025-09-10 at 6 10 11 PM" src="https://github.com/user-attachments/assets/4be058f2-44d7-4901-adbf-00a41675b385" />


Closes: https://github.com/oras-project/oras/issues/1449


