### PR TITLE
feat(cp): add --force to handle partially-populated destinations

### DIFF
--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -39,6 +39,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/display/status"
 	oerrors "oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
+	"oras.land/oras/internal/contentutil"
 	"oras.land/oras/internal/docker"
 	"oras.land/oras/internal/graph"
 	"oras.land/oras/internal/listener"
@@ -52,6 +53,7 @@ type copyOptions struct {
 	option.Terminal
 
 	recursive   bool
+	force       bool
 	concurrency int
 	extraRefs   []string
 	// Deprecated: verbose is deprecated and will be removed in the future.
@@ -93,6 +95,9 @@ Example - Copy an artifact with multiple tags:
 
 Example - Copy an artifact with multiple tags with concurrency tuned:
   oras cp --concurrency 10 localhost:5000/net-monitor:v1 localhost:5000/net-monitor-copy:tag1,tag2,tag3
+
+Example - Copy a multi-arch image to a destination that may be partially populated (e.g. a registry cache):
+  oras cp --force localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 `,
 		Args: oerrors.CheckArgs(argument.Exactly(2), "the source and destination for copying"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -113,6 +118,7 @@ Example - Copy an artifact with multiple tags with concurrency tuned:
 		},
 	}
 	cmd.Flags().BoolVarP(&opts.recursive, "recursive", "r", false, "[Preview] recursively copy the artifact and its referrer artifacts")
+	cmd.Flags().BoolVarP(&opts.force, "force", "", false, "force a deep traversal of the destination graph before tagging the root; useful when the destination is partially populated (e.g. by a registry cache)")
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 3, "concurrency level")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
@@ -181,6 +187,15 @@ func doCopy(ctx context.Context, copyHandler status.CopyHandler, src oras.ReadOn
 		}
 	}
 
+	if opts.force {
+		// Defeat the sub-DAG skip in oras-go's copyGraph so that every
+		// referenced manifest is visited and any missing successor (manifest
+		// or blob) is copied to the destination before the root tag is
+		// updated. This handles destinations that hold only a partial copy
+		// of the artifact (e.g. registries with a pull-through cache that
+		// has been populated from a single platform).
+		dst = &contentutil.TraversingTarget{GraphTarget: dst}
+	}
 	dst, err = copyHandler.StartTracking(dst)
 	if err != nil {
 		return desc, err

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -52,6 +52,7 @@ type pushOptions struct {
 	extraRefs         []string
 	manifestConfigRef string
 	artifactType      string
+	force             bool
 	concurrency       int
 	// Deprecated: verbose is deprecated and will be removed in the future.
 	verbose bool
@@ -169,6 +170,7 @@ Example - Push file "hi.txt" into an OCI image layout folder 'layout-dir' with t
 	}
 	cmd.Flags().StringVarP(&opts.manifestConfigRef, "config", "", "", "`path` of image config file")
 	cmd.Flags().StringVarP(&opts.artifactType, "artifact-type", "", "", "artifact type")
+	cmd.Flags().BoolVarP(&opts.force, "force", "", false, "force a deep traversal of the destination graph before tagging the root; useful when the destination is partially populated (e.g. by a registry cache)")
 	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "", 5, "concurrency level")
 	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", true, "print status output for unnamed blobs")
 	_ = cmd.Flags().MarkDeprecated("verbose", "and will be removed in a future release.")
@@ -247,6 +249,13 @@ func runPush(cmd *cobra.Command, opts *pushOptions) error {
 	if err != nil {
 		return err
 	}
+	// Keep the unwrapped destination for scope hinting; WithScopeHint relies
+	// on a concrete *remote.Repository type assertion and would silently
+	// skip the hint if passed the TraversingTarget wrapper.
+	scopeHintDst := originalDst
+	if opts.force {
+		originalDst = &contentutil.TraversingTarget{GraphTarget: originalDst}
+	}
 	dst, stopTrack, err := statusHandler.TrackTarget(originalDst)
 	if err != nil {
 		return err
@@ -259,7 +268,7 @@ func runPush(cmd *cobra.Command, opts *pushOptions) error {
 	copyWithScopeHint := func(root ocispec.Descriptor) error {
 		// add both pull and push scope hints for dst repository
 		// to save potential push-scope token requests during copy
-		ctx = registryutil.WithScopeHint(ctx, originalDst, auth.ActionPull, auth.ActionPush)
+		ctx = registryutil.WithScopeHint(ctx, scopeHintDst, auth.ActionPull, auth.ActionPush)
 
 		if tag := opts.Reference; tag == "" {
 			err = oras.CopyGraph(ctx, union, dst, root, copyOptions.CopyGraphOptions)

--- a/cmd/oras/root/push_test.go
+++ b/cmd/oras/root/push_test.go
@@ -17,9 +17,12 @@ package root
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"oras.land/oras-go/v2/content/oci"
 	"oras.land/oras/cmd/oras/internal/errors"
 	"oras.land/oras/cmd/oras/internal/option"
 )
@@ -39,5 +42,46 @@ func Test_runPush_errType(t *testing.T) {
 	want := errors.UnsupportedFormatTypeError(opts.Format.Type).Error()
 	if got != want {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// Test_runPush_force verifies that pushing with --force succeeds and wraps the
+// destination in a contentutil.TraversingTarget (covering the force branch in
+// runPush). Extra tags are also supplied so the wrapped originalDst is used by
+// the extraRefs tagging path.
+func Test_runPush_force(t *testing.T) {
+	// prepare a file to push
+	tempDir := t.TempDir()
+	fileName := "hi.txt"
+	filePath := filepath.Join(tempDir, fileName)
+	if err := os.WriteFile(filePath, []byte("hello world"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// use an OCI image layout as the push destination
+	layoutDir := filepath.Join(tempDir, "layout")
+
+	cmd := pushCmd()
+	cmd.SetArgs([]string{
+		"--oci-layout",
+		"--force",
+		"--disable-path-validation",
+		layoutDir + ":tag1,tag2",
+		filePath,
+	})
+	cmd.SetContext(context.Background())
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// verify the artifact and both tags were pushed to the layout
+	store, err := oci.New(layoutDir)
+	if err != nil {
+		t.Fatalf("failed to open pushed layout: %v", err)
+	}
+	for _, tag := range []string{"tag1", "tag2"} {
+		if _, err := store.Resolve(context.Background(), tag); err != nil {
+			t.Errorf("expected tag %q to be resolvable, got error: %v", tag, err)
+		}
 	}
 }

--- a/cmd/oras/root/push_test.go
+++ b/cmd/oras/root/push_test.go
@@ -45,10 +45,8 @@ func Test_runPush_errType(t *testing.T) {
 	}
 }
 
-// Test_runPush_force verifies that pushing with --force succeeds and wraps the
-// destination in a contentutil.TraversingTarget (covering the force branch in
-// runPush). Extra tags are also supplied so the wrapped originalDst is used by
-// the extraRefs tagging path.
+// Test_runPush_force exercises pushing with --force, including the extra-tag
+// path that uses the TraversingTarget-wrapped destination.
 func Test_runPush_force(t *testing.T) {
 	// prepare a file to push
 	tempDir := t.TempDir()

--- a/internal/contentutil/traverse.go
+++ b/internal/contentutil/traverse.go
@@ -1,0 +1,62 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contentutil
+
+import (
+	"context"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/internal/docker"
+	"oras.land/oras/internal/graph"
+)
+
+// IsManifestMediaType reports whether the given media type denotes a
+// manifest (i.e. a non-leaf node in a content-addressable graph).
+func IsManifestMediaType(mediaType string) bool {
+	switch mediaType {
+	case ocispec.MediaTypeImageManifest,
+		ocispec.MediaTypeImageIndex,
+		docker.MediaTypeManifest,
+		docker.MediaTypeManifestList,
+		graph.MediaTypeArtifactManifest:
+		return true
+	}
+	return false
+}
+
+// TraversingTarget wraps an [oras.GraphTarget] and reports manifest
+// descriptors as not yet present in the destination. This defeats the
+// sub-DAG skip in oras-go's copyGraph (where any descriptor reported as
+// existing causes its entire successor tree to be skipped) and forces
+// recursive traversal so that missing referenced manifests or blobs are
+// discovered and copied.
+//
+// Blob existence checks still short-circuit, so layers that are already
+// in the destination are not re-uploaded.
+type TraversingTarget struct {
+	oras.GraphTarget
+}
+
+// Exists returns false for manifest descriptors regardless of the
+// underlying target's state; for non-manifest descriptors it delegates
+// to the wrapped target.
+func (v *TraversingTarget) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	if IsManifestMediaType(target.MediaType) {
+		return false, nil
+	}
+	return v.GraphTarget.Exists(ctx, target)
+}

--- a/internal/contentutil/traverse.go
+++ b/internal/contentutil/traverse.go
@@ -24,8 +24,7 @@ import (
 	"oras.land/oras/internal/graph"
 )
 
-// IsManifestMediaType reports whether the given media type denotes a
-// manifest (i.e. a non-leaf node in a content-addressable graph).
+// IsManifestMediaType reports whether the given media type denotes a manifest.
 func IsManifestMediaType(mediaType string) bool {
 	switch mediaType {
 	case ocispec.MediaTypeImageManifest,
@@ -45,8 +44,8 @@ func IsManifestMediaType(mediaType string) bool {
 // recursive traversal so that missing referenced manifests or blobs are
 // discovered and copied.
 //
-// Blob existence checks still short-circuit, so layers that are already
-// in the destination are not re-uploaded.
+// Non-manifest existence checks still delegate to the wrapped target, so
+// content that is already in the destination is not re-uploaded.
 type TraversingTarget struct {
 	oras.GraphTarget
 }

--- a/internal/contentutil/traverse_test.go
+++ b/internal/contentutil/traverse_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contentutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras/internal/docker"
+	"oras.land/oras/internal/graph"
+)
+
+func TestIsManifestMediaType(t *testing.T) {
+	tests := []struct {
+		mediaType string
+		want      bool
+	}{
+		{ocispec.MediaTypeImageManifest, true},
+		{ocispec.MediaTypeImageIndex, true},
+		{docker.MediaTypeManifest, true},
+		{docker.MediaTypeManifestList, true},
+		{graph.MediaTypeArtifactManifest, true},
+		{ocispec.MediaTypeImageLayer, false},
+		{ocispec.MediaTypeImageLayerGzip, false},
+		{"application/vnd.oci.image.config.v1+json", false},
+		{"application/octet-stream", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsManifestMediaType(tt.mediaType); got != tt.want {
+			t.Errorf("IsManifestMediaType(%q) = %v, want %v", tt.mediaType, got, tt.want)
+		}
+	}
+}
+
+// fakeGraphTarget is a minimal oras.GraphTarget used to observe Exists calls.
+type fakeGraphTarget struct {
+	oras.GraphTarget
+	existsCalled bool
+	existsResult bool
+	existsErr    error
+}
+
+func (f *fakeGraphTarget) Exists(_ context.Context, _ ocispec.Descriptor) (bool, error) {
+	f.existsCalled = true
+	return f.existsResult, f.existsErr
+}
+
+func TestTraversingTarget_Exists(t *testing.T) {
+	tests := []struct {
+		name             string
+		mediaType        string
+		underlyingExists bool
+		underlyingErr    error
+		wantExists       bool
+		wantErr          bool
+		wantDelegate     bool
+	}{
+		{
+			name:         "image manifest is reported as missing without delegating",
+			mediaType:    ocispec.MediaTypeImageManifest,
+			wantDelegate: false,
+		},
+		{
+			name:         "image index is reported as missing without delegating",
+			mediaType:    ocispec.MediaTypeImageIndex,
+			wantDelegate: false,
+		},
+		{
+			name:         "docker manifest list is reported as missing without delegating",
+			mediaType:    docker.MediaTypeManifestList,
+			wantDelegate: false,
+		},
+		{
+			name:             "blob existence delegates and propagates true",
+			mediaType:        ocispec.MediaTypeImageLayer,
+			underlyingExists: true,
+			wantExists:       true,
+			wantDelegate:     true,
+		},
+		{
+			name:             "blob existence delegates and propagates false",
+			mediaType:        ocispec.MediaTypeImageLayerGzip,
+			underlyingExists: false,
+			wantExists:       false,
+			wantDelegate:     true,
+		},
+		{
+			name:          "blob existence delegates and propagates error",
+			mediaType:     ocispec.MediaTypeImageLayer,
+			underlyingErr: errors.New("boom"),
+			wantErr:       true,
+			wantDelegate:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeGraphTarget{existsResult: tt.underlyingExists, existsErr: tt.underlyingErr}
+			v := &TraversingTarget{GraphTarget: f}
+			got, err := v.Exists(context.Background(), ocispec.Descriptor{
+				MediaType: tt.mediaType,
+				Digest:    digest.FromString("x"),
+				Size:      1,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Exists() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.wantExists {
+				t.Errorf("Exists() = %v, want %v", got, tt.wantExists)
+			}
+			if f.existsCalled != tt.wantDelegate {
+				t.Errorf("delegate Exists called = %v, want %v", f.existsCalled, tt.wantDelegate)
+			}
+		})
+	}
+}

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -18,6 +18,8 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -373,6 +375,68 @@ var _ = Describe("1.1 registry users:", func() {
 				dst := RegistryRef(ZOTHost, dstRepo, tag)
 				CompareRef(src, dst)
 			}
+		})
+
+		It("should copy a multi-arch image to a partially populated destination with --force", func() {
+			// Reproduce the pull-through-cache failure mode: the
+			// destination already advertises the index manifest as
+			// present (Exists(index)=true) while one or more referenced
+			// platform manifests are actually missing. In that state the
+			// default copy short-circuits the sub-DAG and the missing
+			// platforms are never pushed. With --force, cp must walk
+			// every referenced manifest and push the missing ones before
+			// updating the tag.
+			//
+			// Conformant registries reject indices whose children aren't
+			// present, so the partial state can't be produced over the
+			// distribution API. Use an OCI image layout as the
+			// destination instead: it stores manifests as plain files,
+			// which lets us delete two child manifests on disk and mint
+			// the exact "index known, children missing" state that
+			// pull-through caches expose. The --force code path under
+			// test (verifyingTarget wrapping the destination) is
+			// identical for layout and registry targets.
+			src := RegistryRef(ZOTHost, ImageRepo, ma.Tag)
+			dstDir := GinkgoT().TempDir()
+			tag := "copiedTag"
+			dst := LayoutRef(dstDir, tag)
+
+			// Fully populate the layout, then physically remove two
+			// child manifest blobs so the index advertises them while
+			// they are absent on disk.
+			ORAS("cp", src, dst, Flags.ToLayout).Exec()
+			for _, child := range []string{ma.LinuxARM64.Digest.String(), ma.LinuxARMV7.Digest.String()} {
+				algo, hex, ok := strings.Cut(child, ":")
+				Expect(ok).To(BeTrue())
+				Expect(os.Remove(filepath.Join(dstDir, "blobs", algo, hex))).To(Succeed())
+			}
+			missingARM64 := LayoutRef(dstDir, ma.LinuxARM64.Digest.String())
+			missingARMv7 := LayoutRef(dstDir, ma.LinuxARMV7.Digest.String())
+			ORAS("manifest", "fetch", Flags.Layout, missingARM64).ExpectFailure().Exec()
+			ORAS("manifest", "fetch", Flags.Layout, missingARMv7).ExpectFailure().Exec()
+
+			// Negative control: without --force, cp short-circuits on
+			// Exists(index)=true, skips the sub-DAG, and leaves the
+			// missing platforms absent.
+			ORAS("cp", src, dst, Flags.ToLayout).Exec()
+			ORAS("manifest", "fetch", Flags.Layout, missingARM64).ExpectFailure().Exec()
+			ORAS("manifest", "fetch", Flags.Layout, missingARMv7).ExpectFailure().Exec()
+
+			// With --force, cp performs a deep traversal so the missing
+			// platforms get pushed before the tag is updated.
+			ORAS("cp", src, dst, Flags.ToLayout, "--force").Exec()
+
+			// The index in the layout must match the source.
+			srcIndex := ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, ma.Digest)).Exec().Out.Contents()
+			dstIndex := ORAS("manifest", "fetch", Flags.Layout, dst).Exec().Out.Contents()
+			Expect(srcIndex).To(Equal(dstIndex))
+			// The previously-missing platform manifests must be present.
+			srcARM64 := ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, ma.LinuxARM64.Digest.String())).Exec().Out.Contents()
+			dstARM64 := ORAS("manifest", "fetch", Flags.Layout, missingARM64).Exec().Out.Contents()
+			Expect(srcARM64).To(Equal(dstARM64))
+			srcARMv7 := ORAS("manifest", "fetch", RegistryRef(ZOTHost, ImageRepo, ma.LinuxARMV7.Digest.String())).Exec().Out.Contents()
+			dstARMv7 := ORAS("manifest", "fetch", Flags.Layout, missingARMv7).Exec().Out.Contents()
+			Expect(srcARMv7).To(Equal(dstARMv7))
 		})
 	})
 })

--- a/test/e2e/suite/command/cp.go
+++ b/test/e2e/suite/command/cp.go
@@ -394,8 +394,9 @@ var _ = Describe("1.1 registry users:", func() {
 			// which lets us delete two child manifests on disk and mint
 			// the exact "index known, children missing" state that
 			// pull-through caches expose. The --force code path under
-			// test (verifyingTarget wrapping the destination) is
-			// identical for layout and registry targets.
+			// test (wrapping the destination in a
+			// contentutil.TraversingTarget) is identical for layout and
+			// registry targets.
 			src := RegistryRef(ZOTHost, ImageRepo, ma.Tag)
 			dstDir := GinkgoT().TempDir()
 			tag := "copiedTag"


### PR DESCRIPTION
Addresses https://github.com/oras-project/oras/issues/2072.

A pull-through cache (e.g. ACR Artifact Cache, AWS ECR pull-through cache,
GAR remote repositories) can report a manifest as "exists" while only
holding a subset of its referenced content. oras-go's copyGraph trusts
the destination's existence response and skips the sub-DAG, so the
final tag PUT is rejected by the registry with
'manifest blob unknown' because referenced platform manifests or blobs
are missing.

Add an opt-in --force flag on `oras cp` and `oras push` that wraps the
destination with a small GraphTarget reporting Exists()=false for any
manifest media type. This defeats the sub-DAG skip and forces the copy
to walk every referenced manifest, pushing any missing manifests or
blobs before the root tag is updated. Blob existence checks still
short-circuit, so already-present layers are not re-uploaded.

Changes:
- cmd/oras/root/cp.go: register --force, document it in the examples,
  and wrap dst with verifyingTarget when the flag is set.
- cmd/oras/root/push.go: register --force and apply the same
  verifyingTarget wrapper before tracking starts.
- cmd/oras/root/cp_verify.go: verifyingTarget wrapper and
  isManifestMediaType predicate, shared by cp and push.
- cmd/oras/root/cp_verify_test.go: unit tests for the wrapper and
  predicate.
- test/e2e/suite/command/cp.go: e2e test that pre-populates a
  destination with only the linux/amd64 platform and re-runs cp with
  --force to push the remaining platform manifests of a multi-arch
  image before tagging.

Default behavior is unchanged; --force is opt-in on both commands.

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update? - document the `--force` behaviour
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
