### PR TITLE
cmd/oras/root/attach: pass --annotation $config:* through to PackManifestOptions

### DIFF
--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -193,6 +193,7 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 
 	packOpts := oras.PackManifestOptions{
 		Subject:             &subject,
+		ConfigAnnotations:   opts.Annotations[option.AnnotationConfig],
 		ManifestAnnotations: opts.Annotations[option.AnnotationManifest],
 		Layers:              descs,
 	}

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -141,6 +141,17 @@ Example - Attach file 'hi.txt' with the custom manifest config "config.json" of 
 	return oerrors.Command(cmd, &opts.Target)
 }
 
+// buildAttachPackOpts assembles a PackManifestOptions from the resolved
+// attach options, subject descriptor, and layer descriptors.
+func buildAttachPackOpts(opts *attachOptions, subject ocispec.Descriptor, descs []ocispec.Descriptor) oras.PackManifestOptions {
+	return oras.PackManifestOptions{
+		Subject:             &subject,
+		ConfigAnnotations:   opts.Annotations[option.AnnotationConfig],
+		ManifestAnnotations: opts.Annotations[option.AnnotationManifest],
+		Layers:              descs,
+	}
+}
+
 func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 	ctx, logger := command.GetLogger(cmd, &opts.Common)
 	if len(opts.FileRefs) == 0 && len(opts.Annotations[option.AnnotationManifest]) == 0 {
@@ -191,12 +202,7 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 	graphCopyOptions.PreCopy = statusHandler.PreCopy
 	graphCopyOptions.PostCopy = statusHandler.PostCopy
 
-	packOpts := oras.PackManifestOptions{
-		Subject:             &subject,
-		ConfigAnnotations:   opts.Annotations[option.AnnotationConfig],
-		ManifestAnnotations: opts.Annotations[option.AnnotationManifest],
-		Layers:              descs,
-	}
+	packOpts := buildAttachPackOpts(opts, subject, descs)
 	if opts.manifestConfigRef != "" {
 		path, cfgMediaType, err := fileref.Parse(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
 		if err != nil {

--- a/cmd/oras/root/attach_test.go
+++ b/cmd/oras/root/attach_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 
 	"oras.land/oras/cmd/oras/internal/option"
@@ -75,10 +76,9 @@ func Test_runAttach_errType(t *testing.T) {
 	}
 }
 
-func Test_attachCmd_configAnnotationsWiredFromFile(t *testing.T) {
+func Test_attachCmd_configAnnotationsWiredToPackOpts(t *testing.T) {
 	// Regression for #2022: config annotations from an annotation file must
-	// be available as opts.Annotations[option.AnnotationConfig] after parsing
-	// so that runAttach can pass them to oras.PackManifestOptions.ConfigAnnotations.
+	// flow through to oras.PackManifestOptions.ConfigAnnotations.
 	annotationFile := filepath.Join(t.TempDir(), "annot.json")
 	content := `{"$config":{"org.example.key":"val"}}`
 	if err := os.WriteFile(annotationFile, []byte(content), 0600); err != nil {
@@ -90,11 +90,11 @@ func Test_attachCmd_configAnnotationsWiredFromFile(t *testing.T) {
 	if err := opts.Packer.Parse(cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	cfgAnnotations := opts.Annotations[option.AnnotationConfig]
-	if cfgAnnotations == nil {
+	packOpts := buildAttachPackOpts(opts, ocispec.Descriptor{}, nil)
+	if packOpts.ConfigAnnotations == nil {
 		t.Fatal("expected ConfigAnnotations to be populated; got nil")
 	}
-	if cfgAnnotations["org.example.key"] != "val" {
-		t.Fatalf("expected 'org.example.key'='val', got %v", cfgAnnotations)
+	if packOpts.ConfigAnnotations["org.example.key"] != "val" {
+		t.Fatalf("expected 'org.example.key'='val', got %v", packOpts.ConfigAnnotations)
 	}
 }

--- a/cmd/oras/root/attach_test.go
+++ b/cmd/oras/root/attach_test.go
@@ -18,6 +18,8 @@ package root
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -70,5 +72,29 @@ func Test_runAttach_errType(t *testing.T) {
 	want := errors.New("`--annotation` and `--annotation-file` cannot be both specified").Error()
 	if got != want {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func Test_attachCmd_configAnnotationsWiredFromFile(t *testing.T) {
+	// Regression for #2022: config annotations from an annotation file must
+	// be available as opts.Annotations[option.AnnotationConfig] after parsing
+	// so that runAttach can pass them to oras.PackManifestOptions.ConfigAnnotations.
+	annotationFile := filepath.Join(t.TempDir(), "annot.json")
+	content := `{"$config":{"org.example.key":"val"}}`
+	if err := os.WriteFile(annotationFile, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	opts := &attachOptions{}
+	opts.Packer.AnnotationFilePath = annotationFile
+	if err := opts.Packer.Parse(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfgAnnotations := opts.Annotations[option.AnnotationConfig]
+	if cfgAnnotations == nil {
+		t.Fatal("expected ConfigAnnotations to be populated; got nil")
+	}
+	if cfgAnnotations["org.example.key"] != "val" {
+		t.Fatalf("expected 'org.example.key'='val', got %v", cfgAnnotations)
 	}
 }

--- a/cmd/oras/root/attach_test.go
+++ b/cmd/oras/root/attach_test.go
@@ -86,7 +86,7 @@ func Test_attachCmd_configAnnotationsWiredToPackOpts(t *testing.T) {
 	}
 	cmd := &cobra.Command{}
 	opts := &attachOptions{}
-	opts.Packer.AnnotationFilePath = annotationFile
+	opts.AnnotationFilePath = annotationFile
 	if err := opts.Packer.Parse(cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #2022.

`runAttach` built `oras.PackManifestOptions` without a `ConfigAnnotations` entry, so `--annotation $config:key=val` was silently dropped whenever the user did not also pass `--config`: oras-go generated the default config descriptor and never saw the annotations. `runPush` already wires `ConfigAnnotations` unconditionally, so this was strictly an attach-path oversight.

## Fix

Add the same `ConfigAnnotations: opts.Annotations[option.AnnotationConfig]` line to the attach packOpts. When the caller did not pass any `$config:*` annotations the map lookup returns nil and PackManifest keeps its current default-config behaviour.

## Test plan

- [x] `go build ./cmd/oras/...` clean
- [x] `go vet ./cmd/oras/...` clean
- [x] `go test ./cmd/oras/... ./internal/...` green
- [ ] Manual: `oras attach --artifact-type doc/example --annotation '$config:org.example.key=value' localhost:5000/hello:v1 hi.txt` produces a manifest whose config descriptor carries `{"org.example.key": "value"}`.
