### PR TITLE
chore: switch snap actions from snapcore to canonical

### DIFF
--- a/.github/workflows/release-snap.yml
+++ b/.github/workflows/release-snap.yml
@@ -52,9 +52,9 @@ jobs:
           sed -i 's/{VERSION}/${{ steps.version.outputs.version }}/g' snapcraft.yaml
           sed -i 's/{ARCH}/${{ matrix.arch }}/g' snapcraft.yaml
           cat snapcraft.yaml
-      - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
+      - uses: canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: build
-      - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+      - uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         name: publish
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}


### PR DESCRIPTION
## Summary

Switch `snapcore/action-build` and `snapcore/action-publish` to the upstream canonical repositories:

- `snapcore/action-build` → `canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79` (v1.3.0)
- `snapcore/action-publish` → `canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40` (v1.2.0)

The `snapcore` organization forks from `canonical`. Using the upstream source directly reduces the dependency chain.

## Test plan

- [ ] Trigger `release-snap` workflow via `workflow_dispatch` to confirm the canonical actions resolve and execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)