### PR TITLE
feat: add --config flag support for oras attach

### DIFF
--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -193,7 +193,6 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 
 	packOpts := oras.PackManifestOptions{
 		Subject:             &subject,
-		ConfigAnnotations:   opts.Annotations[option.AnnotationConfig],
 		ManifestAnnotations: opts.Annotations[option.AnnotationManifest],
 		Layers:              descs,
 	}
@@ -206,7 +205,7 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 		if err != nil {
 			return err
 		}
-		desc.Annotations = packOpts.ConfigAnnotations
+		desc.Annotations = opts.Annotations[option.AnnotationConfig]
 		packOpts.ConfigDescriptor = &desc
 	}
 	pack := func() (ocispec.Descriptor, error) {

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -30,6 +30,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/command"
 	"oras.land/oras/cmd/oras/internal/display"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
+	"oras.land/oras/cmd/oras/internal/fileref"
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/graph"
 	"oras.land/oras/internal/registryutil"
@@ -43,8 +44,9 @@ type attachOptions struct {
 	option.Platform
 	option.Terminal
 
-	artifactType string
-	concurrency  int
+	artifactType      string
+	manifestConfigRef string
+	concurrency       int
 	// Deprecated: verbose is deprecated and will be removed in the future.
 	verbose bool
 }
@@ -92,6 +94,9 @@ Example - Attach file to the manifest tagged 'v1' in an OCI image layout folder 
 
 Example - Attach file to the manifest tagged 'example.com:v1' in an OCI image layout folder 'layout-dir':
   oras attach --artifact-type doc/example --oci-layout-path layout-dir example.com:v1 hi.txt
+
+Example - Attach file 'hi.txt' with the custom manifest config "config.json" of the custom media type "application/vnd.me.config":
+  oras attach --artifact-type doc/example --config config.json:application/vnd.me.config localhost:5000/hello:v1 hi.txt
 `,
 		Args: oerrors.CheckArgs(argument.AtLeast(1), "the destination artifact for attaching."),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -100,6 +105,9 @@ Example - Attach file to the manifest tagged 'example.com:v1' in an OCI image la
 			err := option.Parse(cmd, &opts)
 			if err == nil {
 				opts.DisableTTY(opts.Debug, false)
+				if err = oerrors.CheckMutuallyExclusiveFlags(cmd.Flags(), "config", "platform"); err != nil {
+					return err
+				}
 				if err = opts.EnsureReferenceNotEmpty(cmd, true); err == nil {
 					return nil
 				}
@@ -121,6 +129,7 @@ Example - Attach file to the manifest tagged 'example.com:v1' in an OCI image la
 	}
 
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
+	cmd.Flags().StringVarP(&opts.manifestConfigRef, "config", "", "", "`path` of image config file")
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
 	opts.FlagDescription = "attach to an arch-specific subject"
@@ -184,8 +193,21 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 
 	packOpts := oras.PackManifestOptions{
 		Subject:             &subject,
+		ConfigAnnotations:   opts.Annotations[option.AnnotationConfig],
 		ManifestAnnotations: opts.Annotations[option.AnnotationManifest],
 		Layers:              descs,
+	}
+	if opts.manifestConfigRef != "" {
+		path, cfgMediaType, err := fileref.Parse(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
+		if err != nil {
+			return err
+		}
+		desc, err := addFile(ctx, store, option.AnnotationConfig, cfgMediaType, path)
+		if err != nil {
+			return err
+		}
+		desc.Annotations = packOpts.ConfigAnnotations
+		packOpts.ConfigDescriptor = &desc
 	}
 	pack := func() (ocispec.Descriptor, error) {
 		return oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, opts.artifactType, packOpts)

--- a/cmd/oras/root/attach_test.go
+++ b/cmd/oras/root/attach_test.go
@@ -18,12 +18,39 @@ package root
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
 	"oras.land/oras/cmd/oras/internal/option"
 )
+
+func Test_attachCmd_configAndPlatformMutuallyExclusive(t *testing.T) {
+	cmd := attachCmd()
+	cmd.SetArgs([]string{
+		"--artifact-type", "doc/example",
+		"--config", "config.json",
+		"--platform", "linux/amd64",
+		"localhost:5000/hello:v1",
+		"hi.txt",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be used at the same time") {
+		t.Fatalf("expected mutual exclusion error, got %v", err)
+	}
+}
+
+func Test_attachCmd_configFlagRegistered(t *testing.T) {
+	cmd := attachCmd()
+	f := cmd.Flags().Lookup("config")
+	if f == nil {
+		t.Fatal("expected --config flag to be registered")
+	}
+	if f.Usage != "`path` of image config file" {
+		t.Fatalf("unexpected usage: %q", f.Usage)
+	}
+}
 
 func Test_runAttach_errType(t *testing.T) {
 	// prepare

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -321,6 +321,23 @@ var _ = Describe("1.1 registry users:", func() {
 			ORAS("attach", "--artifact-type", "test/attach", "--config", foobar.FileConfigName, "--platform", "linux/amd64", ref, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia)).
 				ExpectFailure().WithWorkDir(tempDir).Exec()
 		})
+
+		It("should fail when config file path is empty", func() {
+			testRepo := attachTestRepo("config/empty-path")
+			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
+			CopyZOTRepo(ImageRepo, testRepo)
+			tempDir := PrepareTempFiles()
+			ORAS("attach", "--artifact-type", "test/attach", "--config", ":", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia)).
+				ExpectFailure().WithWorkDir(tempDir).Exec()
+		})
+
+		It("should fail when config file does not exist", func() {
+			testRepo := attachTestRepo("config/notfound")
+			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
+			CopyZOTRepo(ImageRepo, testRepo)
+			ORAS("attach", "--artifact-type", "test/attach", "--config", "nonexistent-config.json", subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia)).
+				ExpectFailure().Exec()
+		})
 	})
 })
 

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -16,6 +16,7 @@ limitations under the License.
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -25,6 +26,7 @@ import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/test/e2e/internal/testdata/feature"
 	"oras.land/oras/test/e2e/internal/testdata/foobar"
 	"oras.land/oras/test/e2e/internal/testdata/multi_arch"
@@ -270,6 +272,54 @@ var _ = Describe("1.1 registry users:", func() {
 			ORAS("attach", "--artifact-type", "test/attach", subjectRef, fmt.Sprintf("%s:%s", absAttachFileName, foobar.AttachFileMedia)).
 				ExpectFailure().
 				Exec()
+		})
+
+		It("should attach a file to a subject with customized config file", func() {
+			// prepare
+			testRepo := attachTestRepo("config")
+			tempDir := PrepareTempFiles()
+			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
+			CopyZOTRepo(ImageRepo, testRepo)
+			// test
+			ref := ORAS("attach", "--artifact-type", "test/attach", "--config", foobar.FileConfigName, subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "go-template={{.reference}}").
+				WithWorkDir(tempDir).Exec().Out.Contents()
+			// validate
+			fetched := ORAS("manifest", "fetch", string(ref)).Exec().Out.Contents()
+			var manifest ocispec.Manifest
+			Expect(json.Unmarshal(fetched, &manifest)).ShouldNot(HaveOccurred())
+			Expect(manifest.Config).Should(Equal(ocispec.Descriptor{
+				MediaType: "application/vnd.unknown.config.v1+json",
+				Size:      int64(foobar.FileConfigSize),
+				Digest:    foobar.FileConfigDigest,
+			}))
+		})
+
+		It("should attach a file to a subject with customized config file and media type", func() {
+			// prepare
+			testRepo := attachTestRepo("config/mediatype")
+			configType := "config/type"
+			tempDir := PrepareTempFiles()
+			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
+			CopyZOTRepo(ImageRepo, testRepo)
+			// test
+			ref := ORAS("attach", "--artifact-type", "test/attach", "--config", fmt.Sprintf("%s:%s", foobar.FileConfigName, configType), subjectRef, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia), "--format", "go-template={{.reference}}").
+				WithWorkDir(tempDir).Exec().Out.Contents()
+			// validate
+			fetched := ORAS("manifest", "fetch", string(ref)).Exec().Out.Contents()
+			var manifest ocispec.Manifest
+			Expect(json.Unmarshal(fetched, &manifest)).ShouldNot(HaveOccurred())
+			Expect(manifest.Config).Should(Equal(ocispec.Descriptor{
+				MediaType: configType,
+				Size:      int64(foobar.FileConfigSize),
+				Digest:    foobar.FileConfigDigest,
+			}))
+		})
+
+		It("should fail to use --config and --platform at the same time", func() {
+			ref := RegistryRef(ZOTHost, ImageRepo, foobar.Tag)
+			tempDir := PrepareTempFiles()
+			ORAS("attach", "--artifact-type", "test/attach", "--config", foobar.FileConfigName, "--platform", "linux/amd64", ref, fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia)).
+				ExpectFailure().WithWorkDir(tempDir).Exec()
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Add `--config <file>[:<type>]` flag support to `oras attach`, matching the existing behavior in `oras push`. This allows users to customize the config descriptor (media type and content) when attaching artifacts to a subject.

**Use case:** OCI does not mandate config content for artifacts, so users may need to define custom config data with specific media types when attaching artifacts.

## Changes

- `cmd/oras/root/attach.go`:
  - Add `manifestConfigRef` field to `attachOptions` struct
  - Register `--config` flag with path format `<file>[:<type>]`
  - Parse config file reference using `fileref.Parse()` and add to file store
  - Set `ConfigDescriptor` and `ConfigAnnotations` in `PackManifestOptions`
  - Add mutual exclusivity check between `--config` and `--platform` flags
  - Add usage example in command help text

### Usage

```bash
# Attach with custom config file and media type
oras attach --artifact-type doc/example \
  --config config.json:application/vnd.me.config \
  localhost:5000/hello:v1 hi.txt
```

## Test plan

- [x] `go build ./cmd/oras/` — builds successfully
- [x] `go vet ./cmd/oras/...` — no issues
- [x] `go test ./...` — full test suite passes (all packages OK)

Fixes #1146