### PR TITLE
feat: add release automation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,7 @@ vendor:  ## go mod vendor
 .PHONY: fetch-dist
 fetch-dist:  ## fetch distribution
 	mkdir -p _dist
-	cd _dist && \
-	for obj in ${TARGET_OBJS} ; do \
-		curl -sSL -o oras_${VERSION}_$${obj} https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_$${obj} ; \
-	done
+	gh release download v${VERSION} --repo oras-project/oras --dir _dist --clobber
 
 .PHONY: sign
 sign:  ## sign

--- a/Makefile
+++ b/Makefile
@@ -198,11 +198,11 @@ release-tag:  ## tag release: create and push signed tag
 
 .PHONY: release-validate
 release-validate:  ## validate release: verify CI, artifacts, checksums
-	@scripts/release.sh validate $(VERSION)
+	@scripts/release.sh validate
 
 .PHONY: release-publish
 release-publish:  ## publish release: sign, upload, publish
-	@scripts/release.sh publish $(VERSION)
+	@scripts/release.sh publish
 
 .PHONY: help
 help:  ## Display this help

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,22 @@ teste2e-covdata:  ## test e2e coverage
 	mkdir -p $$GOCOVERDIR; \
 	$(MAKE) teste2e && $(GO_EXE) tool covdata textfmt -i=$$GOCOVERDIR -o "$(CURDIR)/test/e2e/coverage.txt"
 
