### PR TITLE
bump: tag and release ORAS CLI v1.3.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,9 +17,9 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.3.0"
+	Version = "1.3.3"
 	// BuildMetadata is the extra build time data
-	BuildMetadata = "unreleased"
+	BuildMetadata = ""
 	// GitCommit is the git sha1
 	GitCommit = ""
 	// GitTreeState is the state of the git tree


### PR DESCRIPTION
## Release v1.3.3

This PR bumps the version to v1.3.3 for the upcoming release.

### Checklist
- [ ] Version updated in `internal/version/version.go`
- [ ] CI checks pass
- [ ] Vote called in the ORAS Slack channel
- [ ] Super-majority of approval from ORAS maintainers