### PR TITLE
fix: codeql was missing this configuration file

### DIFF
--- a/codeql.yml
+++ b/codeql.yml
@@ -1,0 +1,39 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "ORAS CodeQL Configuration"
+
+disable-default-queries: false
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - "**/test/**"
+  - "**/testdata/**"
+  - "**/*_test.go"
+  - "**/vendor/**"
+  - "**/*.md"
+  - "**/*.yml"
+  - "**/*.yaml"
+
+paths:
+  - "cmd/"
+  - "internal/"
+
+query-filters:
+  - exclude:
+      id: go/example-code
+  - exclude:
+      id: go/unused-variable
+      problem-matcher: "test files"


### PR DESCRIPTION
**What this PR does / why we need it**:

Looks like CodeQL is not running without this file

For example:
https://github.com/oras-project/oras/pull/1854/checks?check_run_id=50246044453
