### PR TITLE
test: validate unreleased oras-go v2.6.1 security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
-	oras.land/oras-go/v2 v2.6.0
+	oras.land/oras-go/v2 v2.6.1-0.20260531015227-3c2e884e12ea
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -68,5 +68,5 @@ golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
-oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
+oras.land/oras-go/v2 v2.6.1-0.20260531015227-3c2e884e12ea h1:QRPk9tkRMz61o5uQDjYKQVBh/WWVrR0NIyzETGh9mtM=
+oras.land/oras-go/v2 v2.6.1-0.20260531015227-3c2e884e12ea/go.mod h1:dhtFrFOuZuDtAVeZ9FUnaa5zfzplG3ZnFX9/uH1J/Yk=


### PR DESCRIPTION
## Purpose

Functional test of the unreleased **oras-go v2.6.1** security fixes against the `oras` CLI, ahead of the v2.6.1 release ([oras-project/oras-go#1195](https://github.com/oras-project/oras-go/pull/1195)).

This bumps `oras.land/oras-go/v2` to a pseudo-version of the current `v2` branch head (`3c2e884`), which contains all five security fixes:

- Drop `Authorization` on cross-origin redirects — GHSA-vh4v-2xq2-g5cg
- Validate bearer `realm` host — GHSA-28r5-37g7-p6mp / GHSA-xf85-363p-868w
- Validate `Location` host before blob upload (SSRF) — GHSA-jxpm-75mh-9fp7
- Reject oversized descriptors in `ReadAll` (DoS) — GHSA-f36w-mj3v-6jqv
- Resolve symlinks when enforcing the write boundary

## Local verification

- `go build ./...` — clean
- `go vet ./cmd/... ./internal/...` — clean
- `go test ./...` — all unit packages pass
- Confirmed the fix code is present in the resolved module (`validateRealm`, the redirect `Authorization` drop, `sameUploadHost`, `maxDescriptorSize`, symlink-escape check)

## Note

⚠️ **Not intended to merge as-is** — it pins a pseudo-version. Once oras-go v2.6.1 is tagged, this would be updated to `oras.land/oras-go/v2 v2.6.1`. Opened to run the full CI suite against the unreleased dependency.
