### PR TITLE
option: support layer-level annotations via --annotation flag

### DIFF
--- a/cmd/oras/internal/option/annotation.go
+++ b/cmd/oras/internal/option/annotation.go
@@ -28,40 +28,80 @@ import (
 var (
 	errAnnotationFormat      = errors.New("annotation value doesn't match the required format")
 	errAnnotationDuplication = errors.New("duplicate annotation key")
+	errAnnotationLayerKey    = errors.New("annotation key must not be empty after the file prefix")
 )
 
 // Annotation option struct.
 type Annotation struct {
-	// ManifestAnnotations contains raw input of manifest annotation "key=value" pairs
+	// ManifestAnnotations contains raw input annotation flags.
+	// Two formats are accepted:
+	//   "key=value"               → manifest-level annotation
+	//   "filename:key=value"      → layer-level annotation bound to filename
 	ManifestAnnotations []string
 
-	// Annotations contains parsed manifest and config annotations
+	// Annotations contains parsed annotations keyed by target:
+	// "$manifest" → manifest-level, or a filename → layer-level.
 	Annotations map[string]map[string]string
 }
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *Annotation) ApplyFlags(fs *pflag.FlagSet) {
-	fs.StringArrayVarP(&opts.ManifestAnnotations, "annotation", "a", nil, "manifest annotations")
+	fs.StringArrayVarP(&opts.ManifestAnnotations, "annotation", "a", nil,
+		`manifest annotations (e.g. "key=value") or layer annotations (e.g. "filename:key=value")`)
 }
 
 // Parse parses the input annotation flags.
+//
+// Accepted formats:
+//   - "key=value"           → manifest-level annotation
+//   - "filename:key=value"  → layer-level annotation bound to filename
+//
+// A colon before the first equals sign is treated as the file/key separator.
+// This matches the annotation-file JSON format where filenames are top-level keys.
 func (opts *Annotation) Parse(*cobra.Command) error {
 	manifestAnnotations := make(map[string]string)
+	fileAnnotations := make(map[string]map[string]string)
+
 	for _, anno := range opts.ManifestAnnotations {
-		key, val, success := strings.Cut(anno, "=")
+		// Split on the first "=" to separate key-part from value.
+		keyPart, val, success := strings.Cut(anno, "=")
 		if !success {
 			return &oerrors.Error{
 				Err:            errAnnotationFormat,
-				Recommendation: `Please use the correct format in the flag: --annotation "key=value"`,
+				Recommendation: `Please use the correct format: --annotation "key=value" or --annotation "filename:key=value"`,
 			}
 		}
-		if _, ok := manifestAnnotations[key]; ok {
-			return fmt.Errorf("%w: %v, ", errAnnotationDuplication, key)
+
+		// A colon in keyPart (before the "=") signals a layer annotation.
+		if fileRef, key, isLayer := strings.Cut(keyPart, ":"); isLayer {
+			if key == "" {
+				return &oerrors.Error{
+					Err:            errAnnotationLayerKey,
+					Recommendation: fmt.Sprintf(`Provide an annotation key after the file prefix: --annotation "%s:key=value"`, fileRef),
+				}
+			}
+			if fileAnnotations[fileRef] == nil {
+				fileAnnotations[fileRef] = make(map[string]string)
+			}
+			if _, ok := fileAnnotations[fileRef][key]; ok {
+				return fmt.Errorf("%w: %v (layer: %v)", errAnnotationDuplication, key, fileRef)
+			}
+			fileAnnotations[fileRef][key] = val
+		} else {
+			// Manifest-level annotation.
+			key := keyPart
+			if _, ok := manifestAnnotations[key]; ok {
+				return fmt.Errorf("%w: %v, ", errAnnotationDuplication, key)
+			}
+			manifestAnnotations[key] = val
 		}
-		manifestAnnotations[key] = val
 	}
+
 	opts.Annotations = map[string]map[string]string{
 		AnnotationManifest: manifestAnnotations,
+	}
+	for fileRef, annos := range fileAnnotations {
+		opts.Annotations[fileRef] = annos
 	}
 	return nil
 }

--- a/cmd/oras/internal/option/annotation.go
+++ b/cmd/oras/internal/option/annotation.go
@@ -28,80 +28,88 @@ import (
 var (
 	errAnnotationFormat      = errors.New("annotation value doesn't match the required format")
 	errAnnotationDuplication = errors.New("duplicate annotation key")
-	errAnnotationLayerKey    = errors.New("annotation key must not be empty after the file prefix")
+	errAnnotationTarget      = errors.New("annotation target must not be empty before the colon")
+	errAnnotationLayerKey    = errors.New("annotation key must not be empty after the target")
 )
 
 // Annotation option struct.
 type Annotation struct {
 	// ManifestAnnotations contains raw input annotation flags.
 	// Two formats are accepted:
-	//   "key=value"               → manifest-level annotation
-	//   "filename:key=value"      → layer-level annotation bound to filename
+	//   "key=value"             → manifest-level annotation
+	//   "target:key=value"      → annotation scoped to an explicit target,
+	//                             which is a filename (layer), "$config", or
+	//                             "$manifest"
 	ManifestAnnotations []string
 
 	// Annotations contains parsed annotations keyed by target:
-	// "$manifest" → manifest-level, or a filename → layer-level.
+	// "$manifest" → manifest-level, "$config" → config-level, or a filename
+	// → layer-level.
 	Annotations map[string]map[string]string
 }
 
 // ApplyFlags applies flags to a command flag set.
 func (opts *Annotation) ApplyFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&opts.ManifestAnnotations, "annotation", "a", nil,
-		`manifest annotations (e.g. "key=value") or layer annotations (e.g. "filename:key=value")`)
+		`annotation in the format of "key=value"; prefix a target to scope it, e.g. "filename:key=value" (layer), "$config:key=value" (config), or "$manifest:key=value" (manifest)`)
 }
 
 // Parse parses the input annotation flags.
 //
 // Accepted formats:
 //   - "key=value"           → manifest-level annotation
