### PR TITLE
chore: replace containerd/console with golang.org/x/term

### DIFF
--- a/cmd/oras/internal/display/status/console/console.go
+++ b/cmd/oras/internal/display/status/console/console.go
@@ -16,10 +16,12 @@ limitations under the License.
 package console
 
 import (
+	"errors"
+	"io"
 	"os"
 
-	containerd "github.com/containerd/console"
 	"github.com/morikuni/aec"
+	"golang.org/x/term"
 )
 
 const (
@@ -33,9 +35,8 @@ const (
 	Restore = "\0338"
 )
 
-// Console is a wrapper around containerd's Console and ANSI escape codes.
+// Console is a wrapper around a terminal and ANSI escape codes.
 type Console interface {
-	containerd.Console
 	GetHeightWidth() (height, width int)
 	Save()
 	NewRow()
@@ -43,60 +44,80 @@ type Console interface {
 	Restore()
 }
 
+// terminal is the minimal backend that a Console renders to. It decouples the
+// cursor and escape-code logic from the underlying terminal implementation so
+// that the backing library (currently golang.org/x/term) can be swapped or
+// extended without touching callers.
+type terminal interface {
+	io.Writer
+	// size returns the height and width of the terminal in cells.
+	size() (height, width int, err error)
+}
+
+// fileTerminal is a terminal backed by an *os.File, using golang.org/x/term
+// for size queries.
+type fileTerminal struct {
+	*os.File
+}
+
+func (t *fileTerminal) size() (height, width int, err error) {
+	width, height, err = term.GetSize(int(t.Fd()))
+	return height, width, err
+}
+
 type console struct {
-	containerd.Console
+	term terminal
 }
 
 // NewConsole generates a console from a file.
 func NewConsole(f *os.File) (Console, error) {
-	c, err := containerd.ConsoleFromFile(f)
-	if err != nil {
-		return nil, err
+	if f == nil {
+		return nil, errors.New("cannot create console from nil file")
 	}
-	return &console{c}, nil
+	return &console{term: &fileTerminal{f}}, nil
 }
 
-// GetHeightWidth returns the width and height of the console.
+// GetHeightWidth returns the height and width of the console.
 // If the console size cannot be determined, returns a default value of 80x10.
 func (c *console) GetHeightWidth() (height, width int) {
-	windowSize, err := c.Size()
+	height, width, err := c.term.size()
 	if err != nil {
 		return MinHeight, MinWidth
 	}
-	if windowSize.Height < MinHeight {
-		windowSize.Height = MinHeight
+	if height < MinHeight {
+		height = MinHeight
 	}
-	if windowSize.Width < MinWidth {
-		windowSize.Width = MinWidth
+	if width < MinWidth {
+		width = MinWidth
 	}
-	return int(windowSize.Height), int(windowSize.Width)
+	return height, width
 }
 
 // Save saves the current cursor position.
 func (c *console) Save() {
-	_, _ = c.Write([]byte(aec.Hide.Apply(Save)))
+	_, _ = c.term.Write([]byte(aec.Hide.Apply(Save)))
 }
 
 // NewRow allocates a horizontal space to the output area with scroll if needed.
 func (c *console) NewRow() {
-	_, _ = c.Write([]byte(Restore))
-	_, _ = c.Write([]byte("\n"))
-	_, _ = c.Write([]byte(Save))
+	_, _ = c.term.Write([]byte(Restore))
+	_, _ = c.term.Write([]byte("\n"))
+	_, _ = c.term.Write([]byte(Save))
 }
 
 // OutputTo outputs a string to a specific line.
 func (c *console) OutputTo(upCnt uint, str string) {
-	_, _ = c.Write([]byte(Restore))
-	_, _ = c.Write([]byte(aec.PreviousLine(upCnt).Apply(str)))
-	_, _ = c.Write([]byte("\n"))
-	_, _ = c.Write([]byte(aec.EraseLine(aec.EraseModes.Tail).String()))
+	_, _ = c.term.Write([]byte(Restore))
+	_, _ = c.term.Write([]byte(aec.PreviousLine(upCnt).Apply(str)))
+	_, _ = c.term.Write([]byte("\n"))
+	_, _ = c.term.Write([]byte(aec.EraseLine(aec.EraseModes.Tail).String()))
 }
 
 // Restore restores the saved cursor position.
 func (c *console) Restore() {
 	// cannot use aec.Restore since DEC has better compatibility than SCO
-	_, _ = c.Write([]byte(Restore))
-	_, _ = c.Write([]byte(aec.Column(0).
+	_, _ = c.term.Write([]byte(Restore))
+	_, _ = c.term.Write([]byte(aec.Column(0).
 		With(aec.EraseLine(aec.EraseModes.All)).
 		With(aec.Show).String()))
 }

--- a/cmd/oras/internal/display/status/console/console_test.go
+++ b/cmd/oras/internal/display/status/console/console_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,120 +16,99 @@ limitations under the License.
 package console
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"testing"
-
-	containerd "github.com/containerd/console"
-	"oras.land/oras/internal/testutils"
 )
 
-func givenConsole(t *testing.T) (c Console, pty containerd.Console) {
-	t.Helper()
-	pty, _, err := containerd.NewPty()
-	if err != nil {
-		t.Fatal(err)
-	}
+var errFake = errors.New("fake size error")
 
-	c = &console{
-		Console: pty,
-	}
-	return c, pty
+// fakeTerminal is an in-memory terminal used to exercise the cursor and escape
+// code logic without a real terminal.
+type fakeTerminal struct {
+	bytes.Buffer
+	height int
+	width  int
+	err    error
 }
 
-func givenTestConsole(t *testing.T) (c Console, pty containerd.Console, tty *os.File) {
-	t.Helper()
-	var err error
-	pty, tty, err = testutils.NewPty()
-	if err != nil {
-		t.Fatal(err)
-	}
-	c, err = NewConsole(tty)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return
+func (f *fakeTerminal) size() (height, width int, err error) {
+	return f.height, f.width, f.err
 }
 
-func validateSize(t *testing.T, gotWidth, gotHeight, wantWidth, wantHeight int) {
-	t.Helper()
-	if gotWidth != wantWidth {
-		t.Errorf("Console.Size() gotWidth = %v, want %v", gotWidth, wantWidth)
-	}
-	if gotHeight != wantHeight {
-		t.Errorf("Console.Size() gotHeight = %v, want %v", gotHeight, wantHeight)
-	}
+func newFakeConsole(ft *fakeTerminal) *console {
+	return &console{term: ft}
 }
 
 func TestNewConsole(t *testing.T) {
-	_, err := NewConsole(os.Stdin)
-	if err == nil {
-		t.Error("expected error creating bogus console")
+	if _, err := NewConsole(nil); err == nil {
+		t.Error("expected error creating console from nil file")
+	}
+	c, err := NewConsole(os.Stdin)
+	if err != nil {
+		t.Errorf("unexpected error creating console: %v", err)
+	}
+	if c == nil {
+		t.Error("expected a non-nil console")
 	}
 }
 
 func TestConsole_GetHeightWidth(t *testing.T) {
-	c, pty := givenConsole(t)
-
-	// minimal width and height
-	gotHeight, gotWidth := c.GetHeightWidth()
-	validateSize(t, gotWidth, gotHeight, MinWidth, MinHeight)
-
-	// zero width
-	_ = pty.Resize(containerd.WinSize{Width: 0, Height: MinHeight})
-	gotHeight, gotWidth = c.GetHeightWidth()
-	validateSize(t, gotWidth, gotHeight, MinWidth, MinHeight)
-
-	// zero height
-	_ = pty.Resize(containerd.WinSize{Width: MinWidth, Height: 0})
-	gotHeight, gotWidth = c.GetHeightWidth()
-	validateSize(t, gotWidth, gotHeight, MinWidth, MinHeight)
-
-	// valid zero and height
-	_ = pty.Resize(containerd.WinSize{Width: 200, Height: 100})
-	gotHeight, gotWidth = c.GetHeightWidth()
-	validateSize(t, gotWidth, gotHeight, 200, 100)
-}
-
-func TestConsole_NewRow(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
-
-	c.NewRow()
-
-	err := testutils.MatchPty(pty, tty, "\x1b8\r\n\x1b7")
-	if err != nil {
-		t.Fatalf("NewRow output error: %v", err)
+	tests := []struct {
+		name                  string
+		ft                    *fakeTerminal
+		wantHeight, wantWidth int
+	}{
+		{"size error falls back to minimum", &fakeTerminal{err: errFake}, MinHeight, MinWidth},
+		{"below minimum is clamped", &fakeTerminal{height: 1, width: 1}, MinHeight, MinWidth},
+		{"width below minimum is clamped", &fakeTerminal{height: 100, width: 1}, 100, MinWidth},
+		{"height below minimum is clamped", &fakeTerminal{height: 1, width: 200}, MinHeight, 200},
+		{"valid size is preserved", &fakeTerminal{height: 100, width: 200}, 100, 200},
 	}
-}
-
-func TestConsole_OutputTo(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
-
-	c.OutputTo(1, "test string")
-
-	err := testutils.MatchPty(pty, tty, "\x1b8\x1b[1Ftest string\x1b[0m\r\n\x1b[0K")
-	if err != nil {
-		t.Fatalf("OutputTo output error: %v", err)
-	}
-}
-
-func TestConsole_Restore(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
-
-	c.Restore()
-
-	err := testutils.MatchPty(pty, tty, "\x1b8\x1b[0G\x1b[2K\x1b[?25h")
-	if err != nil {
-		t.Fatalf("Restore output error: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newFakeConsole(tt.ft)
+			gotHeight, gotWidth := c.GetHeightWidth()
+			if gotHeight != tt.wantHeight || gotWidth != tt.wantWidth {
+				t.Errorf("GetHeightWidth() = (%d, %d), want (%d, %d)", gotHeight, gotWidth, tt.wantHeight, tt.wantWidth)
+			}
+		})
 	}
 }
 
 func TestConsole_Save(t *testing.T) {
-	c, pty, tty := givenTestConsole(t)
-
+	ft := &fakeTerminal{}
+	c := newFakeConsole(ft)
 	c.Save()
+	if got, want := ft.String(), "\x1b[?25l\x1b7\x1b[0m"; got != want {
+		t.Errorf("Save() = %q, want %q", got, want)
+	}
+}
 
-	err := testutils.MatchPty(pty, tty, "\x1b[?25l\x1b7\x1b[0m")
-	if err != nil {
-		t.Fatalf("Save output error: %v", err)
+func TestConsole_NewRow(t *testing.T) {
+	ft := &fakeTerminal{}
+	c := newFakeConsole(ft)
+	c.NewRow()
+	if got, want := ft.String(), "\x1b8\n\x1b7"; got != want {
+		t.Errorf("NewRow() = %q, want %q", got, want)
+	}
+}
+
+func TestConsole_OutputTo(t *testing.T) {
+	ft := &fakeTerminal{}
+	c := newFakeConsole(ft)
+	c.OutputTo(1, "test string")
+	if got, want := ft.String(), "\x1b8\x1b[1Ftest string\x1b[0m\n\x1b[0K"; got != want {
+		t.Errorf("OutputTo() = %q, want %q", got, want)
+	}
+}
+
+func TestConsole_Restore(t *testing.T) {
+	ft := &fakeTerminal{}
+	c := newFakeConsole(ft)
+	c.Restore()
+	if got, want := ft.String(), "\x1b8\x1b[0G\x1b[2K\x1b[?25h"; got != want {
+		t.Errorf("Restore() = %q, want %q", got, want)
 	}
 }

--- a/cmd/oras/internal/display/status/track/target_test.go
+++ b/cmd/oras/internal/display/status/track/target_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +46,7 @@ func (t *testReferenceGraphTarget) PushReference(ctx context.Context, expected o
 
 func Test_referenceGraphTarget_PushReference(t *testing.T) {
 	// prepare
-	pty, device, err := testutils.NewPty()
+	reader, device, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +80,7 @@ func Test_referenceGraphTarget_PushReference(t *testing.T) {
 		t.Fatal("not testing based on a referenceGraphTarget")
 	}
 	// validate
-	if err = testutils.MatchPty(pty, device, donePrompt, desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, device, donePrompt, desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -94,7 +92,7 @@ func Test_referenceGraphTarget_Mount(_ *testing.T) {
 
 func Test_graphTarget_Push_alreadyExists(t *testing.T) {
 	// prepare
-	pty, device, err := testutils.NewPty()
+	reader, device, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +128,7 @@ func Test_graphTarget_Push_alreadyExists(t *testing.T) {
 		t.Fatal("not testing based on a referenceGraphTarget")
 	}
 	// validate
-	if err = testutils.MatchPty(pty, device, donePrompt, desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, device, donePrompt, desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/internal/display/status/tty_console_test.go
+++ b/cmd/oras/internal/display/status/tty_console_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +30,7 @@ type testGraphTarget struct {
 
 func TestTTYPushHandler_TrackTarget(t *testing.T) {
 	// prepare pty
-	_, child, err := testutils.NewPty()
+	_, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +55,7 @@ func TestTTYPushHandler_TrackTarget(t *testing.T) {
 func Test_TTYPullHandler_TrackTarget(t *testing.T) {
 	src := memory.New()
 	t.Run("has TTY", func(t *testing.T) {
-		_, device, err := testutils.NewPty()
+		_, device, err := testutils.NewPipe()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,7 +85,7 @@ func Test_TTYPullHandler_TrackTarget(t *testing.T) {
 }
 
 func TestTTYCopyHandler_OnMounted(t *testing.T) {
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,13 +104,13 @@ func TestTTYCopyHandler_OnMounted(t *testing.T) {
 		t.Fatalf("StopTracking() should not return an error: %v", err)
 	}
 
-	if err = testutils.MatchPty(pty, child, "✓", "Mounted", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100.00%", mockFetcher.OciImage.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, child, "✓", "Mounted", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100.00%", mockFetcher.OciImage.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestTTYCopyHandler_OnCopySkipped(t *testing.T) {
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,13 +128,13 @@ func TestTTYCopyHandler_OnCopySkipped(t *testing.T) {
 	if err = ch.StopTracking(); err != nil {
 		t.Errorf("StopTracking() should not return an error: %v", err)
 	}
-	if err = testutils.MatchPty(pty, child, "Exists", "oci-image", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100.00%"); err != nil {
+	if err = testutils.MatchPipe(reader, child, "Exists", "oci-image", strconv.FormatInt(mockFetcher.OciImage.Size, 10), "100.00%"); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestTTYCopyHandler_PostCopy(t *testing.T) {
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,13 +152,13 @@ func TestTTYCopyHandler_PostCopy(t *testing.T) {
 	if err = ch.StopTracking(); err != nil {
 		t.Errorf("StopTracking() should not return an error: %v", err)
 	}
-	if err = testutils.MatchPty(pty, child, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
+	if err = testutils.MatchPipe(reader, child, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestTTYCopyHandler_PreCopy(t *testing.T) {
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +176,7 @@ func TestTTYCopyHandler_PreCopy(t *testing.T) {
 	if err = ch.StopTracking(); err != nil {
 		t.Errorf("StopTracking() should not return an error: %v", err)
 	}
-	if err = testutils.MatchPty(pty, child, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
+	if err = testutils.MatchPipe(reader, child, "\x1b[?25l\x1b7\x1b[0m"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/internal/display/status/tty_test.go
+++ b/cmd/oras/internal/display/status/tty_test.go
@@ -41,9 +41,9 @@ func TestTTYPushHandler_OnEmptyArtifact(t *testing.T) {
 }
 
 func TestTTYPushHandler_TrackTarget_invalidTTY(t *testing.T) {
-	ph := NewTTYPushHandler(os.Stdin, mockFetcher.Fetcher)
+	ph := NewTTYPushHandler(nil, mockFetcher.Fetcher)
 	if _, _, err := ph.TrackTarget(nil); err == nil {
-		t.Error("TrackTarget() should return an error for non-tty file")
+		t.Error("TrackTarget() should return an error for nil tty")
 	}
 }
 
@@ -116,10 +116,10 @@ func TestNewTTYBackupHandler(t *testing.T) {
 }
 
 func TestTTYBackupHandler_StartTracking_invalidTTY(t *testing.T) {
-	bh := NewTTYBackupHandler(os.Stdin, nil)
+	bh := NewTTYBackupHandler(nil, nil)
 	gt := memory.New()
 	if _, err := bh.StartTracking(gt); err == nil {
-		t.Error("StartTracking() should return an error for non-tty file")
+		t.Error("StartTracking() should return an error for nil tty")
 	}
 }
 
@@ -203,10 +203,10 @@ func TestNewTTYRestoreHandler(t *testing.T) {
 }
 
 func TestTTYRestoreHandler_StartTracking_invalidTTY(t *testing.T) {
-	rh := NewTTYRestoreHandler(os.Stdin, nil)
+	rh := NewTTYRestoreHandler(nil, nil)
 	gt := memory.New()
 	if _, err := rh.StartTracking(gt); err == nil {
-		t.Error("StartTracking() should return an error for non-tty file")
+		t.Error("StartTracking() should return an error for nil tty")
 	}
 }
 

--- a/cmd/oras/internal/option/terminal_test.go
+++ b/cmd/oras/internal/option/terminal_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +25,7 @@ import (
 )
 
 func TestTerminal_Parse(t *testing.T) {
-	_, device, err := testutils.NewPty()
+	_, device, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/oras/root/blob/fetch_test.go
+++ b/cmd/oras/root/blob/fetch_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +28,7 @@ import (
 
 func Test_fetchBlobOptions_doFetch(t *testing.T) {
 	// prepare
-	pty, device, err := testutils.NewPty()
+	reader, device, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +59,7 @@ func Test_fetchBlobOptions_doFetch(t *testing.T) {
 		t.Fatal(err)
 	}
 	// validate
-	if err = testutils.MatchPty(pty, device, "Downloaded  ", desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, device, "Downloaded  ", desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/root/blob/push_test.go
+++ b/cmd/oras/root/blob/push_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +30,7 @@ import (
 
 func Test_pushBlobOptions_doPush(t *testing.T) {
 	// prepare
-	pty, device, err := testutils.NewPty()
+	reader, device, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +51,7 @@ func Test_pushBlobOptions_doPush(t *testing.T) {
 		t.Fatal(err)
 	}
 	// validate
-	if err = testutils.MatchPty(pty, device, "Uploaded", desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, device, "Uploaded", desc.MediaType, "100.00%", desc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,7 +125,7 @@ func TestMain(m *testing.M) {
 
 func Test_doCopy(t *testing.T) {
 	// prepare
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,14 +141,14 @@ func Test_doCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	// validate
-	if err = testutils.MatchPty(pty, child, "Copied", memDesc.MediaType, "100.00%", memDesc.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, child, "Copied", memDesc.MediaType, "100.00%", memDesc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func Test_doCopy_skipped(t *testing.T) {
 	// prepare
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,14 +164,14 @@ func Test_doCopy_skipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	// validate
-	if err = testutils.MatchPty(pty, child, "Exists", memDesc.MediaType, "100.00%", memDesc.Digest.String()); err != nil {
+	if err = testutils.MatchPipe(reader, child, "Exists", memDesc.MediaType, "100.00%", memDesc.Digest.String()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func Test_doCopy_mounted(t *testing.T) {
 	// prepare
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +198,7 @@ func Test_doCopy_mounted(t *testing.T) {
 		t.Fatal(err)
 	}
 	// validate
-	if err = testutils.MatchPty(pty, child, "Mounted", configMediaType, "100.00%", configDigest); err != nil {
+	if err = testutils.MatchPipe(reader, child, "Mounted", configMediaType, "100.00%", configDigest); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -280,7 +278,7 @@ func Test_doCopy_mountFallback(t *testing.T) {
 	testHost := "localhost:" + uri.Port()
 
 	// prepare
-	pty, child, err := testutils.NewPty()
+	reader, child, err := testutils.NewPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +313,7 @@ func Test_doCopy_mountFallback(t *testing.T) {
 		t.Error("expected blob to be uploaded via regular upload after mount failure")
 	}
 	// validate output shows "Copied" instead of "Mounted"
-	if err = testutils.MatchPty(pty, child, "Copied", configMediaType, "100.00%", configDigest); err != nil {
+	if err = testutils.MatchPipe(reader, child, "Copied", configMediaType, "100.00%", configDigest); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.7
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/containerd/console v1.0.5
 	github.com/morikuni/aec v1.1.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
-github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
-github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -60,7 +58,6 @@ golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=

--- a/internal/testutils/console.go
+++ b/internal/testutils/console.go
@@ -1,5 +1,3 @@
-//go:build !windows && !darwin
-
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,35 +22,27 @@ import (
 	"os"
 	"strings"
 	"sync"
-
-	containerd "github.com/containerd/console"
 )
 
-// NewPty creates a new pty pair for testing, caller is responsible for closing
-// the returned device file if err is not nil.
-func NewPty() (containerd.Console, *os.File, error) {
-	pty, devicePath, err := containerd.NewPty()
-	if err != nil {
-		return nil, nil, err
-	}
-	device, err := os.OpenFile(devicePath, os.O_RDWR, 0)
-	if err != nil {
-		return nil, nil, err
-	}
-	return pty, device, nil
+// NewPipe creates an in-memory pipe that stands in for a terminal in tests.
+// The returned writer is passed to the code under test as the TTY device; the
+// returned reader captures everything written to it. The caller is responsible
+// for closing the writer (see MatchPipe, which closes it).
+func NewPipe() (reader *os.File, writer *os.File, err error) {
+	return os.Pipe()
 }
 
-// MatchPty checks that the output matches the expected strings in specified
-// order.
-func MatchPty(pty containerd.Console, device *os.File, expected ...string) error {
+// MatchPipe closes the writer, drains the reader and checks that the captured
+// output contains the expected strings in the specified order.
+func MatchPipe(reader, writer *os.File, expected ...string) error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	var buffer bytes.Buffer
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(&buffer, pty)
+		_, _ = io.Copy(&buffer, reader)
 	}()
-	_ = device.Close()
+	_ = writer.Close()
 	wg.Wait()
 
 	return OrderedMatch(buffer.String(), expected...)


### PR DESCRIPTION
## Summary
- Replaces the effectively-unmaintained `github.com/containerd/console` (notably a long-standing macOS bug) with `golang.org/x/term`, maintained by the Go team and working on linux, mac and windows.
- The `console` package now renders to an internal `terminal` seam backed by `x/term`, keeping the terminal library isolated behind an interface so the backend can be swapped or extended later without touching callers. Cursor/escape-code logic is unchanged.
- Test helpers no longer create a real pty (`containerd.NewPty`); they use `os.Pipe` via `testutils.NewPipe`/`MatchPipe`, so the previously linux-only TTY tests now run on **all platforms** (no creack/pty, no ConPTY, no x/sys).

## Note for reviewers
Terminal detection already lives in `option.Terminal.Parse` (gating on `term.IsTerminal(os.Stderr)` before any TTY handler is constructed). The previous containerd-based `NewConsole` also rejected non-terminal files as defense-in-depth; that check is now redundant, so `NewConsole` rejects only a `nil` file. The three `*_invalidTTY` handler tests were updated to pass `nil` accordingly. Happy to thread an injectable console through the handler chain instead if you'd prefer to keep the non-terminal rejection.

Closes: #1449

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` for affected packages, now passing on macOS (previously skipped)