### PR TITLE
bump: tag and release ORAS CLI v1.3.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.3.1"
+	Version = "1.3.2"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = ""
 	// GitCommit is the git sha1


### PR DESCRIPTION
## Summary
- Bump Go to 1.26.2

## Version bump commit
d0eeaed7a1c90abd2b5b518478efde0b6dda9992

## Test plan
- [ ] Build passes with Go 1.26.2
- [ ] All unit tests pass