### PR TITLE
Add flag to make manifest and tar reproducible

### DIFF
--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
@@ -47,6 +48,7 @@ type attachOptions struct {
 	artifactType      string
 	manifestConfigRef string
 	concurrency       int
+	reproducible      bool
 	// Deprecated: verbose is deprecated and will be removed in the future.
 	verbose bool
 }
@@ -134,6 +136,7 @@ Example - Attach file 'hi.txt' with the custom manifest config "config.json" of 
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
 	opts.FlagDescription = "attach to an arch-specific subject"
 	_ = cmd.MarkFlagRequired("artifact-type")
+	cmd.Flags().BoolVarP(&opts.reproducible, "reproducible", "", false, "make it reproducible")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	opts.EnableDistributionSpecFlag()
 	opts.SetTypes(option.FormatTypeText, option.FormatTypeJSON, option.FormatTypeGoTemplate)
@@ -217,6 +220,19 @@ func runAttach(cmd *cobra.Command, opts *attachOptions) error {
 	}
 	pack := func() (ocispec.Descriptor, error) {
 		return oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, opts.artifactType, packOpts)
+	}
+
+	if opts.reproducible {
+		// make manifest reproducible
+		annotations := packOpts.ManifestAnnotations
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		zero := time.Time{}
+		annotations[ocispec.AnnotationCreated] = zero.Format(time.RFC3339)
+		packOpts.ManifestAnnotations = annotations
+
+		store.TarReproducible = true
 	}
 
 	copyFunc := func(root ocispec.Descriptor) error {

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"time"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
@@ -53,6 +54,7 @@ type pushOptions struct {
 	manifestConfigRef string
 	artifactType      string
 	concurrency       int
+	reproducible      bool
 	// Deprecated: verbose is deprecated and will be removed in the future.
 	verbose bool
 }
@@ -170,6 +172,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 	cmd.Flags().StringVarP(&opts.manifestConfigRef, "config", "", "", "`path` of image config file")
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
+	cmd.Flags().BoolVarP(&opts.reproducible, "reproducible", "", false, "make it reproducible")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
 	opts.SetTypes(option.FormatTypeText, option.FormatTypeJSON, option.FormatTypeGoTemplate)
@@ -190,6 +193,20 @@ func runPush(cmd *cobra.Command, opts *pushOptions) error {
 		return err
 	}
 	defer func() { _ = store.Close() }()
+
+	if opts.reproducible {
+		// make manifest reproducible
+		annotations := packOpts.ManifestAnnotations
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		zero := time.Time{}
+		annotations[ocispec.AnnotationCreated] = zero.Format(time.RFC3339)
+		packOpts.ManifestAnnotations = annotations
+
+		store.TarReproducible = true
+	}
+
 	if opts.manifestConfigRef != "" {
 		path, cfgMediaType, err := fileref.Parse(opts.manifestConfigRef, oras.MediaTypeUnknownConfig)
 		if err != nil {


### PR DESCRIPTION
This will set the timestamps to the zero time.Time timestamp, to avoid it being set to the current/modification timestamp.

For the manifest this translates to 0001-01-01, but for the tarball it translates to 1970-01-01 (since it uses seconds).

**What this PR does / why we need it**:

Adds `--reproducible`  flag, to push and attach.
This will make their resulting digests deterministic.

**Which issue(s) this PR fixes**:

Fixes #1464

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?
