### PR TITLE
fix: revert Alpine image to 3.22.2 to fix multi-arch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR ${ORASPKG}
 RUN make "build-$(echo $TARGETPLATFORM | tr / -)"
 RUN mv ${ORASPKG}/bin/${TARGETPLATFORM}/oras /go/bin/oras
 
-FROM docker.io/library/alpine:3.23.0
+FROM docker.io/library/alpine:3.22.2
 RUN apk --update add ca-certificates
 COPY --from=builder /go/bin/oras /bin/oras
 RUN mkdir /workspace


### PR DESCRIPTION
**What this PR does / why we need it**:

  - Reverts Alpine base image from `3.23.0` to `3.22.2` to fix broken release-ghcr workflow 

  ## Problem
  Alpine 3.23.0 introduced a QEMU emulation incompatibility that causes multi-architecture builds to fail with:
  ERROR: lib/apk/exec/busybox-1.37.0-r29.trigger: exited with error 127
  - execve: No such file or directory
  This affects all non-native architectures: `linux/arm/v7`, `linux/arm64`, `linux/ppc64le`, and `linux/s390x`.

  ## Solution
  Revert to Alpine 3.22.2, which was working correctly before the upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1932

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
