### PR TITLE
chore: move Steve Lasker to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @sajayantony @shizhMSFT @stevelasker @Wwwsylvia @TerryHowe
+* @sajayantony @shizhMSFT @Wwwsylvia @TerryHowe

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -3,11 +3,11 @@
 Owners:
   - Sajay Antony (@sajayantony)
   - Shiwei Zhang (@shizhMSFT)
-  - Steve Lasker (@stevelasker)
   - Terry Howe (@TerryHowe)
 
 Emeritus:
   - Avi Deitcher (@deitch)
   - Jimmy Zelinskie (@jzelinskie)
   - Josh Dolitsky (@jdolitsky)
+  - Steve Lasker (@stevelasker)
   - Vincent Batts (@vbatts)


### PR DESCRIPTION
Steve Lasker has not been active for over six months. While Steve's contributions are greatly appreciated, priorities change.