+.PHONY: release-prep
+release-prep:  ## prepare release: bump version, create PR
+	@scripts/release.sh prep $(VERSION)
+
+.PHONY: release-tag
+release-tag:  ## tag release: create and push signed tag
+	@scripts/release.sh tag $(VERSION) $(SHA)
+
+.PHONY: release-validate
+release-validate:  ## validate release: verify CI, artifacts, checksums
+	@scripts/release.sh validate $(VERSION)
+
+.PHONY: release-publish
+release-publish:  ## publish release: sign, upload, publish
+	@scripts/release.sh publish $(VERSION)
+
 .PHONY: help
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[%\/0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ else
   ARCH = amd64
 endif
 
+ORAS_REPO   ?= oras-project/oras
+
 TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz linux_riscv64.tar.gz linux_loong64.tar.gz windows_amd64.zip freebsd_amd64.tar.gz
 
 LDFLAGS = -w
@@ -168,9 +170,10 @@ vendor:  ## go mod vendor
 	GO111MODULE=on $(GO_EXE) mod vendor
 
 .PHONY: fetch-dist
-fetch-dist:  ## fetch distribution
+fetch-dist:  ## fetch distribution (requires gh CLI: https://cli.github.com)
+	@command -v gh >/dev/null 2>&1 || { echo "gh CLI not found. Install: https://cli.github.com"; exit 1; }
 	mkdir -p _dist
-	gh release download v${VERSION} --repo oras-project/oras --dir _dist --clobber
+	gh release download v${VERSION} --repo $(ORAS_REPO) --dir _dist --clobber
 
 .PHONY: sign
 sign:  ## sign

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ else
   ARCH = amd64
 endif
 
+ORAS_REPO   ?= oras-project/oras
+
 TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz linux_riscv64.tar.gz linux_loong64.tar.gz windows_amd64.zip windows_arm64.zip freebsd_amd64.tar.gz
 
 LDFLAGS = -w
@@ -168,9 +170,10 @@ vendor:  ## go mod vendor
 	GO111MODULE=on $(GO_EXE) mod vendor
 
 .PHONY: fetch-dist
-fetch-dist:  ## fetch distribution
+fetch-dist:  ## fetch distribution (requires gh CLI: https://cli.github.com)
+	@command -v gh >/dev/null 2>&1 || { echo "gh CLI not found. Install: https://cli.github.com"; exit 1; }
 	mkdir -p _dist
-	gh release download v${VERSION} --repo oras-project/oras --dir _dist --clobber
+	gh release download v${VERSION} --repo $(ORAS_REPO) --dir _dist --clobber
 
 .PHONY: sign
 sign:  ## sign

--- a/Makefile
+++ b/Makefile
@@ -175,12 +175,6 @@ fetch-dist:  ## fetch distribution (requires gh CLI: https://cli.github.com)
 	mkdir -p _dist
 	gh release download v${VERSION} --repo $(ORAS_REPO) --dir _dist --clobber
 
-.PHONY: sign
-sign:  ## sign
-	for f in $$(ls _dist/*.{gz,txt} 2>/dev/null) ; do \
-		gpg --armor --detach-sign $${f} ; \
-	done
-
 .PHONY: teste2e-covdata
 teste2e-covdata:  ## test e2e coverage
 	export GOCOVERDIR=$(CURDIR)/test/e2e/.cover; \
@@ -201,7 +195,7 @@ release-validate:  ## validate release: verify CI, artifacts, checksums
 	@scripts/release.sh validate
 
 .PHONY: release-publish
-release-publish:  ## publish release: sign, upload, publish
+release-publish:  ## publish release: verify signatures, publish, trigger snap
 	@scripts/release.sh publish
 
 .PHONY: help

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -424,13 +424,27 @@ do_publish() {
 
     # Sign artifacts
     info "Signing artifacts with GPG..."
-    run make SHELL=/bin/bash sign
-    success "Artifacts signed"
+    local sign_failed=false
+    for f in _dist/oras_"${version}"_*; do
+        [[ "$f" == *.asc ]] && continue
+        [ -f "$f" ] || continue
+        if run gpg --armor --detach-sign "$f"; then
+            success "Signed: $(basename "$f")"
+        else
+            error "Failed to sign: $(basename "$f")"
+            sign_failed=true
+        fi
+    done
+    if [ "$sign_failed" = true ]; then
+        error "One or more artifacts failed to sign. Ensure your GPG key is unlocked and retry."
+        exit 1
+    fi
+    success "All artifacts signed"
 
     # Verify signatures
     info "Verifying GPG signatures..."
     local sig_count=0
-    for asc in _dist/*.asc; do
+    for asc in _dist/oras_"${version}"_*.asc; do
         [ -f "$asc" ] || continue
         local orig="${asc%.asc}"
         if gpg --verify "$asc" "$orig" 2>/dev/null; then
@@ -453,7 +467,7 @@ do_publish() {
     if [[ "$DRY_RUN" == "true" ]]; then
         info "[DRY-RUN] Would upload ${sig_count} .asc files to release v${version}"
     else
-        gh release upload "v${version}" _dist/*.asc --repo "$REPO"
+        gh release upload "v${version}" _dist/oras_"${version}"_*.asc --repo "$REPO" --clobber
     fi
     success "Signatures uploaded"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,7 +62,7 @@ confirm() {
         return 0
     fi
     echo -en "${YELLOW}$1 [y/N]: ${NC}"
-    read -r response
+    read -r response </dev/tty
     case "$response" in
         [yY][eE][sS]|[yY]) return 0 ;;
         *) error "Aborted."; exit 1 ;;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 REPO="oras-project/oras"
 VERSION_FILE="internal/version/version.go"
 REMOTE="${ORAS_REMOTE:-upstream}"
+MAIN_RELEASE_VERSION="${ORAS_MAIN_RELEASE_VERSION:-2.0}"
 
 # Colors
 RED='\033[0;31m'
@@ -131,7 +132,12 @@ do_prep() {
     current_branch=$(git branch --show-current)
     major_minor=$(get_major_minor "$version")
     expected_branch="release-${major_minor}"
-    if [ "$current_branch" != "main" ] && [ "$current_branch" != "$expected_branch" ]; then
+    if [ "$current_branch" = "main" ]; then
+        if [ "$major_minor" != "$MAIN_RELEASE_VERSION" ]; then
+            error "Releases from 'main' must be v${MAIN_RELEASE_VERSION}.x, but version is v${version}. Use branch '${expected_branch}' for this release, or set ORAS_MAIN_RELEASE_VERSION if the next main-branch series has changed."
+            exit 1
+        fi
+    elif [ "$current_branch" != "$expected_branch" ]; then
         error "Must be on 'main' or '${expected_branch}' to release v${version}, but currently on '${current_branch}'."
         exit 1
     fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -356,11 +356,23 @@ do_validate() {
     fi
     success "Checksums verified"
 
-    # Test binary
-    info "Testing linux/amd64 binary..."
+    # Test binary for the current OS/arch
+    local os arch artifact
+    case "$(uname -s)" in
+        Darwin) os="darwin" ;;
+        Linux)  os="linux" ;;
+        *)      os="linux" ;;
+    esac
+    case "$(uname -m)" in
+        x86_64)  arch="amd64" ;;
+        arm64|aarch64) arch="arm64" ;;
+        *)       arch="amd64" ;;
+    esac
+    artifact="${os}_${arch}"
+    info "Testing ${os}/${arch} binary..."
     local tmpdir
     tmpdir=$(mktemp -d)
-    tar -xzf "_dist/oras_${version}_linux_amd64.tar.gz" -C "$tmpdir"
+    tar -xzf "_dist/oras_${version}_${artifact}.tar.gz" -C "$tmpdir"
     local bin_version
     bin_version=$("$tmpdir/oras" version 2>/dev/null | head -1 || echo "unknown")
     rm -rf "$tmpdir"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,497 +14,565 @@
 
 set -euo pipefail
 
-# ── Configuration ────────────────────────────────────────────────────────────
-REPO="oras-project/oras"
-REMOTE="${ORAS_REMOTE:-upstream}"
-DRY_RUN=false
-VERSION_FILE="internal/version/version.go"
+# ORAS Release Helper Script
+# Usage: scripts/release.sh <phase> <version> [args...]
+# Phases: prep, tag, validate, publish
 
-# ── Colors ───────────────────────────────────────────────────────────────────
+REPO="oras-project/oras"
+VERSION_FILE="internal/version/version.go"
+REMOTE="${ORAS_REMOTE:-upstream}"
+
+# Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
-BOLD='\033[1m'
 NC='\033[0m' # No Color
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
 info()    { echo -e "${CYAN}[INFO]${NC} $*"; }
 success() { echo -e "${GREEN}[OK]${NC} $*"; }
-warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[MANUAL]${NC} $*"; }
 error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-fatal()   { error "$@"; exit 1; }
 
-confirm() {
-    local msg="$1"
-    if [[ "$DRY_RUN" == "true" ]]; then
-        info "[dry-run] Would prompt: $msg"
-        return 0
-    fi
-    echo -en "${BOLD}$msg [y/N]${NC} "
-    read -r answer
-    [[ "$answer" =~ ^[Yy]$ ]] || { info "Aborted."; exit 0; }
+DRY_RUN=false
+
+# Parse global flags
+parse_global_flags() {
+    local args=()
+    for arg in "$@"; do
+        case "$arg" in
+            --dry-run) DRY_RUN=true ;;
+            *) args+=("$arg") ;;
+        esac
+    done
+    echo "${args[@]:-}"
 }
 
 run() {
-    if [[ "$DRY_RUN" == "true" ]]; then
-        info "[dry-run] $*"
-    else
-        "$@"
+    if [ "$DRY_RUN" = true ]; then
+        info "[DRY-RUN] $*"
+        return 0
     fi
+    "$@"
 }
 
-# ── Validation ───────────────────────────────────────────────────────────────
-validate_semver() {
+confirm() {
+    if [ "$DRY_RUN" = true ]; then
+        info "[DRY-RUN] Would confirm: $1"
+        return 0
+    fi
+    echo -en "${YELLOW}$1 [y/N]: ${NC}"
+    read -r response
+    case "$response" in
+        [yY][eE][sS]|[yY]) return 0 ;;
+        *) error "Aborted."; exit 1 ;;
+    esac
+}
+
+# Validate semver format
+validate_version() {
     local version="$1"
-    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
-        fatal "Invalid semver: '$version'. Expected format: X.Y.Z or X.Y.Z-(alpha|beta|rc).N"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+        error "Invalid version format: $version (expected semver like 1.2.3 or 1.2.3-rc.1)"
+        exit 1
     fi
 }
 
+# Check if this is a new minor version (patch == 0, no pre-release)
+is_new_minor() {
+    local version="$1"
+    local patch
+    patch=$(echo "$version" | cut -d. -f3 | cut -d- -f1)
+    if [[ "$patch" == "0" && ! "$version" =~ - ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# Get major.minor from version
+get_major_minor() {
+    local version="$1"
+    echo "$version" | cut -d. -f1-2
+}
+
+###############################################################################
+# Check prerequisites (gh, gpg, remote)
+###############################################################################
 check_prerequisites() {
     info "Checking prerequisites..."
-
     if ! command -v gh &>/dev/null; then
-        fatal "'gh' (GitHub CLI) is not installed. Install it from https://cli.github.com/"
+        error "'gh' CLI not found. Install: https://cli.github.com"
+        exit 1
     fi
-
     if ! gh auth status &>/dev/null; then
-        fatal "'gh' is not authenticated. Run 'gh auth login' first."
+        error "'gh' CLI not authenticated. Run: gh auth login"
+        exit 1
     fi
-
     if ! command -v gpg &>/dev/null; then
-        fatal "'gpg' is not installed. Install GnuPG first."
+        error "'gpg' not found. Install GPG."
+        exit 1
     fi
-
-    if ! gpg --list-secret-keys --keyid-format=long 2>/dev/null | grep -q sec; then
-        fatal "No GPG secret keys found. Generate one with 'gpg --full-generate-key'."
+    if ! gpg --list-secret-keys --keyid-format LONG 2>/dev/null | grep -q sec; then
+        error "No GPG secret keys found. Import or generate a key."
+        exit 1
     fi
-
     if ! git remote get-url "$REMOTE" &>/dev/null; then
-        fatal "Git remote '$REMOTE' not found. Set ORAS_REMOTE or add the remote."
-    fi
-
-    success "All prerequisites satisfied."
-}
-
-parse_version_parts() {
-    local version="$1"
-    local base="${version%%-*}"
-    MAJOR="${base%%.*}"
-    local rest="${base#*.}"
-    MINOR="${rest%%.*}"
-    PATCH="${rest#*.}"
-    PRERELEASE=""
-    if [[ "$version" == *-* ]]; then
-        PRERELEASE="${version#*-}"
+        error "Git remote '${REMOTE}' not found. Set ORAS_REMOTE or add the remote."
+        exit 1
     fi
 }
 
-# ── Phase: prep ──────────────────────────────────────────────────────────────
-phase_prep() {
+###############################################################################
+# Phase 1: Prep
+###############################################################################
+do_prep() {
     local version="$1"
-    validate_semver "$version"
+    validate_version "$version"
+    info "Preparing release v${version}"
+
     check_prerequisites
+    success "Prerequisites OK"
 
-    parse_version_parts "$version"
-
-    # Determine base branch
-    local base_branch="main"
-    if [[ "$PATCH" -gt 0 ]]; then
-        base_branch="release-${MAJOR}.${MINOR}"
-        info "Patch release detected, targeting branch '$base_branch'."
+    # Check we're on main and up to date
+    local current_branch
+    current_branch=$(git branch --show-current)
+    if [ "$current_branch" != "main" ]; then
+        warn "Currently on branch '$current_branch', not 'main'."
+        confirm "Continue anyway?"
     fi
 
-    info "Preparing release v${version}..."
-
-    # Ensure we are up-to-date
-    info "Fetching latest from ${REMOTE}..."
-    run git fetch "$REMOTE"
-
-    # Create release branch
-    local branch="chore/release-v${version}"
-    info "Creating branch '${branch}' from '${REMOTE}/${base_branch}'..."
-    run git checkout -b "$branch" "${REMOTE}/${base_branch}"
+    # Ensure working tree is clean
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        error "Working tree is not clean. Commit or stash changes before running prep."
+        exit 1
+    fi
 
     # Update version file
     info "Updating ${VERSION_FILE}..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        sed -i.bak -E "s/(Version = \").*(\")/\1${version}\2/" "$VERSION_FILE"
-        sed -i.bak -E "s/(BuildMetadata = \").*(\")/\1\2/" "$VERSION_FILE"
-        rm -f "${VERSION_FILE}.bak"
-    else
-        info "[dry-run] Would set Version = \"${version}\" and BuildMetadata = \"\""
-    fi
+    sed -i.bak -E "s/Version = \"[^\"]+\"/Version = \"${version}\"/" "$VERSION_FILE"
+    sed -i.bak -E "s/BuildMetadata = \"[^\"]*\"/BuildMetadata = \"\"/" "$VERSION_FILE"
+    rm -f "${VERSION_FILE}.bak"
+    success "Version set to ${version}"
 
-    # Commit and push
-    info "Committing version bump..."
+    # Show the diff
+    git diff "$VERSION_FILE"
+
+    # Create branch, commit, push, PR
+    local branch="chore/release-v${version}"
+    info "Creating branch ${branch}..."
+    run git checkout -b "$branch"
     run git add "$VERSION_FILE"
-    run git commit -s -m "chore: bump version to ${version}"
-    info "Pushing branch '${branch}' to origin..."
-    run git push origin "$branch"
+    run git commit -m "bump: tag and release ORAS CLI v${version}"
+    run git push "${REMOTE}" "$branch"
 
-    # Create PR
-    local pr_title="bump: tag and release ORAS CLI v${version}"
     info "Creating pull request..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        gh pr create \
-            --repo "$REPO" \
-            --title "$pr_title" \
-            --base "$base_branch" \
-            --body "$(cat <<EOF
-## Release ORAS CLI v${version}
-
-This PR bumps the version to **${version}** and clears the build metadata in preparation for the release.
-
-### Changes
-- Set \`Version\` to \`${version}\`
-- Set \`BuildMetadata\` to \`""\`
-
-### Release Checklist
-- [ ] Version bump reviewed
-- [ ] CI passing
-- [ ] Maintainer approval received
-EOF
-)"
+    local pr_url
+    if [ "$DRY_RUN" = true ]; then
+        pr_url="https://github.com/${REPO}/pull/DRY-RUN"
+        info "[DRY-RUN] Would create PR"
     else
-        info "[dry-run] Would create PR: '$pr_title' targeting '$base_branch'"
-    fi
+        pr_url=$(gh pr create \
+            --repo "$REPO" \
+            --title "bump: tag and release ORAS CLI v${version}" \
+            --body "$(cat <<EOF
+## Release v${version}
 
-    # Print commit SHA
+This PR bumps the version to v${version} for the upcoming release.
+
+### Checklist
+- [ ] Version updated in \`internal/version/version.go\`
+- [ ] CI checks pass
+- [ ] Vote called in Slack
+- [ ] Vote passed (3+ binding votes, no vetoes)
+EOF
+)" \
+            --head "$branch" \
+            --base main)
+    fi
+    success "PR created: ${pr_url}"
+
+    # Get the commit SHA
     local sha
     sha=$(git rev-parse HEAD)
-    success "Version bump committed."
     echo ""
-    echo -e "${BOLD}Commit SHA:${NC} ${sha}"
-    echo ""
+    success "Release commit SHA: ${sha}"
 
-    # Slack vote template
-    echo -e "${BOLD}Slack Vote Template:${NC}"
-    echo "────────────────────────────────────────"
+    # Print Slack vote template
+    echo ""
+    warn "Copy the following message to Slack #oras to call for a vote:"
+    echo ""
+    echo -e "${CYAN}---${NC}"
     cat <<EOF
-:oras: *ORAS CLI v${version} Release Vote*
+:ballot_box: *[VOTE] Release ORAS CLI v${version}*
 
-Hi team, I'd like to propose the release of ORAS CLI v${version}.
+Hi everyone, I'd like to call a vote for the release of ORAS CLI v${version}.
 
-*Release PR:* (paste PR URL here)
-*Commit SHA:* \`${sha}\`
+*Release PR:* ${pr_url}
+*Release commit:* \`${sha}\`
 
-Please vote:
-:+1: Approve
-:-1: Object (please provide reason)
+Please review the PR and vote:
+  :+1: (binding) — approve
+  :-1: (binding) — veto (please provide reason)
 
-Vote closes in 48 hours. Requires at least 2 approvals from maintainers.
+The vote will remain open for at least 72 hours.
+A minimum of 3 binding +1 votes and no vetoes is required.
 EOF
-    echo "────────────────────────────────────────"
+    echo -e "${CYAN}---${NC}"
+    echo ""
+    warn "After the vote passes and the PR is merged, run:"
+    echo "  scripts/release.sh tag ${version} <merged-commit-sha>"
 }
 
-# ── Phase: tag ───────────────────────────────────────────────────────────────
-phase_tag() {
+###############################################################################
+# Phase 2: Tag
+###############################################################################
+do_tag() {
     local version="$1"
-    local sha="$2"
-    validate_semver "$version"
+    local sha="${2:-}"
+    validate_version "$version"
 
-    info "Tagging release v${version} at ${sha}..."
-
-    # Validate the commit has the correct version
-    info "Validating version at commit ${sha}..."
-    local committed_version
-    committed_version=$(git show "${sha}:${VERSION_FILE}" | grep 'Version = ' | sed -E 's/.*"(.*)".*/\1/')
-    if [[ "$committed_version" != "$version" ]]; then
-        fatal "Version mismatch: commit has '${committed_version}', expected '${version}'."
+    if [ -z "$sha" ]; then
+        error "Usage: scripts/release.sh tag <version> <commit-sha>"
+        exit 1
     fi
 
-    local committed_metadata
-    committed_metadata=$(git show "${sha}:${VERSION_FILE}" | grep 'BuildMetadata = ' | sed -E 's/.*"(.*)".*/\1/')
-    if [[ -n "$committed_metadata" ]]; then
-        fatal "BuildMetadata is not empty at ${sha}: '${committed_metadata}'. Expected empty string."
+    info "Tagging v${version} at ${sha}"
+
+    check_prerequisites
+    success "Prerequisites OK"
+
+    # Verify the commit exists and is on main
+    if ! git cat-file -t "$sha" &>/dev/null; then
+        error "Commit ${sha} not found. Did you fetch latest?"
+        exit 1
     fi
 
-    success "Version validated: ${version} (BuildMetadata is clear)."
+    # Check that the version file at that commit has the right version
+    local file_version
+    file_version=$(git show "${sha}:${VERSION_FILE}" | grep 'Version = ' | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ "$file_version" != "$version" ]; then
+        error "Version in ${VERSION_FILE} at ${sha} is '${file_version}', expected '${version}'"
+        exit 1
+    fi
 
     # Create signed tag
     confirm "Create signed tag v${version} at ${sha}?"
-    info "Creating signed tag v${version}..."
     run git tag -s "v${version}" "$sha" -m "Release v${version}"
-    info "Pushing tag v${version} to ${REMOTE}..."
-    run git push "$REMOTE" "v${version}"
+    success "Tag v${version} created"
 
-    success "Tag v${version} pushed to ${REMOTE}."
+    # Push tag
+    confirm "Push tag v${version} to ${REMOTE}?"
+    run git push "${REMOTE}" "v${version}"
+    success "Tag pushed"
 
-    # Create release branch for new minor versions (patch==0, no pre-release)
-    parse_version_parts "$version"
-    if [[ "$PATCH" -eq 0 && -z "$PRERELEASE" ]]; then
-        local release_branch="release-${MAJOR}.${MINOR}"
-        info "New minor release detected. Creating release branch '${release_branch}'..."
-        confirm "Create and push release branch '${release_branch}'?"
+    # Create release branch for new minor versions
+    if is_new_minor "$version"; then
+        local release_branch="release-$(get_major_minor "$version")"
+        info "New minor version detected. Creating release branch ${release_branch}..."
         run git branch "$release_branch" "$sha"
-        run git push "$REMOTE" "$release_branch"
-        success "Release branch '${release_branch}' created and pushed."
+        confirm "Push release branch ${release_branch} to ${REMOTE}?"
+        run git push "${REMOTE}" "$release_branch"
+        success "Release branch ${release_branch} pushed"
     fi
+
+    echo ""
+    info "CI workflows triggered. Monitor at:"
+    echo "  https://github.com/${REPO}/actions?query=event%3Apush+branch%3Av${version}"
+    echo ""
+    warn "Once CI completes, run:"
+    echo "  scripts/release.sh validate ${version}"
 }
 
-# ── Phase: validate ──────────────────────────────────────────────────────────
-phase_validate() {
+###############################################################################
+# Phase 3: Validate
+###############################################################################
+do_validate() {
     local version="$1"
-    validate_semver "$version"
+    validate_version "$version"
+    info "Validating release v${version}"
 
-    info "Validating release v${version}..."
-
-    # Poll GitHub Actions workflows
+    # Wait for CI workflows
+    info "Checking CI workflow status..."
     local workflows=("release-ghcr" "release-github")
-    for wf in "${workflows[@]}"; do
-        info "Polling workflow '${wf}' for tag v${version}..."
-        if [[ "$DRY_RUN" == "true" ]]; then
-            info "[dry-run] Would poll workflow '${wf}' until completion."
-            continue
-        fi
+    local all_done=false
+    local max_attempts=60  # 30 minutes at 30s intervals
+    local attempt=0
 
-        local max_attempts=60
-        local attempt=0
-        while [[ $attempt -lt $max_attempts ]]; do
+    while [ "$all_done" != "true" ] && [ "$attempt" -lt "$max_attempts" ]; do
+        all_done=true
+        for wf in "${workflows[@]}"; do
             local status
             status=$(gh run list \
                 --repo "$REPO" \
-                --workflow "${wf}.yml" \
+                --workflow "$wf" \
                 --branch "v${version}" \
                 --limit 1 \
                 --json status,conclusion \
                 --jq '.[0] | "\(.status) \(.conclusion)"' 2>/dev/null || echo "not_found")
 
-            if [[ "$status" == "not_found" || "$status" == " " ]]; then
-                info "Workflow '${wf}' not found yet, waiting..."
-            elif [[ "$status" == "completed success" ]]; then
-                success "Workflow '${wf}' completed successfully."
-                break
-            elif [[ "$status" == completed* ]]; then
-                fatal "Workflow '${wf}' failed: ${status}"
+            if [[ "$status" == *"completed success"* ]]; then
+                success "Workflow ${wf}: completed successfully"
+            elif [[ "$status" == *"completed"* ]]; then
+                error "Workflow ${wf}: ${status}"
+                exit 1
+            elif [[ "$status" == "not_found" ]]; then
+                warn "Workflow ${wf}: not found yet"
+                all_done=false
             else
-                info "Workflow '${wf}' status: ${status}. Waiting..."
+                info "Workflow ${wf}: ${status} (waiting...)"
+                all_done=false
             fi
-
-            attempt=$((attempt + 1))
-            sleep 30
         done
 
-        if [[ $attempt -ge $max_attempts ]]; then
-            fatal "Timed out waiting for workflow '${wf}' to complete."
+        if [ "$all_done" != "true" ]; then
+            ((attempt++))
+            if [ "$attempt" -lt "$max_attempts" ]; then
+                info "Waiting 30s for workflows... (attempt ${attempt}/${max_attempts})"
+                sleep 30
+            fi
         fi
     done
+
+    if [ "$all_done" != "true" ]; then
+        error "Timed out waiting for workflows"
+        exit 1
+    fi
+    success "All CI workflows completed"
 
     # Fetch distribution artifacts
     info "Fetching distribution artifacts..."
     run make fetch-dist VERSION="$version"
+    success "Artifacts downloaded to _dist/"
 
     # Verify checksums
     info "Verifying checksums..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        cd _dist
-        if ! shasum -a 256 -c "oras_${version}_checksums.txt" --ignore-missing; then
-            fatal "Checksum verification failed!"
-        fi
-        success "Checksums verified."
-        cd ..
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd _dist && sha256sum -c "oras_${version}_checksums.txt" --ignore-missing)
+    elif command -v shasum >/dev/null 2>&1; then
+        (cd _dist && shasum -a 256 -c "oras_${version}_checksums.txt" --ignore-missing)
+    else
+        error "Neither sha256sum nor shasum is available; cannot verify checksums."
+        exit 1
+    fi
+    success "Checksums verified"
+
+    # Test binary
+    info "Testing linux/amd64 binary..."
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    tar -xzf "_dist/oras_${version}_linux_amd64.tar.gz" -C "$tmpdir"
+    local bin_version
+    bin_version=$("$tmpdir/oras" version 2>/dev/null | head -1 || echo "unknown")
+    rm -rf "$tmpdir"
+
+    if echo "$bin_version" | grep -q "$version"; then
+        success "Binary version matches: ${bin_version}"
+    else
+        error "Binary version mismatch. Expected '${version}', got: ${bin_version}"
+        exit 1
     fi
 
-    # Test linux/amd64 binary
-    info "Testing linux/amd64 binary version..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        local tarball="_dist/oras_${version}_linux_amd64.tar.gz"
-        if [[ ! -f "$tarball" ]]; then
-            fatal "Binary archive not found: ${tarball}"
-        fi
-        local tmpdir
-        tmpdir=$(mktemp -d)
-        tar -xzf "$tarball" -C "$tmpdir"
-        local binary_version
-        binary_version=$("${tmpdir}/oras" version 2>/dev/null | grep 'Version:' | awk '{print $2}' || echo "unknown")
-        rm -rf "$tmpdir"
-
-        if [[ "$binary_version" != "$version" ]]; then
-            fatal "Binary version mismatch: got '${binary_version}', expected '${version}'."
-        fi
-        success "Binary version verified: ${binary_version}"
+    # Check git commit in binary
+    local tag_sha
+    tag_sha=$(git rev-list -n 1 "v${version}" 2>/dev/null || echo "unknown")
+    if echo "$bin_version" | grep -q "${tag_sha:0:7}"; then
+        success "Binary git commit matches tag SHA"
+    else
+        warn "Could not verify git commit in binary output (non-fatal)"
     fi
 
-    success "Release v${version} validation complete."
+    echo ""
+    success "All validation checks passed!"
+    echo ""
+    warn "Review the release notes at:"
+    echo "  https://github.com/${REPO}/releases/tag/v${version}"
+    echo ""
+    warn "When ready, run:"
+    echo "  scripts/release.sh publish ${version}"
 }
 
-# ── Phase: publish ───────────────────────────────────────────────────────────
-phase_publish() {
+###############################################################################
+# Phase 4: Sign & Publish
+###############################################################################
+do_publish() {
     local version="$1"
-    validate_semver "$version"
+    validate_version "$version"
+    info "Publishing release v${version}"
 
-    info "Publishing release v${version}..."
+    # Check artifacts exist
+    if [ ! -d "_dist" ]; then
+        error "_dist/ directory not found. Run 'scripts/release.sh validate ${version}' first."
+        exit 1
+    fi
 
     # Sign artifacts
-    info "Signing artifacts..."
-    run make sign
+    info "Signing artifacts with GPG..."
+    run make SHELL=/bin/bash sign
+    success "Artifacts signed"
 
-    # Verify GPG signatures
+    # Verify signatures
     info "Verifying GPG signatures..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        local failed=false
-        for sig in _dist/*.asc; do
-            local original="${sig%.asc}"
-            if ! gpg --verify "$sig" "$original" 2>/dev/null; then
-                error "GPG verification failed for: ${original}"
-                failed=true
-            fi
-        done
-        if [[ "$failed" == "true" ]]; then
-            fatal "One or more GPG signature verifications failed."
+    local sig_count=0
+    for asc in _dist/*.asc; do
+        [ -f "$asc" ] || continue
+        local orig="${asc%.asc}"
+        if gpg --verify "$asc" "$orig" 2>/dev/null; then
+            success "Verified: $(basename "$asc")"
+            ((sig_count++))
+        else
+            error "Signature verification failed: $(basename "$asc")"
+            exit 1
         fi
-        success "All GPG signatures verified."
+    done
+    if [ "$sig_count" -eq 0 ]; then
+        error "No .asc signature files found in _dist/"
+        exit 1
+    fi
+    success "All ${sig_count} signatures verified"
+
+    # Upload signatures to GitHub release
+    info "Uploading signatures to GitHub release..."
+    confirm "Upload ${sig_count} .asc files to release v${version}?"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[DRY-RUN] Would upload ${sig_count} .asc files to release v${version}"
+    else
+        gh release upload "v${version}" _dist/*.asc --repo "$REPO"
+    fi
+    success "Signatures uploaded"
+
+    # Get GPG key fingerprint for release notes
+    local fingerprint
+    fingerprint=$(gpg --list-secret-keys --keyid-format LONG 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d/ -f2)
+    if [ -n "$fingerprint" ]; then
+        info "Adding signing key info to release notes..."
+        local note="## Verification\n\nAll release artifacts are signed with GPG key \`${fingerprint}\`. Signatures (\`.asc\` files) are attached to this release.\n\nPublic keys are available in the [KEYS](https://github.com/${REPO}/blob/main/KEYS) file."
+        if [ "$DRY_RUN" = true ]; then
+            info "[DRY-RUN] Would append signing info to release notes"
+        else
+            local existing_notes
+            existing_notes=$(gh release view "v${version}" --repo "$REPO" --json body --jq '.body')
+            gh release edit "v${version}" --repo "$REPO" --notes "$(printf '%s\n\n%b' "$existing_notes" "$note")"
+        fi
+        success "Release notes updated with signing key info"
     fi
 
-    # Upload .asc files to GitHub release
-    info "Uploading signature files to GitHub release..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        for sig in _dist/*.asc; do
-            info "Uploading $(basename "$sig")..."
-            gh release upload "v${version}" "$sig" --repo "$REPO" --clobber
-        done
-        success "Signature files uploaded."
-    fi
-
-    # Add signing key info to release notes
-    info "Adding signing key information to release notes..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        local gpg_key_id
-        gpg_key_id=$(gpg --list-secret-keys --keyid-format=long 2>/dev/null \
-            | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
-
-        local existing_notes
-        existing_notes=$(gh release view "v${version}" --repo "$REPO" --json body --jq '.body')
-
-        local signing_note
-        signing_note="$(cat <<EOF
-
----
-
-## Verification
-
-The release artifacts are signed with GPG key \`${gpg_key_id}\`.
-
-To verify a downloaded artifact:
-\`\`\`bash
-# Import the signing key (if not already imported)
-gpg --keyserver keyserver.ubuntu.com --recv-keys ${gpg_key_id}
-
-# Verify the signature
-gpg --verify oras_${version}_linux_amd64.tar.gz.asc oras_${version}_linux_amd64.tar.gz
-\`\`\`
-EOF
-)"
-        gh release edit "v${version}" --repo "$REPO" \
-            --notes "${existing_notes}${signing_note}"
-        success "Release notes updated with signing key info."
-    fi
-
-    # Publish release (remove draft status)
+    # Publish release
     confirm "Publish release v${version} (remove draft status)?"
-    info "Publishing release..."
     run gh release edit "v${version}" --repo "$REPO" --draft=false
+    success "Release v${version} published!"
 
     # Trigger snap workflow
     info "Triggering snap workflow..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        gh workflow run snap.yml --repo "$REPO" --ref "v${version}" 2>/dev/null || \
-            warn "Could not trigger snap workflow. You may need to trigger it manually."
+    local is_stable="true"
+    if [[ "$version" == *"-"* ]]; then
+        is_stable="false"
+    fi
+    if [ "$DRY_RUN" = true ]; then
+        info "[DRY-RUN] Would trigger release-snap.yml with version=v${version} isStable=${is_stable}"
+    else
+        gh workflow run release-snap.yml \
+            --repo "$REPO" \
+            --ref "v${version}" \
+            --field version="v${version}" \
+            --field isStable="${is_stable}" 2>/dev/null \
+        && success "Snap workflow triggered" \
+        || warn "Could not trigger snap workflow. You may need to trigger it manually."
     fi
 
     # Clean up
-    info "Cleaning up _dist/ directory..."
-    run rm -rf _dist/
+    confirm "Remove _dist/ directory?"
+    run rm -rf _dist
+    success "Cleaned up _dist/"
 
-    success "Release v${version} published successfully!"
     echo ""
-    echo -e "${BOLD}Post-release Slack Template:${NC}"
-    echo "────────────────────────────────────────"
+    success "Release v${version} is live!"
+    echo "  https://github.com/${REPO}/releases/tag/v${version}"
+    echo ""
+    warn "Post-release steps (manual):"
+    echo "  1. Update oras-www docs if needed"
+    echo "  2. Announce in Slack #oras:"
+    echo ""
+    echo -e "${CYAN}---${NC}"
     cat <<EOF
-:tada: *ORAS CLI v${version} has been released!*
+:tada: *ORAS CLI v${version} Released!*
 
-*Release page:* https://github.com/${REPO}/releases/tag/v${version}
-*GHCR:* \`ghcr.io/oras-project/oras:v${version}\`
+We're excited to announce the release of ORAS CLI v${version}!
 
-Thanks to all contributors! :heart:
+*Release:* https://github.com/${REPO}/releases/tag/v${version}
+*Changelog:* https://github.com/${REPO}/releases/tag/v${version}
+
+Thank you to all contributors!
 EOF
-    echo "────────────────────────────────────────"
+    echo -e "${CYAN}---${NC}"
 }
 
-# ── Main ─────────────────────────────────────────────────────────────────────
+###############################################################################
+# Main
+###############################################################################
 usage() {
     cat <<EOF
-Usage: $(basename "$0") [--dry-run] <phase> <version> [sha]
+Usage: scripts/release.sh [--dry-run] <phase> <version> [args...]
 
 Phases:
-  prep <version>        Prepare a release: bump version, create PR
-  tag <version> <sha>   Tag a release: create and push signed tag
-  validate <version>    Validate a release: verify CI, artifacts, checksums
-  publish <version>     Publish a release: sign, upload, publish
+  prep <version>              Bump version, create PR, print vote template
+  tag <version> <commit-sha>  Create and push signed tag
+  validate <version>          Wait for CI, download and verify artifacts
+  publish <version>           Sign, upload signatures, publish release
 
-Options:
-  --dry-run    Print commands without executing them
+Flags:
+  --dry-run                   Print actions without executing them
 
 Environment:
-  ORAS_REMOTE  Git remote for upstream (default: upstream)
+  ORAS_REMOTE                 Git remote name (default: upstream)
 
 Examples:
-  $(basename "$0") prep 1.3.0
-  $(basename "$0") tag 1.3.0 abc1234
-  $(basename "$0") validate 1.3.0
-  $(basename "$0") publish 1.3.0
-  $(basename "$0") --dry-run prep 1.3.0-rc.1
+  scripts/release.sh prep 1.3.0
+  scripts/release.sh tag 1.3.0 abc1234
+  scripts/release.sh validate 1.3.0
+  scripts/release.sh publish 1.3.0
+  scripts/release.sh --dry-run prep 1.3.0-rc.1
 EOF
 }
 
 main() {
-    # Parse global flags
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --dry-run)
-                DRY_RUN=true
-                info "Dry-run mode enabled."
-                shift
-                ;;
-            -h|--help)
-                usage
-                exit 0
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
+    local args
+    args=$(parse_global_flags "$@")
+    # Re-split args
+    set -- $args
 
-    if [[ $# -lt 1 ]]; then
+    local phase="${1:-}"
+    local version="${2:-}"
+
+    if [ -z "$phase" ]; then
         usage
         exit 1
     fi
 
-    local phase="$1"
-    shift
+    # Ensure we're in the repo root
+    cd "$(git rev-parse --show-toplevel)"
 
     case "$phase" in
         prep)
-            [[ $# -ge 1 ]] || { error "Usage: $0 prep <version>"; exit 1; }
-            phase_prep "$1"
+            [ -z "$version" ] && { error "Usage: scripts/release.sh prep <version>"; exit 1; }
+            do_prep "$version"
             ;;
         tag)
-            [[ $# -ge 2 ]] || { error "Usage: $0 tag <version> <sha>"; exit 1; }
-            phase_tag "$1" "$2"
+            [ -z "$version" ] && { error "Usage: scripts/release.sh tag <version> <sha>"; exit 1; }
+            do_tag "$version" "${3:-}"
             ;;
         validate)
-            [[ $# -ge 1 ]] || { error "Usage: $0 validate <version>"; exit 1; }
-            phase_validate "$1"
+            [ -z "$version" ] && { error "Usage: scripts/release.sh validate <version>"; exit 1; }
+            do_validate "$version"
             ;;
         publish)
-            [[ $# -ge 1 ]] || { error "Usage: $0 publish <version>"; exit 1; }
-            phase_publish "$1"
+            [ -z "$version" ] && { error "Usage: scripts/release.sh publish <version>"; exit 1; }
+            do_publish "$version"
+            ;;
+        help|--help|-h)
+            usage
             ;;
         *)
-            error "Unknown phase: '${phase}'"
+            error "Unknown phase: ${phase}"
             usage
             exit 1
             ;;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,18 +56,6 @@ run() {
     "$@"
 }
 
-confirm() {
-    if [ "$DRY_RUN" = true ]; then
-        info "[DRY-RUN] Would confirm: $1"
-        return 0
-    fi
-    echo -en "${YELLOW}$1 [y/N]: ${NC}"
-    read -r response </dev/tty
-    case "$response" in
-        [yY][eE][sS]|[yY]) return 0 ;;
-        *) error "Aborted."; exit 1 ;;
-    esac
-}
 
 # Validate semver format
 validate_version() {
@@ -133,12 +121,14 @@ do_prep() {
     check_prerequisites
     success "Prerequisites OK"
 
-    # Check we're on main and up to date
-    local current_branch
+    # Verify we're on main or the correct release branch
+    local current_branch major_minor expected_branch
     current_branch=$(git branch --show-current)
-    if [ "$current_branch" != "main" ]; then
-        warn "Currently on branch '$current_branch', not 'main'."
-        confirm "Continue anyway?"
+    major_minor=$(get_major_minor "$version")
+    expected_branch="release-${major_minor}"
+    if [ "$current_branch" != "main" ] && [ "$current_branch" != "$expected_branch" ]; then
+        error "Must be on 'main' or '${expected_branch}' to release v${version}, but currently on '${current_branch}'."
+        exit 1
     fi
 
     # Ensure working tree is clean
@@ -256,12 +246,10 @@ do_tag() {
     fi
 
     # Create signed tag
-    confirm "Create signed tag v${version} at ${sha}?"
     run git tag -s "v${version}" "$sha" -m "Release v${version}"
     success "Tag v${version} created"
 
     # Push tag
-    confirm "Push tag v${version} to ${REMOTE}?"
     run git push "${REMOTE}" "v${version}"
     success "Tag pushed"
 
@@ -270,7 +258,6 @@ do_tag() {
         local release_branch="release-$(get_major_minor "$version")"
         info "New minor version detected. Creating release branch ${release_branch}..."
         run git branch "$release_branch" "$sha"
-        confirm "Push release branch ${release_branch} to ${REMOTE}?"
         run git push "${REMOTE}" "$release_branch"
         success "Release branch ${release_branch} pushed"
     fi
@@ -463,7 +450,6 @@ do_publish() {
 
     # Upload signatures to GitHub release
     info "Uploading signatures to GitHub release..."
-    confirm "Upload ${sig_count} .asc files to release v${version}?"
     if [[ "$DRY_RUN" == "true" ]]; then
         info "[DRY-RUN] Would upload ${sig_count} .asc files to release v${version}"
     else
@@ -488,7 +474,6 @@ do_publish() {
     fi
 
     # Publish release
-    confirm "Publish release v${version} (remove draft status)?"
     run gh release edit "v${version}" --repo "$REPO" --draft=false
     success "Release v${version} published!"
 
@@ -511,7 +496,6 @@ do_publish() {
     fi
 
     # Clean up
-    confirm "Remove _dist/ directory?"
     run rm -rf _dist
     success "Cleaned up _dist/"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -325,7 +325,7 @@ do_validate() {
         done
 
         if [ "$all_done" != "true" ]; then
-            ((attempt++))
+            attempt=$(( attempt + 1 ))
             if [ "$attempt" -lt "$max_attempts" ]; then
                 info "Waiting 30s for workflows... (attempt ${attempt}/${max_attempts})"
                 sleep 30
@@ -449,7 +449,7 @@ do_publish() {
         local orig="${asc%.asc}"
         if gpg --verify "$asc" "$orig" 2>/dev/null; then
             success "Verified: $(basename "$asc")"
-            ((sig_count++))
+            sig_count=$(( sig_count + 1 ))
         else
             error "Signature verification failed: $(basename "$asc")"
             exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,6 +83,11 @@ get_major_minor() {
     echo "$version" | cut -d. -f1-2
 }
 
+# Read version from VERSION_FILE
+version_from_file() {
+    sed -nE 's/.*Version = "([^"]+)".*/\1/p' "$VERSION_FILE"
+}
+
 ###############################################################################
 # Check prerequisites (gh, gpg, remote)
 ###############################################################################
@@ -531,8 +536,8 @@ Usage: scripts/release.sh [--dry-run] <phase> <version> [args...]
 Phases:
   prep <version>              Bump version, create PR, print vote template
   tag <version> <commit-sha>  Create and push signed tag
-  validate <version>          Wait for CI, download and verify artifacts
-  publish <version>           Sign, upload signatures, publish release
+  validate [version]          Wait for CI, download and verify artifacts (default: version from version.go)
+  publish [version]           Sign, upload signatures, publish release (default: version from version.go)
 
 Flags:
   --dry-run                   Print actions without executing them
@@ -543,8 +548,8 @@ Environment:
 Examples:
   scripts/release.sh prep 1.3.0
   scripts/release.sh tag 1.3.0 abc1234
-  scripts/release.sh validate 1.3.0
-  scripts/release.sh publish 1.3.0
+  scripts/release.sh validate
+  scripts/release.sh publish
   scripts/release.sh --dry-run prep 1.3.0-rc.1
 EOF
 }
@@ -576,11 +581,13 @@ main() {
             do_tag "$version" "${3:-}"
             ;;
         validate)
-            [ -z "$version" ] && { error "Usage: scripts/release.sh validate <version>"; exit 1; }
+            [ -z "$version" ] && version=$(version_from_file)
+            [ -z "$version" ] && { error "Usage: scripts/release.sh validate [version]"; exit 1; }
             do_validate "$version"
             ;;
         publish)
