### PR TITLE
test: fix unused test parameters

### DIFF
--- a/cmd/oras/root/discover_test.go
+++ b/cmd/oras/root/discover_test.go
@@ -32,7 +32,7 @@ type cyclicReferrerTarget struct {
 	referrers map[digest.Digest][]ocispec.Descriptor
 }
 
-func (t *cyclicReferrerTarget) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
+func (t *cyclicReferrerTarget) Referrers(_ context.Context, desc ocispec.Descriptor, _ string, fn func(referrers []ocispec.Descriptor) error) error {
 	return fn(t.referrers[desc.Digest])
 }
 
@@ -57,7 +57,7 @@ type recordingDiscoverHandler struct {
 	count int
 }
 
-func (h *recordingDiscoverHandler) OnDiscovered(referrer, subject ocispec.Descriptor) error {
+func (h *recordingDiscoverHandler) OnDiscovered(_, _ ocispec.Descriptor) error {
 	h.count++
 	return nil
 }

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -253,7 +253,7 @@ func TestRecursiveFindReferrers(t *testing.T) {
 		descA := ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest, Digest: digest.FromString("A"), Size: 1}
 		descB := ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest, Digest: digest.FromString("B"), Size: 1}
 		opts := oras.DefaultExtendedCopyGraphOptions
-		opts.FindPredecessors = func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		opts.FindPredecessors = func(_ context.Context, _ content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			switch desc.Digest {
 			case descA.Digest:
 				return []ocispec.Descriptor{descB}, nil


### PR DESCRIPTION
### What does this PR change?

Renames unused test-helper callback parameters to `_` so revive no longer reports unused-parameter lint failures.

Fixes #2092.

### Verification

- `mise x go@1.25.7 golangci-lint@2.12.2 -- sh -lc 'gofmt -w cmd/oras/root/discover_test.go internal/graph/graph_test.go && go test ./cmd/oras/root ./internal/graph && golangci-lint run ./...'`