### PR TITLE
test: strengthen display handler test assertions

### DIFF
--- a/cmd/oras/internal/display/metadata/json/pull_test.go
+++ b/cmd/oras/internal/display/metadata/json/pull_test.go
@@ -38,12 +38,11 @@ func TestPullHandler_OnLayerSkipped(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      1024,
 	}
 
-	err := handler.OnLayerSkipped(desc)
-	if err != nil {
+	if err := handler.OnLayerSkipped(desc); err != nil {
 		t.Errorf("PullHandler.OnLayerSkipped() error = %v, want nil", err)
 	}
 }
@@ -54,13 +53,23 @@ func TestPullHandler_OnFilePulled(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      1024,
 	}
 
-	err := handler.OnFilePulled("test.txt", "/output", desc, "blobs/sha256/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-	if err != nil {
-		t.Errorf("PullHandler.OnFilePulled() error = %v, want nil", err)
+	if err := handler.OnFilePulled("test.txt", "/output", desc, "blobs/sha256/"+testDigest[len("sha256:"):]); err != nil {
+		t.Fatalf("PullHandler.OnFilePulled() error = %v, want nil", err)
+	}
+
+	files := handler.pulled.Files()
+	if len(files) != 1 {
+		t.Fatalf("PullHandler.OnFilePulled() did not record file: got %d files, want 1", len(files))
+	}
+	if files[0].Digest != desc.Digest {
+		t.Errorf("recorded file Digest = %q, want %q", files[0].Digest, desc.Digest)
+	}
+	if files[0].MediaType != desc.MediaType {
+		t.Errorf("recorded file MediaType = %q, want %q", files[0].MediaType, desc.MediaType)
 	}
 }
 
@@ -70,7 +79,7 @@ func TestPullHandler_OnPulled(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      100,
 	}
 
@@ -85,22 +94,54 @@ func TestPullHandler_Render(t *testing.T) {
 	buf := &bytes.Buffer{}
 	handler := NewPullHandler(buf, "localhost:5000/test").(*PullHandler)
 
-	desc := ocispec.Descriptor{
+	rootDesc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      100,
 	}
-
-	handler.OnPulled(&option.Target{}, desc)
-
-	err := handler.Render()
-	if err != nil {
-		t.Errorf("PullHandler.Render() error = %v, want nil", err)
+	fileDesc := ocispec.Descriptor{
+		MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+		Digest:    testDigest,
+		Size:      1024,
 	}
 
-	// Verify JSON output is valid
-	var result map[string]interface{}
+	handler.OnPulled(&option.Target{}, rootDesc)
+	if err := handler.OnFilePulled("test.txt", "/output", fileDesc, "blobs/sha256/"+testDigest[len("sha256:"):]); err != nil {
+		t.Fatalf("PullHandler.OnFilePulled() error = %v", err)
+	}
+
+	if err := handler.Render(); err != nil {
+		t.Fatalf("PullHandler.Render() error = %v, want nil", err)
+	}
+
+	var result struct {
+		Reference string `json:"reference"`
+		Files     []struct {
+			Path      string `json:"path"`
+			Reference string `json:"reference"`
+			MediaType string `json:"mediaType"`
+			Digest    string `json:"digest"`
+			Size      int64  `json:"size"`
+		} `json:"files"`
+	}
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Errorf("PullHandler.Render() produced invalid JSON: %v", err)
+		t.Fatalf("PullHandler.Render() produced invalid JSON: %v", err)
+	}
+
+	wantReference := "localhost:5000/test@" + testDigest
+	if result.Reference != wantReference {
+		t.Errorf("Render() reference = %q, want %q", result.Reference, wantReference)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("Render() files length = %d, want 1", len(result.Files))
+	}
+	if result.Files[0].MediaType != fileDesc.MediaType {
+		t.Errorf("Render() files[0].mediaType = %q, want %q", result.Files[0].MediaType, fileDesc.MediaType)
+	}
+	if result.Files[0].Digest != string(fileDesc.Digest) {
+		t.Errorf("Render() files[0].digest = %q, want %q", result.Files[0].Digest, fileDesc.Digest)
+	}
+	if result.Files[0].Size != fileDesc.Size {
+		t.Errorf("Render() files[0].size = %d, want %d", result.Files[0].Size, fileDesc.Size)
 	}
 }