-            [ -z "$version" ] && { error "Usage: scripts/release.sh publish <version>"; exit 1; }
+            [ -z "$version" ] && version=$(version_from_file)
+            [ -z "$version" ] && { error "Usage: scripts/release.sh publish [version]"; exit 1; }
             do_publish "$version"
             ;;
         help|--help|-h)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,514 @@
+#!/usr/bin/env bash
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+REPO="oras-project/oras"
+REMOTE="${ORAS_REMOTE:-upstream}"
+DRY_RUN=false
+VERSION_FILE="internal/version/version.go"
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+info()    { echo -e "${CYAN}[INFO]${NC} $*"; }
+success() { echo -e "${GREEN}[OK]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+fatal()   { error "$@"; exit 1; }
+
+confirm() {
+    local msg="$1"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[dry-run] Would prompt: $msg"
+        return 0
+    fi
+    echo -en "${BOLD}$msg [y/N]${NC} "
+    read -r answer
+    [[ "$answer" =~ ^[Yy]$ ]] || { info "Aborted."; exit 0; }
+}
+
+run() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        info "[dry-run] $*"
+    else
+        "$@"
+    fi
+}
+
+# ── Validation ───────────────────────────────────────────────────────────────
+validate_semver() {
+    local version="$1"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+        fatal "Invalid semver: '$version'. Expected format: X.Y.Z or X.Y.Z-(alpha|beta|rc).N"
+    fi
+}
+
+check_prerequisites() {
+    info "Checking prerequisites..."
+
+    if ! command -v gh &>/dev/null; then
+        fatal "'gh' (GitHub CLI) is not installed. Install it from https://cli.github.com/"
+    fi
+
+    if ! gh auth status &>/dev/null; then
+        fatal "'gh' is not authenticated. Run 'gh auth login' first."
+    fi
+
+    if ! command -v gpg &>/dev/null; then
+        fatal "'gpg' is not installed. Install GnuPG first."
+    fi
+
+    if ! gpg --list-secret-keys --keyid-format=long 2>/dev/null | grep -q sec; then
+        fatal "No GPG secret keys found. Generate one with 'gpg --full-generate-key'."
+    fi
+
+    if ! git remote get-url "$REMOTE" &>/dev/null; then
+        fatal "Git remote '$REMOTE' not found. Set ORAS_REMOTE or add the remote."
+    fi
+
+    success "All prerequisites satisfied."
+}
+
+parse_version_parts() {
+    local version="$1"
+    local base="${version%%-*}"
+    MAJOR="${base%%.*}"
+    local rest="${base#*.}"
+    MINOR="${rest%%.*}"
+    PATCH="${rest#*.}"
+    PRERELEASE=""
+    if [[ "$version" == *-* ]]; then
+        PRERELEASE="${version#*-}"
+    fi
+}
+
+# ── Phase: prep ──────────────────────────────────────────────────────────────
+phase_prep() {
+    local version="$1"
+    validate_semver "$version"
+    check_prerequisites
+
+    parse_version_parts "$version"
+
+    # Determine base branch
+    local base_branch="main"
+    if [[ "$PATCH" -gt 0 ]]; then
+        base_branch="release-${MAJOR}.${MINOR}"
+        info "Patch release detected, targeting branch '$base_branch'."
+    fi
+
+    info "Preparing release v${version}..."
+
+    # Ensure we are up-to-date
+    info "Fetching latest from ${REMOTE}..."
+    run git fetch "$REMOTE"
+
+    # Create release branch
+    local branch="chore/release-v${version}"
+    info "Creating branch '${branch}' from '${REMOTE}/${base_branch}'..."
+    run git checkout -b "$branch" "${REMOTE}/${base_branch}"
+
+    # Update version file
+    info "Updating ${VERSION_FILE}..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        sed -i.bak -E "s/(Version = \").*(\")/\1${version}\2/" "$VERSION_FILE"
+        sed -i.bak -E "s/(BuildMetadata = \").*(\")/\1\2/" "$VERSION_FILE"
+        rm -f "${VERSION_FILE}.bak"
+    else
+        info "[dry-run] Would set Version = \"${version}\" and BuildMetadata = \"\""
+    fi
+
+    # Commit and push
+    info "Committing version bump..."
+    run git add "$VERSION_FILE"
+    run git commit -s -m "chore: bump version to ${version}"
+    info "Pushing branch '${branch}' to origin..."
+    run git push origin "$branch"
+
+    # Create PR
+    local pr_title="bump: tag and release ORAS CLI v${version}"
+    info "Creating pull request..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        gh pr create \
+            --repo "$REPO" \
+            --title "$pr_title" \
+            --base "$base_branch" \
+            --body "$(cat <<EOF
+## Release ORAS CLI v${version}
+
+This PR bumps the version to **${version}** and clears the build metadata in preparation for the release.
+
+### Changes
+- Set \`Version\` to \`${version}\`
+- Set \`BuildMetadata\` to \`""\`
+
+### Release Checklist
+- [ ] Version bump reviewed
+- [ ] CI passing
+- [ ] Maintainer approval received
+EOF
+)"
+    else
+        info "[dry-run] Would create PR: '$pr_title' targeting '$base_branch'"
+    fi
+
+    # Print commit SHA
+    local sha
+    sha=$(git rev-parse HEAD)
+    success "Version bump committed."
+    echo ""
+    echo -e "${BOLD}Commit SHA:${NC} ${sha}"
+    echo ""
+
+    # Slack vote template
+    echo -e "${BOLD}Slack Vote Template:${NC}"
+    echo "────────────────────────────────────────"
+    cat <<EOF
+:oras: *ORAS CLI v${version} Release Vote*
+
+Hi team, I'd like to propose the release of ORAS CLI v${version}.
+
+*Release PR:* (paste PR URL here)
+*Commit SHA:* \`${sha}\`
+
+Please vote:
+:+1: Approve
+:-1: Object (please provide reason)
+
+Vote closes in 48 hours. Requires at least 2 approvals from maintainers.
+EOF
+    echo "────────────────────────────────────────"
+}
+
+# ── Phase: tag ───────────────────────────────────────────────────────────────
+phase_tag() {
+    local version="$1"
+    local sha="$2"
+    validate_semver "$version"
+
+    info "Tagging release v${version} at ${sha}..."
+
+    # Validate the commit has the correct version
+    info "Validating version at commit ${sha}..."
+    local committed_version
+    committed_version=$(git show "${sha}:${VERSION_FILE}" | grep 'Version = ' | sed -E 's/.*"(.*)".*/\1/')
+    if [[ "$committed_version" != "$version" ]]; then
+        fatal "Version mismatch: commit has '${committed_version}', expected '${version}'."
+    fi
+
+    local committed_metadata
+    committed_metadata=$(git show "${sha}:${VERSION_FILE}" | grep 'BuildMetadata = ' | sed -E 's/.*"(.*)".*/\1/')
+    if [[ -n "$committed_metadata" ]]; then
+        fatal "BuildMetadata is not empty at ${sha}: '${committed_metadata}'. Expected empty string."
+    fi
+
+    success "Version validated: ${version} (BuildMetadata is clear)."
+
+    # Create signed tag
+    confirm "Create signed tag v${version} at ${sha}?"
+    info "Creating signed tag v${version}..."
+    run git tag -s "v${version}" "$sha" -m "Release v${version}"
+    info "Pushing tag v${version} to ${REMOTE}..."
+    run git push "$REMOTE" "v${version}"
+
+    success "Tag v${version} pushed to ${REMOTE}."
+
+    # Create release branch for new minor versions (patch==0, no pre-release)
+    parse_version_parts "$version"
+    if [[ "$PATCH" -eq 0 && -z "$PRERELEASE" ]]; then
+        local release_branch="release-${MAJOR}.${MINOR}"
+        info "New minor release detected. Creating release branch '${release_branch}'..."
+        confirm "Create and push release branch '${release_branch}'?"
+        run git branch "$release_branch" "$sha"
+        run git push "$REMOTE" "$release_branch"
+        success "Release branch '${release_branch}' created and pushed."
+    fi
+}
+
+# ── Phase: validate ──────────────────────────────────────────────────────────
+phase_validate() {
+    local version="$1"
+    validate_semver "$version"
+
+    info "Validating release v${version}..."
+
+    # Poll GitHub Actions workflows
+    local workflows=("release-ghcr" "release-github")
+    for wf in "${workflows[@]}"; do
+        info "Polling workflow '${wf}' for tag v${version}..."
+        if [[ "$DRY_RUN" == "true" ]]; then
+            info "[dry-run] Would poll workflow '${wf}' until completion."
+            continue
+        fi
+
+        local max_attempts=60
+        local attempt=0
+        while [[ $attempt -lt $max_attempts ]]; do
+            local status
+            status=$(gh run list \
+                --repo "$REPO" \
+                --workflow "${wf}.yml" \
+                --branch "v${version}" \
+                --limit 1 \
+                --json status,conclusion \
+                --jq '.[0] | "\(.status) \(.conclusion)"' 2>/dev/null || echo "not_found")
+
+            if [[ "$status" == "not_found" || "$status" == " " ]]; then
+                info "Workflow '${wf}' not found yet, waiting..."
+            elif [[ "$status" == "completed success" ]]; then
+                success "Workflow '${wf}' completed successfully."
+                break
+            elif [[ "$status" == completed* ]]; then
+                fatal "Workflow '${wf}' failed: ${status}"
+            else
+                info "Workflow '${wf}' status: ${status}. Waiting..."
+            fi
+
+            attempt=$((attempt + 1))
+            sleep 30
+        done
+
+        if [[ $attempt -ge $max_attempts ]]; then
+            fatal "Timed out waiting for workflow '${wf}' to complete."
+        fi
+    done
+
+    # Fetch distribution artifacts
+    info "Fetching distribution artifacts..."
+    run make fetch-dist VERSION="$version"
+
+    # Verify checksums
+    info "Verifying checksums..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        cd _dist
+        if ! shasum -a 256 -c "oras_${version}_checksums.txt" --ignore-missing; then
+            fatal "Checksum verification failed!"
+        fi
+        success "Checksums verified."
+        cd ..
+    fi
+
+    # Test linux/amd64 binary
+    info "Testing linux/amd64 binary version..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        local tarball="_dist/oras_${version}_linux_amd64.tar.gz"
+        if [[ ! -f "$tarball" ]]; then
+            fatal "Binary archive not found: ${tarball}"
+        fi
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        tar -xzf "$tarball" -C "$tmpdir"
+        local binary_version
+        binary_version=$("${tmpdir}/oras" version 2>/dev/null | grep 'Version:' | awk '{print $2}' || echo "unknown")
+        rm -rf "$tmpdir"
+
+        if [[ "$binary_version" != "$version" ]]; then
+            fatal "Binary version mismatch: got '${binary_version}', expected '${version}'."
+        fi
+        success "Binary version verified: ${binary_version}"
+    fi
+
+    success "Release v${version} validation complete."
+}
+
+# ── Phase: publish ───────────────────────────────────────────────────────────
+phase_publish() {
+    local version="$1"
+    validate_semver "$version"
+
+    info "Publishing release v${version}..."
+
+    # Sign artifacts
+    info "Signing artifacts..."
+    run make sign
+
+    # Verify GPG signatures
+    info "Verifying GPG signatures..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        local failed=false
+        for sig in _dist/*.asc; do
+            local original="${sig%.asc}"
+            if ! gpg --verify "$sig" "$original" 2>/dev/null; then
+                error "GPG verification failed for: ${original}"
+                failed=true
+            fi
+        done
+        if [[ "$failed" == "true" ]]; then
+            fatal "One or more GPG signature verifications failed."
+        fi
+        success "All GPG signatures verified."
+    fi
+
+    # Upload .asc files to GitHub release
+    info "Uploading signature files to GitHub release..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        for sig in _dist/*.asc; do
+            info "Uploading $(basename "$sig")..."
+            gh release upload "v${version}" "$sig" --repo "$REPO" --clobber
+        done
+        success "Signature files uploaded."
+    fi
+
+    # Add signing key info to release notes
+    info "Adding signing key information to release notes..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        local gpg_key_id
+        gpg_key_id=$(gpg --list-secret-keys --keyid-format=long 2>/dev/null \
+            | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
+
+        local existing_notes
+        existing_notes=$(gh release view "v${version}" --repo "$REPO" --json body --jq '.body')
+
+        local signing_note
+        signing_note="$(cat <<EOF
+
+---
+
+## Verification
+
+The release artifacts are signed with GPG key \`${gpg_key_id}\`.
+
+To verify a downloaded artifact:
+\`\`\`bash
+# Import the signing key (if not already imported)
+gpg --keyserver keyserver.ubuntu.com --recv-keys ${gpg_key_id}
+
+# Verify the signature
+gpg --verify oras_${version}_linux_amd64.tar.gz.asc oras_${version}_linux_amd64.tar.gz
+\`\`\`
+EOF
+)"
+        gh release edit "v${version}" --repo "$REPO" \
+            --notes "${existing_notes}${signing_note}"
+        success "Release notes updated with signing key info."
+    fi
+
+    # Publish release (remove draft status)
+    confirm "Publish release v${version} (remove draft status)?"
+    info "Publishing release..."
+    run gh release edit "v${version}" --repo "$REPO" --draft=false
+
+    # Trigger snap workflow
+    info "Triggering snap workflow..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        gh workflow run snap.yml --repo "$REPO" --ref "v${version}" 2>/dev/null || \
+            warn "Could not trigger snap workflow. You may need to trigger it manually."
+    fi
+
+    # Clean up
+    info "Cleaning up _dist/ directory..."
+    run rm -rf _dist/
+
+    success "Release v${version} published successfully!"
+    echo ""
+    echo -e "${BOLD}Post-release Slack Template:${NC}"
+    echo "────────────────────────────────────────"
+    cat <<EOF
+:tada: *ORAS CLI v${version} has been released!*
+
+*Release page:* https://github.com/${REPO}/releases/tag/v${version}
+*GHCR:* \`ghcr.io/oras-project/oras:v${version}\`
+
+Thanks to all contributors! :heart:
+EOF
+    echo "────────────────────────────────────────"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--dry-run] <phase> <version> [sha]
+
+Phases:
+  prep <version>        Prepare a release: bump version, create PR
+  tag <version> <sha>   Tag a release: create and push signed tag
+  validate <version>    Validate a release: verify CI, artifacts, checksums
+  publish <version>     Publish a release: sign, upload, publish
+
+Options:
+  --dry-run    Print commands without executing them
+
+Environment:
+  ORAS_REMOTE  Git remote for upstream (default: upstream)
+
+Examples:
+  $(basename "$0") prep 1.3.0
+  $(basename "$0") tag 1.3.0 abc1234
+  $(basename "$0") validate 1.3.0
+  $(basename "$0") publish 1.3.0
+  $(basename "$0") --dry-run prep 1.3.0-rc.1
+EOF
+}
+
+main() {
+    # Parse global flags
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)
+                DRY_RUN=true
+                info "Dry-run mode enabled."
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    if [[ $# -lt 1 ]]; then
+        usage
+        exit 1
+    fi
+
+    local phase="$1"
+    shift
+
+    case "$phase" in
+        prep)
+            [[ $# -ge 1 ]] || { error "Usage: $0 prep <version>"; exit 1; }
+            phase_prep "$1"
+            ;;
+        tag)
+            [[ $# -ge 2 ]] || { error "Usage: $0 tag <version> <sha>"; exit 1; }
+            phase_tag "$1" "$2"
+            ;;
+        validate)
+            [[ $# -ge 1 ]] || { error "Usage: $0 validate <version>"; exit 1; }
+            phase_validate "$1"
+            ;;
+        publish)
+            [[ $# -ge 1 ]] || { error "Usage: $0 publish <version>"; exit 1; }
+            phase_publish "$1"
+            ;;
+        *)
+            error "Unknown phase: '${phase}'"
+            usage
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -339,9 +339,14 @@ do_validate() {
     fi
     success "All CI workflows completed"
 
-    # Fetch distribution artifacts
+    # Fetch distribution artifacts via gh to support draft releases
     info "Fetching distribution artifacts..."
-    run make fetch-dist VERSION="$version"
+    run mkdir -p _dist
+    run gh release download "v${version}" \
+        --repo "$REPO" \
+        --dir _dist/ \
+        --pattern "oras_${version}_*" \
+        --clobber
     success "Artifacts downloaded to _dist/"
 
     # Verify checksums

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -525,7 +525,6 @@ do_publish() {
 We're excited to announce the release of ORAS CLI v${version}!
 
 *Release:* https://github.com/${REPO}/releases/tag/v${version}
-*Changelog:* https://github.com/${REPO}/releases/tag/v${version}
 
 Thank you to all contributors!
 EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,7 +23,7 @@ VERSION_FILE="internal/version/version.go"
 # Resolved lazily by detect_remote() once we're inside the repo. Do not assume
 # any particular remote name (e.g. "upstream") here.
 REMOTE=""
-MAIN_RELEASE_VERSION="${ORAS_MAIN_RELEASE_VERSION:-2.0}"
+MAIN_RELEASE_VERSION="${ORAS_MAIN_RELEASE_VERSION:-3.0}"
 
 # Colors
 RED='\033[0;31m'

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,17 +38,20 @@ warn()    { echo -e "${YELLOW}[MANUAL]${NC} $*"; }
 error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 DRY_RUN=false
+POSITIONAL_ARGS=()
 
-# Parse global flags
+# Parse global flags, leaving non-flag arguments in the POSITIONAL_ARGS global.
+# This sets DRY_RUN in the current shell, so it MUST be called directly and not
+# in a command substitution / subshell, or the assignment would be lost (which
+# previously caused --dry-run to be silently ignored).
 parse_global_flags() {
-    local args=()
+    POSITIONAL_ARGS=()
     for arg in "$@"; do
         case "$arg" in
             --dry-run) DRY_RUN=true ;;
-            *) args+=("$arg") ;;
+            *) POSITIONAL_ARGS+=("$arg") ;;
         esac
     done
-    echo "${args[@]:-}"
 }
 
 run() {
@@ -230,7 +233,7 @@ EOF
 
     # Print Slack vote template
     echo ""
-    warn "Copy the following message to Slack #oras to call for a vote:"
+    warn "Copy the following message to the Slack #oras-maintainers channel to call for a vote:"
     echo ""
     echo -e "${CYAN}---${NC}"
     cat <<EOF
@@ -594,10 +597,8 @@ EOF
 }
 
 main() {
-    local args
-    args=$(parse_global_flags "$@")
-    # Re-split args
-    set -- $args
+    parse_global_flags "$@"
+    set -- ${POSITIONAL_ARGS[@]+"${POSITIONAL_ARGS[@]}"}
 
     local phase="${1:-}"
     local version="${2:-}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,7 +20,9 @@ set -euo pipefail
 
 REPO="oras-project/oras"
 VERSION_FILE="internal/version/version.go"
-REMOTE="${ORAS_REMOTE:-upstream}"
+# Resolved lazily by detect_remote() once we're inside the repo. Do not assume
+# any particular remote name (e.g. "upstream") here.
+REMOTE=""
 MAIN_RELEASE_VERSION="${ORAS_MAIN_RELEASE_VERSION:-2.0}"
 
 # Colors
@@ -89,6 +91,31 @@ version_from_file() {
     sed -nE 's/.*Version = "([^"]+)".*/\1/p' "$VERSION_FILE"
 }
 
+# Detect the git remote that points at the canonical ORAS repo ($REPO).
+# Honors ORAS_REMOTE when set; otherwise it matches each remote's URL against
+# $REPO so it works no matter what the remote is named (upstream, origin, ...).
+# Matches both SSH (git@github.com:oras-project/oras.git) and HTTPS forms, with
+# or without a trailing ".git".
+detect_remote() {
+    if [ -n "${ORAS_REMOTE:-}" ]; then
+        if ! git remote get-url "$ORAS_REMOTE" &>/dev/null; then
+            error "ORAS_REMOTE is set to '${ORAS_REMOTE}', but no such git remote exists."
+            return 1
+        fi
+        echo "$ORAS_REMOTE"
+        return 0
+    fi
+    local remote url
+    while read -r remote; do
+        url=$(git remote get-url "$remote" 2>/dev/null || echo "")
+        if [[ "$url" == *"${REPO}.git" || "$url" == *"${REPO}" ]]; then
+            echo "$remote"
+            return 0
+        fi
+    done < <(git remote)
+    return 1
+}
+
 ###############################################################################
 # Check prerequisites (gh, gpg, remote)
 ###############################################################################
@@ -110,10 +137,11 @@ check_prerequisites() {
         error "No GPG secret keys found. Import or generate a key."
         exit 1
     fi
-    if ! git remote get-url "$REMOTE" &>/dev/null; then
-        error "Git remote '${REMOTE}' not found. Set ORAS_REMOTE or add the remote."
+    if ! REMOTE=$(detect_remote); then
+        error "Could not find a git remote pointing at ${REPO}. Add it (e.g. 'git remote add upstream https://github.com/${REPO}.git') or set ORAS_REMOTE to the correct remote name."
         exit 1
     fi
+    info "Using git remote '${REMOTE}' for ${REPO}"
 }
 
 ###############################################################################
@@ -158,8 +186,10 @@ do_prep() {
     # Show the diff
     git diff "$VERSION_FILE"
 
-    # Create branch, commit, push, PR
+    # Create branch, commit, push, PR. The PR targets the branch we are
+    # releasing from: 'main' for the main series, or 'release-X.Y' for patches.
     local branch="chore/release-v${version}"
+    local base_branch="$current_branch"
     info "Creating branch ${branch}..."
     run git checkout -b "$branch"
     run git add "$VERSION_FILE"
@@ -183,12 +213,12 @@ This PR bumps the version to v${version} for the upcoming release.
 ### Checklist
 - [ ] Version updated in \`internal/version/version.go\`
 - [ ] CI checks pass
-- [ ] Vote called in Slack
-- [ ] Vote passed (3+ binding votes, no vetoes)
+- [ ] Vote called in the ORAS Slack channel
+- [ ] Super-majority of approval from ORAS maintainers
 EOF
 )" \
             --head "$branch" \
-            --base main)
+            --base "$base_branch")
     fi
     success "PR created: ${pr_url}"
 
@@ -212,11 +242,10 @@ Hi everyone, I'd like to call a vote for the release of ORAS CLI v${version}.
 *Release commit:* \`${sha}\`
 
 Please review the PR and vote:
-  :+1: (binding) — approve
-  :-1: (binding) — veto (please provide reason)
+  :+1: — approve
+  :-1: — request changes (please provide a reason)
 
-The vote will remain open for at least 72 hours.
-A minimum of 3 binding +1 votes and no vetoes is required.
+A super-majority of approval from ORAS maintainers is required before the PR can be merged.
 EOF
     echo -e "${CYAN}---${NC}"
     echo ""
@@ -548,7 +577,9 @@ Flags:
   --dry-run                   Print actions without executing them
 
 Environment:
-  ORAS_REMOTE                 Git remote name (default: upstream)
+  ORAS_REMOTE                 Git remote name for ${REPO}
+                              (default: auto-detected from remote URLs)
+  ORAS_MAIN_RELEASE_VERSION   Major.minor series released from 'main' (default: ${MAIN_RELEASE_VERSION})
 
 Examples:
   scripts/release.sh prep 1.3.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -497,12 +497,15 @@ do_publish() {
     fi
     success "Signatures uploaded"
 
-    # Get GPG key fingerprint for release notes
-    local fingerprint
-    fingerprint=$(gpg --list-secret-keys --keyid-format LONG 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d/ -f2)
+    # Get GPG fingerprint and signer handle for release notes
+    local fingerprint signer
+    fingerprint=$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '/^fpr:/ {print $10; exit}')
+    signer=$(gh api user --jq '.login' 2>/dev/null || echo "")
     if [ -n "$fingerprint" ]; then
         info "Adding signing key info to release notes..."
-        local note="## Verification\n\nAll release artifacts are signed with GPG key \`${fingerprint}\`. Signatures (\`.asc\` files) are attached to this release.\n\nPublic keys are available in the [KEYS](https://github.com/${REPO}/blob/main/KEYS) file."
+        local signed_by="."
+        [ -n "$signer" ] && signed_by=" by [@${signer}](https://github.com/${signer}) (key: https://github.com/${signer}.gpg)."
+        local note="## Verification\n\nThis release was signed with GPG key \`${fingerprint}\`${signed_by} Signatures (\`.asc\` files) are attached to this release.\n\nPublic keys are available in the [KEYS](https://github.com/${REPO}/blob/main/KEYS) file."
         if [ "$DRY_RUN" = true ]; then
             info "[DRY-RUN] Would append signing info to release notes"
         else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -196,7 +196,7 @@ do_prep() {
     info "Creating branch ${branch}..."
     run git checkout -b "$branch"
     run git add "$VERSION_FILE"
-    run git commit -m "bump: tag and release ORAS CLI v${version}"
+    run git commit -s -m "bump: tag and release ORAS CLI v${version}"
     run git push "${REMOTE}" "$branch"
 
     info "Creating pull request..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,7 +23,9 @@ VERSION_FILE="internal/version/version.go"
 # Resolved lazily by detect_remote() once we're inside the repo. Do not assume
 # any particular remote name (e.g. "upstream") here.
 REMOTE=""
-MAIN_RELEASE_VERSION="${ORAS_MAIN_RELEASE_VERSION:-3.0}"
+# Fingerprint of the ORAS project release key. Artifacts are signed with it in
+# CI by release-github.yml; see the "signs" block in .goreleaser.yml.
+RELEASE_SIGNING_KEY="C6FC42F0DE84A345FAADB742F44418110791EF37"
 
 # Colors
 RED='\033[0;31m'
@@ -89,6 +91,18 @@ get_major_minor() {
     echo "$version" | cut -d. -f1-2
 }
 
+# Major.minor series currently released from 'main'. Honors
+# ORAS_MAIN_RELEASE_VERSION when set; otherwise it is derived from the version
+# already recorded in VERSION_FILE on the current branch, so it tracks the
+# branch instead of needing a hardcoded edit every time the series moves.
+main_release_version() {
+    if [ -n "${ORAS_MAIN_RELEASE_VERSION:-}" ]; then
+        echo "$ORAS_MAIN_RELEASE_VERSION"
+        return 0
+    fi
+    get_major_minor "$(version_from_file)"
+}
+
 # Read version from VERSION_FILE
 version_from_file() {
     sed -nE 's/.*Version = "([^"]+)".*/\1/p' "$VERSION_FILE"
@@ -132,19 +146,44 @@ check_prerequisites() {
         error "'gh' CLI not authenticated. Run: gh auth login"
         exit 1
     fi
-    if ! command -v gpg &>/dev/null; then
-        error "'gpg' not found. Install GPG."
-        exit 1
-    fi
-    if ! gpg --list-secret-keys --keyid-format LONG 2>/dev/null | grep -q sec; then
-        error "No GPG secret keys found. Import or generate a key."
-        exit 1
-    fi
     if ! REMOTE=$(detect_remote); then
         error "Could not find a git remote pointing at ${REPO}. Add it (e.g. 'git remote add upstream https://github.com/${REPO}.git') or set ORAS_REMOTE to the correct remote name."
         exit 1
     fi
     info "Using git remote '${REMOTE}' for ${REPO}"
+}
+
+# Check that git can sign the commits and tags this script creates.
+# 'git tag -s' honors gpg.format, which may be openpgp (the default), ssh or
+# x509. Testing only for a GPG secret key both rejects maintainers who sign
+# with SSH and passes maintainers whose GPG key git will never reach for.
+check_signing() {
+    local format
+    format=$(git config --get gpg.format || echo "openpgp")
+    case "$format" in
+        ssh)
+            if [ -z "$(git config --get user.signingkey || echo "")" ] &&
+               [ -z "$(git config --get gpg.ssh.defaultKeyCommand || echo "")" ]; then
+                error "gpg.format is 'ssh' but neither user.signingkey nor gpg.ssh.defaultKeyCommand is set."
+                exit 1
+            fi
+            info "Signing tags and commits with SSH key"
+            ;;
+        openpgp|"")
+            if ! command -v gpg &>/dev/null; then
+                error "'gpg' not found. Install GPG, or configure SSH signing (git config gpg.format ssh)."
+                exit 1
+            fi
+            if ! gpg --list-secret-keys --keyid-format LONG 2>/dev/null | grep -q sec; then
+                error "No GPG secret keys found. Import or generate a key."
+                exit 1
+            fi
+            info "Signing tags and commits with GPG key"
+            ;;
+        *)
+            info "Tag signing format is '${format}'; skipping signing key check"
+            ;;
+    esac
 }
 
 ###############################################################################
@@ -156,6 +195,7 @@ do_prep() {
     info "Preparing release v${version}"
 
     check_prerequisites
+    check_signing
     success "Prerequisites OK"
 
     # Verify we're on main or the correct release branch
@@ -164,8 +204,13 @@ do_prep() {
     major_minor=$(get_major_minor "$version")
     expected_branch="release-${major_minor}"
     if [ "$current_branch" = "main" ]; then
-        if [ "$major_minor" != "$MAIN_RELEASE_VERSION" ]; then
-            error "Releases from 'main' must be v${MAIN_RELEASE_VERSION}.x, but version is v${version}. Use branch '${expected_branch}' for this release, or set ORAS_MAIN_RELEASE_VERSION if the next main-branch series has changed."
+        # 'main' carries the current series, and it is also where the next
+        # minor is cut from, so allow both. Older patch releases belong on
+        # their own release branch.
+        local main_series
+        main_series=$(main_release_version)
+        if [ "$major_minor" != "$main_series" ] && ! is_new_minor "$version"; then
+            error "'main' is on the v${main_series} series, so it cannot cut patch release v${version}. Use branch '${expected_branch}', or set ORAS_MAIN_RELEASE_VERSION to override the detected series."
             exit 1
         fi
     elif [ "$current_branch" != "$expected_branch" ]; then
@@ -179,15 +224,21 @@ do_prep() {
         exit 1
     fi
 
-    # Update version file
+    # Update version file. These edits are guarded explicitly rather than via
+    # run(), which cannot wrap a redirect-free in-place sed, so that --dry-run
+    # leaves the working tree untouched.
     info "Updating ${VERSION_FILE}..."
-    sed -i.bak -E "s/Version = \"[^\"]+\"/Version = \"${version}\"/" "$VERSION_FILE"
-    sed -i.bak -E "s/BuildMetadata = \"[^\"]*\"/BuildMetadata = \"\"/" "$VERSION_FILE"
-    rm -f "${VERSION_FILE}.bak"
-    success "Version set to ${version}"
+    if [ "$DRY_RUN" = true ]; then
+        info "[DRY-RUN] Would set Version to ${version} and clear BuildMetadata in ${VERSION_FILE}"
+    else
+        sed -i.bak -E "s/Version = \"[^\"]+\"/Version = \"${version}\"/" "$VERSION_FILE"
+        sed -i.bak -E "s/BuildMetadata = \"[^\"]*\"/BuildMetadata = \"\"/" "$VERSION_FILE"
+        rm -f "${VERSION_FILE}.bak"
+        success "Version set to ${version}"
 
-    # Show the diff
-    git diff "$VERSION_FILE"
+        # Show the diff
+        git diff "$VERSION_FILE"
+    fi
 
     # Create branch, commit, push, PR. The PR targets the branch we are
     # releasing from: 'main' for the main series, or 'release-X.Y' for patches.
@@ -272,6 +323,7 @@ do_tag() {
     info "Tagging v${version} at ${sha}"
 
     check_prerequisites
+    check_signing
     success "Prerequisites OK"
 
     # Verify the commit exists and is on main
@@ -439,7 +491,7 @@ do_validate() {
 }
 
 ###############################################################################
-# Phase 4: Sign & Publish
+# Phase 4: Verify & Publish
 ###############################################################################
 do_publish() {
     local version="$1"
@@ -452,71 +504,58 @@ do_publish() {
         exit 1
     fi
 
-    # Sign artifacts
-    info "Signing artifacts with GPG..."
-    local sign_failed=false
-    for f in _dist/oras_"${version}"_*; do
-        [[ "$f" == *.asc ]] && continue
-        [ -f "$f" ] || continue
-        if run gpg --armor --detach-sign "$f"; then
-            success "Signed: $(basename "$f")"
-        else
-            error "Failed to sign: $(basename "$f")"
-            sign_failed=true
+    # Artifacts are signed in CI with the ORAS project release key (see the
+    # "signs" block in .goreleaser.yml), and the .asc files ship with the
+    # release, so 'validate' already downloaded them. Verify them here rather
+    # than signing again: a local signature would be made with whichever key
+    # gpg defaults to and would replace the project key's signatures on the
+    # release.
+    if ! gpg --list-keys "$RELEASE_SIGNING_KEY" &>/dev/null; then
+        info "Release signing key not in keyring, importing from KEYS..."
+        gpg --import KEYS &>/dev/null || true
+        if ! gpg --list-keys "$RELEASE_SIGNING_KEY" &>/dev/null; then
+            error "Release signing key ${RELEASE_SIGNING_KEY} is not in your keyring and could not be imported from KEYS."
+            exit 1
         fi
-    done
-    if [ "$sign_failed" = true ]; then
-        error "One or more artifacts failed to sign. Ensure your GPG key is unlocked and retry."
-        exit 1
     fi
-    success "All artifacts signed"
 
-    # Verify signatures
-    info "Verifying GPG signatures..."
+    info "Verifying release signatures against ${RELEASE_SIGNING_KEY}..."
     local sig_count=0
     for asc in _dist/oras_"${version}"_*.asc; do
         [ -f "$asc" ] || continue
         local orig="${asc%.asc}"
-        if gpg --verify "$asc" "$orig" 2>/dev/null; then
-            success "Verified: $(basename "$asc")"
+        if [ ! -f "$orig" ]; then
+            error "Signature $(basename "$asc") has no matching artifact in _dist/"
+            exit 1
+        fi
+        if gpg --verify --status-fd=1 "$asc" "$orig" 2>/dev/null | grep -q "VALIDSIG .*${RELEASE_SIGNING_KEY}"; then
+            success "Verified: $(basename "$orig")"
             sig_count=$(( sig_count + 1 ))
         else
-            error "Signature verification failed: $(basename "$asc")"
+            error "Signature verification failed for $(basename "$orig"); expected a signature by ${RELEASE_SIGNING_KEY}"
             exit 1
         fi
     done
     if [ "$sig_count" -eq 0 ]; then
-        error "No .asc signature files found in _dist/"
+        error "No .asc signature files found in _dist/. Check that release-github.yml signed the artifacts."
         exit 1
     fi
     success "All ${sig_count} signatures verified"
 
-    # Upload signatures to GitHub release
-    info "Uploading signatures to GitHub release..."
-    if [[ "$DRY_RUN" == "true" ]]; then
-        info "[DRY-RUN] Would upload ${sig_count} .asc files to release v${version}"
+    # Record the signing key in the release notes
+    local existing_notes
+    if [ "$DRY_RUN" = true ]; then
+        info "[DRY-RUN] Would append signing info to release notes"
     else
-        gh release upload "v${version}" _dist/oras_"${version}"_*.asc --repo "$REPO" --clobber
-    fi
-    success "Signatures uploaded"
-
-    # Get GPG fingerprint and signer handle for release notes
-    local fingerprint signer
-    fingerprint=$(gpg --list-secret-keys --with-colons 2>/dev/null | awk -F: '/^fpr:/ {print $10; exit}')
-    signer=$(gh api user --jq '.login' 2>/dev/null || echo "")
-    if [ -n "$fingerprint" ]; then
-        info "Adding signing key info to release notes..."
-        local signed_by="."
-        [ -n "$signer" ] && signed_by=" by [@${signer}](https://github.com/${signer}) (key: https://github.com/${signer}.gpg)."
-        local note="## Verification\n\nThis release was signed with GPG key \`${fingerprint}\`${signed_by} Signatures (\`.asc\` files) are attached to this release.\n\nPublic keys are available in the [KEYS](https://github.com/${REPO}/blob/main/KEYS) file."
-        if [ "$DRY_RUN" = true ]; then
-            info "[DRY-RUN] Would append signing info to release notes"
+        existing_notes=$(gh release view "v${version}" --repo "$REPO" --json body --jq '.body')
+        if [[ "$existing_notes" == *"## Verification"* ]]; then
+            info "Release notes already carry a Verification section, leaving them as they are"
         else
-            local existing_notes
-            existing_notes=$(gh release view "v${version}" --repo "$REPO" --json body --jq '.body')
+            info "Adding signing key info to release notes..."
+            local note="## Verification\n\nRelease artifacts are signed with the ORAS project release key \`${RELEASE_SIGNING_KEY}\`. Signatures (\`.asc\` files) are attached to this release.\n\nPublic keys are available in the [KEYS](https://github.com/${REPO}/blob/main/KEYS) file."
             gh release edit "v${version}" --repo "$REPO" --notes "$(printf '%s\n\n%b' "$existing_notes" "$note")"
+            success "Release notes updated with signing key info"
         fi
-        success "Release notes updated with signing key info"
     fi
 
     # Publish release
@@ -577,7 +616,7 @@ Phases:
   prep <version>              Bump version, create PR, print vote template
   tag <version> <commit-sha>  Create and push signed tag
   validate [version]          Wait for CI, download and verify artifacts (default: version from version.go)
-  publish [version]           Sign, upload signatures, publish release (default: version from version.go)
+  publish [version]           Verify signatures, publish release (default: version from version.go)
 
 Flags:
   --dry-run                   Print actions without executing them
@@ -585,7 +624,8 @@ Flags:
 Environment:
   ORAS_REMOTE                 Git remote name for ${REPO}
                               (default: auto-detected from remote URLs)
-  ORAS_MAIN_RELEASE_VERSION   Major.minor series released from 'main' (default: ${MAIN_RELEASE_VERSION})
+  ORAS_MAIN_RELEASE_VERSION   Major.minor series released from 'main'
+                              (default: derived from ${VERSION_FILE})
 
 Examples:
   scripts/release.sh prep 1.3.0


### PR DESCRIPTION
## Summary

Adds `scripts/release.sh`, a bash release automation script that codifies the manual steps from https://oras.land/community/release-process into four repeatable phases.

## Phases

- **`prep <version>`** - Validates semver format, checks `gh`/signing prerequisites, updates `internal/version/version.go` (sets Version, clears BuildMetadata), creates branch `chore/release-v<version>`, commits with sign-off, pushes, creates a PR titled "bump: tag and release ORAS CLI v\<version>" targeting `main` (or the release branch for patches), and prints the commit SHA with a Slack vote template.

- **`tag <version> <sha>`** - Validates that the commit at the given SHA contains the correct version and cleared BuildMetadata, creates a signed git tag `v<version>`, pushes the tag, and creates a release branch (e.g. `release-X.Y`) for new minor versions (patch==0, no pre-release suffix).

- **`validate [version]`** - Polls the `release-ghcr` and `release-github` GitHub Actions workflows until they complete, downloads artifacts with `gh release download` (works against the draft release), verifies checksums with `sha256sum`/`shasum`, and tests that the binary for the *current* OS/arch reports the expected version and git commit.

- **`publish [version]`** - Verifies the artifact signatures, appends a Verification section to the release notes, publishes the release (`--draft=false`), triggers the snap workflow, cleans up `_dist/`, and prints a post-release Slack template.

`validate` and `publish` infer the version from `internal/version/version.go` when it is not given explicitly.

## Signing

Artifacts are signed **in CI**, not locally. The `signs` block in `.goreleaser.yml` signs every artifact with the ORAS project release key (`C6FC42F0DE84A345FAADB742F44418110791EF37`) during `release-github.yml`, and the `.asc` files ship with the release.

`publish` therefore *verifies* those signatures against the project key rather than creating new ones — signing locally would use whichever key `gpg` defaults to and would replace the project key's signatures on the release. This also drops the now-orphaned `sign` Makefile target, which had exactly that failure mode and was referenced by nothing.

## Features

- `--dry-run` flag for safe testing
- Upstream remote auto-detected from remote URLs; overridable with `ORAS_REMOTE`
- `ORAS_MAIN_RELEASE_VERSION` to override the major.minor series released from `main`
- `ORAS_REPO` Makefile variable for `fetch-dist`
- Color-coded output, with manual follow-up steps called out as `[MANUAL]`
- Slack templates for the release vote and the announcement

## Makefile Targets

Adds `release-prep`, `release-tag`, `release-validate`, `release-publish`. Switches `fetch-dist` to `gh release download` (the previous `curl` loop could not see draft releases) and removes the orphaned `sign` target.

## Test plan

- [x] Run `scripts/release.sh --help` to verify usage output
- [x] Run `scripts/release.sh --dry-run prep 1.3.0` to verify prep phase logic
- [x] Run `scripts/release.sh --dry-run tag 1.3.0 abc1234` to verify tag phase logic
- [x] Run `scripts/release.sh --dry-run validate 1.3.0` to verify validate phase logic
- [x] Run `scripts/release.sh --dry-run publish 1.3.0` to verify publish phase logic
- [x] Verify `make help` shows the new release targets

## Note on further automation

This script automates the *local* runbook; a maintainer still drives each phase. Moving to the model `oras-go` uses — merging a `release/vX.Y.Z` PR triggers a workflow that tags, releases and publishes with no laptop involved — additionally requires a bypass actor on the repository's tag-creation ruleset so CI can push tags, and dropping `draft: true` from `.goreleaser.yml`. Out of scope here.

https://claude.ai/code/session_01Fxbefi17MX51RbvRLerggB
