### PR TITLE
feat: sign release checksums in the release workflow

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -34,6 +34,11 @@ jobs:
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           syft-version: v1.32.0
+      - name: Import GPG signing key
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -41,3 +46,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,16 @@ sboms:
 release:
   draft: true
   prerelease: auto
-#signs:
-#  - artifacts: all
-#    args: ["--output", "${signature}", "--detach-sign", "--armor", "${artifact}"]
-#    signature: "${artifact}.asc"
+
+signs:
+  - artifacts: checksum
+    signature: "${artifact}.asc"
+    args:
+      - "--batch"
+      - "--pinentry-mode=loopback"
+      - "--passphrase={{ .Env.GPG_PASSPHRASE }}"
+      - "--local-user=C6FC42F0DE84A345FAADB742F44418110791EF37"
+      - "--output=${signature}"
+      - "--detach-sign"
+      - "--armor"
+      - "${artifact}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,7 @@ release:
   prerelease: auto
 
 signs:
-  - artifacts: checksum
+  - artifacts: all
     signature: "${artifact}.asc"
     args:
       - "--batch"

--- a/KEYS
+++ b/KEYS
@@ -7,6 +7,16 @@ For users to import keys:
        or
        gpg --import KEYS
 
+To verify a release, download the checksums file and its detached
+signature from the release assets, then verify with the imported keys:
+       gpg --import KEYS
+       gpg --verify oras_<version>_checksums.txt.asc oras_<version>_checksums.txt
+
+Newer releases sign the checksums file automatically in the release
+workflow using the "ORAS Project Release Signing" key
+(C6FC42F0DE84A345FAADB742F44418110791EF37). Earlier releases were signed
+manually by an individual maintainer's key (both are listed below).
+
 Developers to add their keys:
         pgp -kxa <your name> and append it to this file.
         or
@@ -85,4 +95,20 @@ hEdWAwEIB4h4BBgWCgAgFiEELaRh0TsMJ4Re36d/5GKjiUy6qkcFAmhCwxACGwwA
 CgkQ5GKjiUy6qkfIYAEAnN+lGbgYfzmB2JIj/qb39teFmciJCU8vfxfkNKeE7FoA
 /jV/gyOIb3rPCBxzkbBOoFi76lGK4GUdEZNU6OJAg1QD
 =ePpx
+-----END PGP PUBLIC KEY BLOCK-----
+pub   ed25519 2026-07-13 [SC]
+      C6FC42F0DE84A345FAADB742F44418110791EF37
+uid           [ultimate] ORAS Project Release Signing <cncf-oras-maintainers@lists.cncf.io>
+sig 3        F44418110791EF37 2026-07-13  [self-signature]
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEalVhihYJKwYBBAHaRw8BAQdA56vV8wwUieNmNq3U3D1aIZI6n+fTArN0eYVx
+C9wQ49+0Qk9SQVMgUHJvamVjdCBSZWxlYXNlIFNpZ25pbmcgPGNuY2Ytb3Jhcy1t
+YWludGFpbmVyc0BsaXN0cy5jbmNmLmlvPoivBBMWCgBXFiEExvxC8N6Eo0X6rbdC
+9EQYEQeR7zcFAmpVYYobFIAAAAAABAAObWFudTIsMi41KzEuMTIsMCwzAhsDBQsJ
+CAcCAiICBhUKCQgLAgQWAgMBAh4HAheAAAoJEPREGBEHke83OOwA/1wm5SLdQ/vU
+0HYBq2aoWubI3Cycx0iJtmWr4EpBEoIXAQC90f56D8kvaqh5pVqiYiDFnW/hqRW2
+hgRzY6sk5H7bAw==
+=2Eeb
 -----END PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
## What

Sign the release `checksums.txt` automatically in the release workflow so the `.asc` signature file is always published.

## Why

The `oras_<version>_checksums.txt.asc` signature has been produced by a manual, out-of-band maintainer step each release. That step was missed for v1.3.3, so the signature file was absent from the release assets and consumers' GPG-based verification pipelines broke (#2111). The `.asc` for v1.3.3 has since been added by hand; this PR prevents a recurrence by automating it.

## Changes

- **`.goreleaser.yml`** — enable a scoped `signs` block (`artifacts: checksum`) that produces `${artifact}.asc` using a dedicated **ORAS Project Release Signing** key via loopback pinentry.
- **`.github/workflows/release-github.yml`** — import the signing key from the `GPG_PRIVATE_KEY` secret and pass `GPG_PASSPHRASE` to goreleaser.
- **`KEYS`** — add the new project signing public key (`C6FC42F0DE84A345FAADB742F44418110791EF37`) and document how to verify a release.

## New signing key

This introduces a **dedicated project signing key** rather than continuing to sign with an individual maintainer's personal key. The new public key is added to `KEYS`. Both the old and new keys are listed, so this does not invalidate signatures on prior releases — but anyone pinning a specific maintainer key for verification should add the new one.

## Required before this can be used

Two repository secrets must be configured on `oras-project/oras` before the next tagged release:

- `GPG_PRIVATE_KEY` — ASCII-armored private key for the signing key above
- `GPG_PASSPHRASE` — its passphrase

## Verifying a release (after this lands)

```
gpg --import KEYS
gpg --verify oras_<version>_checksums.txt.asc oras_<version>_checksums.txt
```

Relates to #2111, #2006.