--- a/cmd/oras/internal/display/metadata/json/push_test.go
+++ b/cmd/oras/internal/display/metadata/json/push_test.go
@@ -18,11 +18,14 @@ package json
 import (
 	"bytes"
 	"encoding/json"
+	"slices"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras/cmd/oras/internal/option"
 )
+
+const testDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 func TestNewPushHandler(t *testing.T) {
 	buf := &bytes.Buffer{}
@@ -38,13 +41,17 @@ func TestPushHandler_OnTagged(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      100,
 	}
 
-	err := handler.OnTagged(desc, "v1.0.0")
-	if err != nil {
-		t.Errorf("PushHandler.OnTagged() error = %v, want nil", err)
+	if err := handler.OnTagged(desc, "v1.0.0"); err != nil {
+		t.Fatalf("PushHandler.OnTagged() error = %v, want nil", err)
+	}
+
+	tags := handler.tagged.Tags()
+	if !slices.Contains(tags, "v1.0.0") {
+		t.Errorf("PushHandler.OnTagged() did not store tag: got tags = %v, want to contain %q", tags, "v1.0.0")
 	}
 }
 
@@ -54,7 +61,7 @@ func TestPushHandler_OnCopied(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      100,
 	}
 
@@ -64,9 +71,19 @@ func TestPushHandler_OnCopied(t *testing.T) {
 		Reference:    "v1.0.0",
 	}
 
-	err := handler.OnCopied(opts, desc)
-	if err != nil {
-		t.Errorf("PushHandler.OnCopied() error = %v, want nil", err)
+	if err := handler.OnCopied(opts, desc); err != nil {
+		t.Fatalf("PushHandler.OnCopied() error = %v, want nil", err)
+	}
+
+	if handler.path != opts.Path {
+		t.Errorf("PushHandler.OnCopied() path = %q, want %q", handler.path, opts.Path)
+	}
+	if handler.root.Digest != desc.Digest {
+		t.Errorf("PushHandler.OnCopied() root.Digest = %q, want %q", handler.root.Digest, desc.Digest)
+	}
+	tags := handler.tagged.Tags()
+	if !slices.Contains(tags, "v1.0.0") {
+		t.Errorf("PushHandler.OnCopied() did not store tag for non-digest reference: got tags = %v", tags)
 	}
 }
 
@@ -76,19 +93,28 @@ func TestPushHandler_OnCopied_WithDigest(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      100,
 	}
 
 	opts := &option.Target{
-		RawReference: "localhost:5000/test@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		RawReference: "localhost:5000/test@" + testDigest,
 		Path:         "localhost:5000/test",
-		Reference:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Reference:    testDigest,
 	}
 
-	err := handler.OnCopied(opts, desc)
-	if err != nil {
-		t.Errorf("PushHandler.OnCopied() error = %v, want nil", err)
+	if err := handler.OnCopied(opts, desc); err != nil {
+		t.Fatalf("PushHandler.OnCopied() error = %v, want nil", err)
+	}
+
+	if tags := handler.tagged.Tags(); len(tags) != 0 {
+		t.Errorf("PushHandler.OnCopied() with digest reference should not add a tag, got tags = %v", tags)
+	}
+	if handler.path != opts.Path {
+		t.Errorf("PushHandler.OnCopied() path = %q, want %q", handler.path, opts.Path)
+	}
+	if handler.root.Digest != desc.Digest {
+		t.Errorf("PushHandler.OnCopied() root.Digest = %q, want %q", handler.root.Digest, desc.Digest)
 	}
 }
 
@@ -98,7 +124,7 @@ func TestPushHandler_Render(t *testing.T) {
 
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
-		Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		Digest:    testDigest,
 		Size:      100,
 	}
 
@@ -112,14 +138,36 @@ func TestPushHandler_Render(t *testing.T) {
 		t.Fatalf("PushHandler.OnCopied() error = %v", err)
 	}
 
-	err := handler.Render()
-	if err != nil {
-		t.Errorf("PushHandler.Render() error = %v, want nil", err)
+	if err := handler.Render(); err != nil {
+		t.Fatalf("PushHandler.Render() error = %v, want nil", err)
 	}
 
-	// Verify JSON output is valid
-	var result map[string]interface{}
+	var result struct {
+		Reference       string   `json:"reference"`
+		MediaType       string   `json:"mediaType"`
+		Digest          string   `json:"digest"`
+		Size            int64    `json:"size"`
+		ReferenceAsTags []string `json:"referenceAsTags"`
+	}
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
-		t.Errorf("PushHandler.Render() produced invalid JSON: %v", err)
+		t.Fatalf("PushHandler.Render() produced invalid JSON: %v", err)
+	}
+
+	wantReference := opts.Path + "@" + testDigest
+	if result.Reference != wantReference {
+		t.Errorf("Render() reference = %q, want %q", result.Reference, wantReference)
+	}
+	if result.MediaType != desc.MediaType {
+		t.Errorf("Render() mediaType = %q, want %q", result.MediaType, desc.MediaType)
+	}
+	if result.Digest != string(desc.Digest) {
+		t.Errorf("Render() digest = %q, want %q", result.Digest, desc.Digest)
+	}
+	if result.Size != desc.Size {
+		t.Errorf("Render() size = %d, want %d", result.Size, desc.Size)
+	}
+	wantRefAsTags := []string{"localhost:5000/test:v1.0.0"}
+	if !slices.Equal(result.ReferenceAsTags, wantRefAsTags) {
+		t.Errorf("Render() referenceAsTags = %v, want %v", result.ReferenceAsTags, wantRefAsTags)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1950 that addresses the Copilot review feedback left on that PR. The previously added tests only asserted that handler methods returned no error; this PR adds assertions on the state mutations and rendered JSON output that those methods are actually supposed to produce.

> [!NOTE]
> This branch is stacked on #1950. It currently shows that PR's commits plus this one in the diff. Please merge #1950 first — once that lands, GitHub will recompute this PR's diff to show only the changes here.

### Changes

`cmd/oras/internal/display/metadata/json/push_test.go`
- `TestPushHandler_OnTagged` now asserts the tag is stored in `handler.tagged.Tags()`.
- `TestPushHandler_OnCopied` now asserts `handler.path`, `handler.root.Digest`, and that the non-digest reference was added as a tag.
- `TestPushHandler_OnCopied_WithDigest` now asserts that **no** tag is added when the reference is a digest — the whole purpose of that code path.
- `TestPushHandler_Render` now decodes the JSON into a typed struct and asserts `reference`, `mediaType`, `digest`, `size`, and `referenceAsTags` rather than only checking that the output parses.

`cmd/oras/internal/display/metadata/json/pull_test.go`
- `TestPullHandler_OnFilePulled` now asserts the file was recorded in `handler.pulled.Files()` with the expected digest and media type.
- `TestPullHandler_Render` now calls `OnFilePulled` before rendering and decodes the output into a typed struct, asserting `reference` and the `files` array contents.

`cmd/oras/internal/display/content/discard_test.go`
- One-line drive-by: rename the unused `t` parameter in `TestDiscardHandler_ImplementsInterfaces` to `_` so the branch passes `revive`'s `unused-parameter` check.

## Test plan
- [x] `go test ./cmd/oras/internal/display/metadata/json/... ./cmd/oras/internal/display/content/...` passes
- [x] `golangci-lint run ./cmd/oras/internal/display/metadata/json/... ./cmd/oras/internal/display/content/...` reports 0 issues

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>