### PR TITLE
feature: add test coverage script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ default: test build-$(OS)-$(ARCH)
 test: tidy vendor check-encoding  ## tidy and run tests
 	$(GO_EXE) test -race -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=$(PKG) $(PKG)
 
+.PHONY: test-coverage
+test-coverage:  ## look at code coverage
+	@echo
+	@echo "==> Running unit tests with coverage: $(PKG) <=="
+	@ ./scripts/coverage.sh $(PKG)
+
 .PHONY: teste2e
 teste2e:  ## run end to end tests
 	./test/e2e/scripts/e2e.sh $(shell git rev-parse --show-toplevel) --clean

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+covermode=${COVERMODE:-atomic}
+coverdir=$(mktemp -d /tmp/coverage.XXXXXXXXXX)
+profile="${coverdir}/cover.out"
+target="${1:-./...}" # by default the whole repository is tested
+
+generate_cover_data() {
+  for d in $(go list "$target"); do
+    (
+      local output="${coverdir}/${d//\//-}.cover"
+      go test -coverprofile="${output}" -covermode="$covermode" "$d"
+    )
+  done
+
+  echo "mode: $covermode" >"$profile"
+  grep -h -v "^mode:" "$coverdir"/*.cover >>"$profile"
+}
+
+generate_cover_data
+go tool cover -func "${profile}"
+
+case "${1-}" in
+  --html)
+    go tool cover -html "${profile}"
+    ;;
+esac
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Add test coverage script for simple reports I can diff:

````
% diff coverage.before coverage.after 
14c14
< ok  	oras.land/oras/cmd/oras/internal/display/metadata/text	(cached)	coverage: 31.5% of statements
---
> ok  	oras.land/oras/cmd/oras/internal/display/metadata/text	0.270s	coverage: 41.4% of statements
155,157c155,157
< oras.land/oras/cmd/oras/internal/display/metadata/text/attach.go:36:			NewAttachHandler		0.0%
< oras.land/oras/cmd/oras/internal/display/metadata/text/attach.go:43:			OnAttached			0.0%
< oras.land/oras/cmd/oras/internal/display/metadata/text/attach.go:56:			Render				0.0%
---
> oras.land/oras/cmd/oras/internal/display/metadata/text/attach.go:36:			NewAttachHandler		100.0%
> oras.land/oras/cmd/oras/internal/display/metadata/text/attach.go:43:			OnAttached			100.0%
> oras.land/oras/cmd/oras/internal/display/metadata/text/attach.go:56:			Render				100.0%
663c663
< total:											(statements)		34.8%
---
> total:											(statements)		35.1%
````
