### PR TITLE
fix: upgrade Go snap to 1.26 in snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
       - on amd64 to {ARCH}:
         - TARGET_ARCH: "{ARCH}"
     build-snaps:
-      - go/1.25/stable
+      - go/1.26/stable
     build-packages:
       - make
     stage-packages:


### PR DESCRIPTION
## Problem

The snap release CI job for `release-1.3` is failing with:

```
Environment validation failed for part 'oras': invalid go compiler version 'go: downloading go1.26.1 (linux/amd64)'.
Failed to execute pack in instance.
```

## Root Cause

`snapcraft.yaml` pins the build snap to `go/1.25/stable`, but `go.mod` requires `go 1.26.1`. Go 1.21+ defaults to `GOTOOLCHAIN=auto`, which causes the Go 1.25 binary to attempt downloading Go 1.26.1 at build time. Snapcraft's environment validator then receives the download progress message (`go: downloading go1.26.1 (linux/amd64)`) as the Go compiler version string — which is invalid — causing the build to fail.

## Fix

Upgrade the build snap channel from `go/1.25/stable` to `go/1.26/stable` to match the Go version required by `go.mod`.

## References

- Failing CI run: https://github.com/oras-project/oras/actions/runs/23341326576/job/67895417718