### PR TITLE
fix: resolve gosec lint failures (G703, G117, G704)

### DIFF
--- a/cmd/oras/internal/display/metadata/tree/discover_test.go
+++ b/cmd/oras/internal/display/metadata/tree/discover_test.go
@@ -55,7 +55,6 @@ func TestDiscoverHandler_OnDiscovered(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create temporary file: %v", err)
 		}
-		defer func() { _ = os.Remove(tmp.Name()) }()
 		defer func() { _ = tmp.Close() }()
 
 		h := NewDiscoverHandler(&buf, path, subjectDesc, true, tmp)

--- a/cmd/oras/internal/option/remote.go
+++ b/cmd/oras/internal/option/remote.go
@@ -67,7 +67,7 @@ type Remote struct {
 	Configs         []string
 	Username        string
 	secretFromStdin bool
-	Secret          string
+	Secret          string //nolint:gosec // G117: not a hardcoded secret, this is a CLI option field
 	flagPrefix      string
 
 	resolveFlag           []string

--- a/internal/crypto/certificate_test.go
+++ b/internal/crypto/certificate_test.go
@@ -37,7 +37,7 @@ func TestLoadCertPool(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // G704: URL is from local httptest.Server
 	if err == nil {
 		resp.Body.Close()
 		t.Fatalf("expecting TLS check failure error but didn't get one")
@@ -53,7 +53,7 @@ func TestLoadCertPool(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	client = &http.Client{Transport: tp}
-	resp, err = client.Do(req)
+	resp, err = client.Do(req) //nolint:gosec // G704: URL is from local httptest.Server
 	if err != nil {
 		t.Fatalf("failed to trust the self signed pem: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Remove unnecessary `os.Remove` in `discover_test.go` since `t.TempDir()` auto-cleans (G703)
- Add nolint directive for `Secret` field in `Remote` struct — it's a CLI option, not a hardcoded secret (G117)
- Add nolint directives for `client.Do(req)` calls in `certificate_test.go` — URLs come from local `httptest.Server` (G704)

Resolves #1984

Signed-off-by: Terry Howe <terrylhowe@gmail.com>
