### PR TITLE
fix: allow setting org.opencontainers.image.title in annotation file

### DIFF
--- a/cmd/oras/root/file.go
+++ b/cmd/oras/root/file.go
@@ -42,6 +42,12 @@ func loadFiles(ctx context.Context, store *file.Store, annotations map[string]ma
 			name = filepath.ToSlash(name)
 		}
 
+		if value, ok := annotations[filename]; ok {
+			if nameFromAnnotations, ok := value[ocispec.AnnotationTitle]; ok {
+				name = nameFromAnnotations
+			}
+		}
+
 		err = displayStatus.OnFileLoading(name)
 		if err != nil {
 			return nil, err

--- a/test/e2e/testdata/files/foobar/annotation-rename.json
+++ b/test/e2e/testdata/files/foobar/annotation-rename.json
@@ -1,0 +1,1 @@
+{"$config":{"hello":"config"},"$manifest":{"hi":"manifest"},"foobar/bar":{"foo":"bar","org.opencontainers.image.title":"foobar/baz"}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, trying to set "org.opencontainers.image.title" in an annotation file will error:

```console
$ echo $RANDOM > file; echo '{"file":{"org.opencontainers.image.title":"file2"}}' > annotations.json; oras push --annotation-file annotations.json registry.example/test/test file

Error response from registry: file2: application/vnd.oci.image.layer.v1.tar: not found
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
