### PR TITLE
refactor: referrers api parameter

### DIFF
--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -372,8 +372,8 @@ func (remo *Remote) NewRepository(reference string, common Common, logger logrus
 		return nil, err
 	}
 	repo.SkipReferrersGC = true
-	if remo.ReferrersAPI != nil {
-		if err := repo.SetReferrersCapability(*remo.ReferrersAPI); err != nil {
+	if remo.ReferrersAPI != ReferrersStateUnknown {
+		if err := repo.SetReferrersCapability(remo.ReferrersAPI == ReferrersStateSupported); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/oras/root/manifest/delete.go
+++ b/cmd/oras/root/manifest/delete.go
@@ -92,7 +92,7 @@ func deleteManifest(cmd *cobra.Command, opts *deleteOptions) error {
 
 	// add both pull and delete scope hints for dst repository to save potential delete-scope token requests during deleting
 	hints := []string{auth.ActionPull, auth.ActionDelete}
-	if opts.ReferrersAPI == nil || !*opts.ReferrersAPI {
+	if opts.ReferrersAPI != option.ReferrersStateSupported {
 		// possibly needed when adding a new referrers index
 		hints = append(hints, auth.ActionPush)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Clean up referrers API parameter.
