### PR TITLE
chore: update snap actions to node24

### DIFF
--- a/.github/workflows/release-snap.yml
+++ b/.github/workflows/release-snap.yml
@@ -52,9 +52,9 @@ jobs:
           sed -i 's/{VERSION}/${{ steps.version.outputs.version }}/g' snapcraft.yaml
           sed -i 's/{ARCH}/${{ matrix.arch }}/g' snapcraft.yaml
           cat snapcraft.yaml
-      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
+      - uses: TerryHowe/action-build@edf78ca622b1eb99b69f09420bb19f77e4f84ac1 # v1-node24
         id: build
-      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
+      - uses: TerryHowe/action-publish@588a985778981df144826adfbbf3a236c1231dd2 # v1-node24
         name: publish
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}


### PR DESCRIPTION
## Summary

- Switches `action-build` and `action-publish` from the canonical `snapcore/` actions to TerryHowe's forks at the `chore/update-to-node24` branch
- Upgrades the GitHub Actions runner runtime from `node20` to `node24`
- No `dist/index.js` rebuild required — only the runtime specifier in `action.yml` changed, compiled JS is unchanged

## Background

The `snapcore/action-build` and `snapcore/action-publish` actions currently use `node20` as their runtime (`using: 'node20'`). Node.js 20 will reach end-of-life in April 2026. The fork branches pin to `node24` while an upstream PR to snapcore is pending.

## Test plan

- [ ] Verify `TerryHowe/action-build@edf78ca` and `TerryHowe/action-publish@588a985` are publicly accessible on GitHub
- [ ] Run `release-snap` workflow via `workflow_dispatch` to confirm `using: 'node24'` is accepted by the GitHub Actions runner
- [ ] Confirm snap builds and publishes successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)