### PR TITLE
refactor: rename parse repository method

### DIFF
--- a/cmd/oras/root/repo/ls.go
+++ b/cmd/oras/root/repo/ls.go
@@ -67,7 +67,7 @@ Example - [Experimental] List the repositories under the registry using the give
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			if opts.hostname, opts.namespace, err = repository.ParseRepoPath(args[0]); err != nil {
+			if opts.hostname, opts.namespace, err = repository.ParseRemoteRepository(args[0]); err != nil {
 				return fmt.Errorf("could not parse repository path: %w", err)
 			}
 			return listRepository(cmd, &opts)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -22,8 +22,8 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
-// ParserRepoPath extracts hostname and namespace from rawReference.
-func ParseRepoPath(rawReference string) (hostname, namespace string, err error) {
+// ParseRemoteRepository extracts hostname and namespace from rawReference.
+func ParseRemoteRepository(rawReference string) (hostname, namespace string, err error) {
 	rawReference = strings.TrimSuffix(rawReference, "/")
 	if strings.Contains(rawReference, "/") {
 		var ref registry.Reference

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -87,7 +87,7 @@ func Test_ParseRepoPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotHostname, gotNamespace, err := ParseRepoPath(tt.args.rawReference)
+			gotHostname, gotNamespace, err := ParseRemoteRepository(tt.args.rawReference)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseRepoPath() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename ParseRepoPath method
