### PR TITLE
fix: bump alpine base image from 3.22.1 to 3.22.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR ${ORASPKG}
 RUN make "build-$(echo $TARGETPLATFORM | tr / -)"
 RUN mv ${ORASPKG}/bin/${TARGETPLATFORM}/oras /go/bin/oras
 
-FROM docker.io/library/alpine:3.22.1
+FROM docker.io/library/alpine:3.22.3
 RUN apk --update add ca-certificates
 COPY --from=builder /go/bin/oras /bin/oras
 RUN mkdir /workspace


### PR DESCRIPTION
## Summary
- Bumps the Alpine runtime base image in the Dockerfile from 3.22.1 to 3.22.3
- Addresses CVEs reported by container image scanning tools (GHSA-g3vc-q8gm-c5x2)
- The vulnerabilities (CWE-476: NULL Pointer Dereference, CWE-787: Out-of-bounds Write) are in Alpine system libraries, resolved by updating to the latest 3.22 patch release

## Test plan
- [ ] Verify the Docker image builds successfully
- [ ] Run container image scanner against the updated image to confirm CVEs are resolved