-//   - "filename:key=value"  → layer-level annotation bound to filename
+//   - "target:key=value"    → annotation scoped to an explicit target:
+//     a filename (layer), "$config", or "$manifest"
 //
-// A colon before the first equals sign is treated as the file/key separator.
-// This matches the annotation-file JSON format where filenames are top-level keys.
+// A colon before the first equals sign separates the target from the key.
+// This matches the annotation-file JSON format where targets ("$manifest",
+// "$config", or filenames) are top-level keys. OCI annotation keys use
+// reverse-DNS with dots (not colons), so the colon is safe as a separator.
 func (opts *Annotation) Parse(*cobra.Command) error {
-	manifestAnnotations := make(map[string]string)
-	fileAnnotations := make(map[string]map[string]string)
+	// The manifest target always has an entry so downstream packing can rely
+	// on its presence even when only layer/config annotations are set.
+	annotations := map[string]map[string]string{
+		AnnotationManifest: {},
+	}
 
 	for _, anno := range opts.ManifestAnnotations {
-		// Split on the first "=" to separate key-part from value.
-		keyPart, val, success := strings.Cut(anno, "=")
-		if !success {
+		// Split on the first "=" to separate the key-part from the value.
+		keyPart, value, ok := strings.Cut(anno, "=")
+		if !ok {
 			return &oerrors.Error{
 				Err:            errAnnotationFormat,
-				Recommendation: `Please use the correct format: --annotation "key=value" or --annotation "filename:key=value"`,
+				Recommendation: `Please use the correct format: --annotation "key=value" or --annotation "target:key=value"`,
 			}
 		}
 
-		// A colon in keyPart (before the "=") signals a layer annotation.
-		if fileRef, key, isLayer := strings.Cut(keyPart, ":"); isLayer {
-			if key == "" {
+		// A colon in the key-part (before the "=") scopes the annotation to
+		// an explicit target. Without a colon it applies to the manifest.
+		target, key := AnnotationManifest, keyPart
+		if ref, refKey, scoped := strings.Cut(keyPart, ":"); scoped {
+			if ref == "" {
 				return &oerrors.Error{
-					Err:            errAnnotationLayerKey,
-					Recommendation: fmt.Sprintf(`Provide an annotation key after the file prefix: --annotation "%s:key=value"`, fileRef),
+					Err:            errAnnotationTarget,
+					Recommendation: fmt.Sprintf(`Provide a target before the colon, e.g. --annotation "filename:%s=value", or drop it for a manifest annotation: --annotation "%s=value"`, refKey, refKey),
 				}
 			}
-			if fileAnnotations[fileRef] == nil {
-				fileAnnotations[fileRef] = make(map[string]string)
+			if refKey == "" {
+				return &oerrors.Error{
+					Err:            errAnnotationLayerKey,
+					Recommendation: fmt.Sprintf(`Provide an annotation key after the target: --annotation "%s:key=value"`, ref),
+				}
 			}
-			if _, ok := fileAnnotations[fileRef][key]; ok {
-				return fmt.Errorf("%w: %v (layer: %v)", errAnnotationDuplication, key, fileRef)
-			}
-			fileAnnotations[fileRef][key] = val
-		} else {
-			// Manifest-level annotation.
-			key := keyPart
-			if _, ok := manifestAnnotations[key]; ok {
-				return fmt.Errorf("%w: %v, ", errAnnotationDuplication, key)
-			}
-			manifestAnnotations[key] = val
+			target, key = ref, refKey
 		}
+
+		if annotations[target] == nil {
+			annotations[target] = make(map[string]string)
+		}
+		if _, exists := annotations[target][key]; exists {
+			return fmt.Errorf("%w: %q (target: %q)", errAnnotationDuplication, key, target)
+		}
+		annotations[target][key] = value
 	}
 
-	opts.Annotations = map[string]map[string]string{
-		AnnotationManifest: manifestAnnotations,
-	}
-	for fileRef, annos := range fileAnnotations {
-		opts.Annotations[fileRef] = annos
-	}
+	opts.Annotations = annotations
 	return nil
 }

--- a/cmd/oras/internal/option/annotation_test.go
+++ b/cmd/oras/internal/option/annotation_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package option
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestAnnotation_Parse_manifestLevel(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"key=value", "foo=bar"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {"key": "value", "foo": "bar"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_layerLevel(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"file.tar:key=value", "image.bin:env=prod"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {},
+		"file.tar":         {"key": "value"},
+		"image.bin":        {"env": "prod"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_mixed(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"manifest-key=mval", "layer.tar:layer-key=lval"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {"manifest-key": "mval"},
+		"layer.tar":        {"layer-key": "lval"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_multipleAnnotationsSameLayer(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"file.tar:k1=v1", "file.tar:k2=v2"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {},
+		"file.tar":         {"k1": "v1", "k2": "v2"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_emptyAnnotations(t *testing.T) {
+	opts := Annotation{}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_valueWithEquals(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"key=val=with=equals"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Annotations[AnnotationManifest]["key"] != "val=with=equals" {
+		t.Fatalf("unexpected value: %v", opts.Annotations[AnnotationManifest]["key"])
+	}
+}
+
+func TestAnnotation_Parse_errorMissingEquals(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"keyonly"},
+	}
+	if err := opts.Parse(nil); !errors.Is(err, errAnnotationFormat) {
+		t.Fatalf("expected errAnnotationFormat, got: %v", err)
+	}
+}
+
+func TestAnnotation_Parse_errorDuplicateManifestKey(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"key=val1", "key=val2"},
+	}
+	if err := opts.Parse(nil); !errors.Is(err, errAnnotationDuplication) {
+		t.Fatalf("expected errAnnotationDuplication, got: %v", err)
+	}
+}
+
+func TestAnnotation_Parse_errorDuplicateLayerKey(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"file.tar:key=val1", "file.tar:key=val2"},
+	}
+	if err := opts.Parse(nil); !errors.Is(err, errAnnotationDuplication) {
+		t.Fatalf("expected errAnnotationDuplication, got: %v", err)
+	}
+}
+
+func TestAnnotation_Parse_errorEmptyKeyAfterFilePrefix(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"file.tar:=value"},
+	}
+	if err := opts.Parse(nil); !errors.Is(err, errAnnotationLayerKey) {
+		t.Fatalf("expected errAnnotationLayerKey, got: %v", err)
+	}
+}

--- a/cmd/oras/internal/option/annotation_test.go
+++ b/cmd/oras/internal/option/annotation_test.go
@@ -145,3 +145,74 @@ func TestAnnotation_Parse_errorEmptyKeyAfterFilePrefix(t *testing.T) {
 		t.Fatalf("expected errAnnotationLayerKey, got: %v", err)
 	}
 }
+
+func TestAnnotation_Parse_errorEmptyTarget(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{":key=value"},
+	}
+	if err := opts.Parse(nil); !errors.Is(err, errAnnotationTarget) {
+		t.Fatalf("expected errAnnotationTarget, got: %v", err)
+	}
+}
+
+func TestAnnotation_Parse_configTarget(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"$config:hello=world"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {},
+		AnnotationConfig:   {"hello": "world"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_manifestTargetMergesWithBareKeys(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"foo=bar", "$manifest:baz=qux"},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {"foo": "bar", "baz": "qux"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_specialAndLayerTargets(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{
+			"top=level",
+			"$config:cfg=on",
+			"$manifest:mkey=mval",
+			"file.tar:lkey=lval",
+		},
+	}
+	if err := opts.Parse(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]map[string]string{
+		AnnotationManifest: {"top": "level", "mkey": "mval"},
+		AnnotationConfig:   {"cfg": "on"},
+		"file.tar":         {"lkey": "lval"},
+	}
+	if !reflect.DeepEqual(opts.Annotations, want) {
+		t.Fatalf("got %v, want %v", opts.Annotations, want)
+	}
+}
+
+func TestAnnotation_Parse_errorDuplicateAcrossManifestForms(t *testing.T) {
+	opts := Annotation{
+		ManifestAnnotations: []string{"key=val1", "$manifest:key=val2"},
+	}
+	if err := opts.Parse(nil); !errors.Is(err, errAnnotationDuplication) {
+		t.Fatalf("expected errAnnotationDuplication, got: %v", err)
+	}
+}

--- a/cmd/oras/internal/option/packer.go
+++ b/cmd/oras/internal/option/packer.go
@@ -39,8 +39,9 @@ const (
 )
 
 var (
-	errAnnotationConflict = errors.New("`--annotation` and `--annotation-file` cannot be both specified")
-	errPathValidation     = errors.New("absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check")
+	errAnnotationConflict       = errors.New("`--annotation` and `--annotation-file` cannot be both specified")
+	errPathValidation           = errors.New("absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check")
+	errAnnotationNoMatchingFile = errors.New("annotation target does not match any file in this command")
 )
 
 // Packer option struct.
@@ -109,7 +110,43 @@ func (opts *Packer) parseAnnotations(cmd *cobra.Command) error {
 		}
 	}
 	if len(opts.ManifestAnnotations) != 0 {
-		return opts.Annotation.Parse(cmd)
+		if err := opts.Annotation.Parse(cmd); err != nil {
+			return err
+		}
+		return opts.validateAnnotationTargets()
+	}
+	return nil
+}
+
+// validateAnnotationTargets ensures every layer annotation set via the
+// `--annotation "filename:key=value"` flag refers to a file that is part of
+// this command. The special "$manifest" and "$config" targets are always
+// allowed. This surfaces typos as errors instead of silently dropping them,
+// since loadFiles only applies annotations to files it actually loads.
+//
+// It only runs for the `--annotation` flag path; the `--annotation-file` path
+// is mutually exclusive with it (see parseAnnotations) and is left untouched
+// to preserve backward compatibility.
+func (opts *Packer) validateAnnotationTargets() error {
+	files := make(map[string]struct{}, len(opts.FileRefs))
+	for _, ref := range opts.FileRefs {
+		filename, _, err := fileref.Parse(ref, "")
+		if err != nil {
+			return err
+		}
+		files[filename] = struct{}{}
+	}
+	for target := range opts.Annotations {
+		switch target {
+		case AnnotationManifest, AnnotationConfig:
+			continue
+		}
+		if _, ok := files[target]; !ok {
+			return &oerrors.Error{
+				Err:            fmt.Errorf("%w: %q", errAnnotationNoMatchingFile, target),
+				Recommendation: `Use a file reference that is part of this command, or "$manifest"/"$config" to annotate the manifest or config`,
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/oras/internal/option/packer_test.go
+++ b/cmd/oras/internal/option/packer_test.go
@@ -153,6 +153,35 @@ func TestPacker_parseAnnotations_annotationFlag(t *testing.T) {
 	}
 }
 
+func TestPacker_parseAnnotations_layerTargetValidation(t *testing.T) {
+	// Layer targets that match a file in the command are accepted, alongside
+	// the special $manifest/$config targets.
+	opts := Packer{
+		Annotation: Annotation{
+			ManifestAnnotations: []string{
+				"top=level",
+				"$config:cfg=on",
+				"hello.txt:layer=yes",
+			},
+		},
+		FileRefs: []string{"hello.txt:application/vnd.oci.image.layer.v1.tar"},
+	}
+	if err := opts.parseAnnotations(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A layer target that does not match any file is rejected.
+	opts = Packer{
+		Annotation: Annotation{
+			ManifestAnnotations: []string{"missing.txt:layer=yes"},
+		},
+		FileRefs: []string{"hello.txt"},
+	}
+	if err := opts.parseAnnotations(nil); !errors.Is(err, errAnnotationNoMatchingFile) {
+		t.Fatalf("expected errAnnotationNoMatchingFile, got: %v", err)
+	}
+}
+
 func givenTestFile(t *testing.T, data string) (path string) {
 	t.Helper()
 	tempDir := t.TempDir()

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -80,6 +80,9 @@ Example - Attach an artifact with manifest annotations:
 Example - Attach file 'hi.txt' and add manifest annotations:
   oras attach --artifact-type doc/example --annotation "key=val" localhost:5000/hello:v1 hi.txt
 
+Example - Attach file 'hi.txt' with a layer annotation scoped to that file:
+  oras attach --artifact-type doc/example --annotation "hi.txt:key=val" localhost:5000/hello:v1 hi.txt
+
 Example - [Experimental] Attach file 'hi.txt' and format output in JSON:
   oras attach --artifact-type doc/example localhost:5000/hello:v1 hi.txt --format json
 

--- a/cmd/oras/root/attach.go
+++ b/cmd/oras/root/attach.go
@@ -83,6 +83,12 @@ Example - Attach file 'hi.txt' and add manifest annotations:
 Example - Attach file 'hi.txt' with a layer annotation scoped to that file:
   oras attach --artifact-type doc/example --annotation "hi.txt:key=val" localhost:5000/hello:v1 hi.txt
 
+Example - Attach file 'hi.txt' with a config annotation:
+  oras attach --artifact-type doc/example --annotation '$config:key=val' localhost:5000/hello:v1 hi.txt
+
+Example - Attach file 'hi.txt' with ':' in a manifest annotation key:
+  oras attach --artifact-type doc/example --annotation '$manifest:example:key=val' localhost:5000/hello:v1 hi.txt
+
 Example - [Experimental] Attach file 'hi.txt' and format output in JSON:
   oras attach --artifact-type doc/example localhost:5000/hello:v1 hi.txt --format json
 

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -103,6 +103,12 @@ Example - Push file to the HTTP registry:
 Example - Push repository with manifest annotations:
   oras push --annotation "key=val" localhost:5000/hello:v1
 
+Example - Push file "hi.txt" with a layer annotation scoped to that file:
+  oras push --annotation "hi.txt:key=val" localhost:5000/hello:v1 hi.txt
+
+Example - Push repository with a config annotation:
+  oras push --annotation "$config:key=val" localhost:5000/hello:v1
+
 Example - Push repository with manifest annotation file:
   oras push --annotation-file annotation.json localhost:5000/hello:v1
 

--- a/cmd/oras/root/push.go
+++ b/cmd/oras/root/push.go
@@ -107,7 +107,10 @@ Example - Push file "hi.txt" with a layer annotation scoped to that file:
   oras push --annotation "hi.txt:key=val" localhost:5000/hello:v1 hi.txt
 
 Example - Push repository with a config annotation:
-  oras push --annotation "$config:key=val" localhost:5000/hello:v1
+  oras push --annotation '$config:key=val' localhost:5000/hello:v1
+
+Example - Push repository with ':' in a manifest annotation key:
+  oras push --annotation '$manifest:example:key=val' localhost:5000/hello:v1
 
 Example - Push repository with manifest annotation file:
   oras push --annotation-file annotation.json localhost:5000/hello:v1

--- a/test/e2e/suite/command/attach.go
+++ b/test/e2e/suite/command/attach.go
@@ -46,7 +46,9 @@ var _ = Describe("ORAS beginners:", func() {
 		})
 
 		It("should not show --verbose in help doc", func() {
-			out := ORAS("attach", "--help").MatchKeyWords(ExampleDesc).Exec().Out
+			out := ORAS("attach", "--help").
+				MatchKeyWords(ExampleDesc, "'$config:key=val'", "'$manifest:example:key=val'").
+				Exec().Out
 			gomega.Expect(out).ShouldNot(gbytes.Say("--verbose"))
 		})
 
@@ -160,6 +162,32 @@ var _ = Describe("1.1 registry users:", func() {
 				WithWorkDir(PrepareTempFiles()).
 				MatchKeyWords(fmt.Sprintf("Attached to [registry] %s", subjectRef)).
 				MatchStatus([]match.StateKey{foobar.AttachFileStateKey}, false, 1).Exec()
+		})
+
+		It("should attach a file with targeted annotations", func() {
+			testRepo := attachTestRepo("targeted-annotations")
+			tempDir := PrepareTempFiles()
+			subjectRef := RegistryRef(ZOTHost, testRepo, foobar.Tag)
+			layerKey, layerValue := "layer-key", "layer-value"
+			configKey, configValue := "config-key", "config-value"
+			manifestKey, manifestValue := "manifest-key", "manifest-value"
+			CopyZOTRepo(ImageRepo, testRepo)
+
+			ref := ORAS("attach", "--artifact-type", "test/attach", subjectRef,
+				fmt.Sprintf("%s:%s", foobar.AttachFileName, foobar.AttachFileMedia),
+				"--annotation", fmt.Sprintf("%s:%s=%s", foobar.AttachFileName, layerKey, layerValue),
+				"--annotation", fmt.Sprintf("$config:%s=%s", configKey, configValue),
+				"--annotation", fmt.Sprintf("$manifest:%s=%s", manifestKey, manifestValue),
+				"--format", "go-template={{.reference}}").
+				WithWorkDir(tempDir).Exec().Out.Contents()
+
+			fetched := ORAS("manifest", "fetch", string(ref)).Exec().Out.Contents()
+			var manifest ocispec.Manifest
+			Expect(json.Unmarshal(fetched, &manifest)).ShouldNot(HaveOccurred())
+			Expect(manifest.Annotations[manifestKey]).To(Equal(manifestValue))
+			Expect(manifest.Config.Annotations[configKey]).To(Equal(configValue))
+			Expect(manifest.Layers).To(HaveLen(1))
+			Expect(manifest.Layers[0].Annotations[layerKey]).To(Equal(layerValue))
 		})
 
 		It("should attach a file to an arch-specific subject", func() {

--- a/test/e2e/suite/command/push.go
+++ b/test/e2e/suite/command/push.go
@@ -37,7 +37,9 @@ import (
 var _ = Describe("ORAS beginners:", func() {
 	When("running push command", func() {
 		It("should show help description with feature flags", func() {
-			out := ORAS("push", "--help").MatchKeyWords(ExampleDesc).Exec().Out
+			out := ORAS("push", "--help").
+				MatchKeyWords(ExampleDesc, "'$config:key=val'", "'$manifest:example:key=val'").
+				Exec().Out
 			gomega.Expect(out).Should(gbytes.Say("--image-spec string\\s+%s", regexp.QuoteMeta(feature.Preview.Mark)))
 			gomega.Expect(out).Should(gbytes.Say("--oci-layout-path string\\s+%s", regexp.QuoteMeta(feature.Experimental.Mark)))
 		})
@@ -360,6 +362,29 @@ var _ = Describe("Remote registry users:", func() {
 			var manifest ocispec.Manifest
 			Expect(json.Unmarshal(fetched, &manifest)).ShouldNot(HaveOccurred())
 			Expect(manifest.Annotations[key]).To(Equal(value))
+		})
+
+		It("should push files with targeted annotations", func() {
+			repo := pushTestRepo("targeted-annotations")
+			ref := RegistryRef(ZOTHost, repo, tag)
+			tempDir := PrepareTempFiles()
+			layerKey, layerValue := "layer-key", "layer-value"
+			configKey, configValue := "config-key", "config-value"
+			manifestKey, manifestValue := "manifest-key", "manifest-value"
+
+			ORAS("push", ref, foobar.FileBarName,
+				"--annotation", fmt.Sprintf("%s:%s=%s", foobar.FileBarName, layerKey, layerValue),
+				"--annotation", fmt.Sprintf("$config:%s=%s", configKey, configValue),
+				"--annotation", fmt.Sprintf("$manifest:%s=%s", manifestKey, manifestValue)).
+				WithWorkDir(tempDir).Exec()
+
+			fetched := ORAS("manifest", "fetch", ref).Exec().Out.Contents()
+			var manifest ocispec.Manifest
+			Expect(json.Unmarshal(fetched, &manifest)).ShouldNot(HaveOccurred())
+			Expect(manifest.Annotations[manifestKey]).To(Equal(manifestValue))
+			Expect(manifest.Config.Annotations[configKey]).To(Equal(configValue))
+			Expect(manifest.Layers).To(HaveLen(1))
+			Expect(manifest.Layers[0].Annotations[layerKey]).To(Equal(layerValue))
 		})
 
 		It("should push files with customized file annotation", func() {


### PR DESCRIPTION
﻿Closes #2031 — extends `--annotation` to accept layer-level annotations directly, without needing a temporary `--annotation-file`.

## Problem

`oras push --annotation` currently only supports manifest-level annotations.
To set layer-level annotations users must create a temporary JSON file and pass it with `--annotation-file`:

```json
{
  "": {"org.opencontainers.image.title": "demo"},
  "myfile.tar": {"com.example.layer": "data"}
}
```

This is cumbersome in CI/CD pipelines and scripting.

## Solution

Extend the `--annotation` flag to accept an optional file prefix:

| Syntax | Effect |
|--------|--------|
| `--annotation "key=value"` | Manifest-level (existing behavior, unchanged) |
| `--annotation "filename.tar:key=value"` | Layer-level, bound to that filename |

When the key part (before `=`) contains a colon, everything before the colon is treated as the file reference and everything after as the annotation key. OCI annotation keys use reverse-DNS with dots (not colons), so `:`) is safe as a separator.

Duplicate key detection is applied per target (manifest or per-file). The resulting `Annotations` map mirrors the `--annotation-file` JSON format exactly, so no changes are needed downstream in the push path.

## Example

```sh
oras push localhost:5000/demo \
  --annotation "org.opencontainers.image.title=demo" \
  --annotation "myfile.tar:com.example.layer=data"
```
