### PR TITLE
fix: set GOTOOLCHAIN=local in snapcraft.yaml to prevent auto-download

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,6 +31,7 @@ parts:
     source-type: git
     source-tag: $SNAPCRAFT_PROJECT_VERSION
     build-environment:
+      - GOTOOLCHAIN: "local"
       - on amd64 to {ARCH}:
         - TARGET_ARCH: "{ARCH}"
     build-snaps:


### PR DESCRIPTION
## Problem

When building the snap package, if the Go toolchain installed via the build snap is older than the version specified in `go.mod`, Go's default `GOTOOLCHAIN=auto` behavior causes it to attempt downloading a newer toolchain. Snapcraft's environment validator then receives the download progress message (e.g. `go: downloading go1.x.x (linux/amd64)`) as the Go compiler version string — which is invalid — causing the snap build to fail.

This was observed in the `release-1.3` snap CI job: https://github.com/oras-project/oras/actions/runs/23341326576/job/67895417718

## Fix

Add `GOTOOLCHAIN: "local"` to the `build-environment` in `snapcraft.yaml`. This ensures the snap's bundled Go toolchain is always used, preventing unexpected downloads during snap builds. The `go/1.25/stable` snap channel tracks the latest Go 1.25 patch releases and is compatible with the `go 1.25.7` requirement in `go.mod`.