### PR TITLE
Fall back to config media type for old-style artifact types

### DIFF
--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -241,6 +241,13 @@ func enrichDescriptor(ctx context.Context, target oras.ReadOnlyTarget, desc ocis
 			return ocispec.Descriptor{}, err
 		}
 		desc.ArtifactType = manifest.ArtifactType
+		if desc.ArtifactType == "" && manifest.Config.MediaType != ocispec.MediaTypeImageConfig {
+			// Old-style artifacts predate the manifest artifactType field and
+			// convey their type through config.mediaType instead. Per the
+			// image-spec descriptor guidance, fall back to config.mediaType so
+			// the enriched descriptor still advertises an artifactType.
+			desc.ArtifactType = manifest.Config.MediaType
+		}
 	} else if descriptor.IsIndex(desc) {
 		var index ocispec.Index
 		if err := json.Unmarshal(manifestBytes, &index); err != nil {

--- a/cmd/oras/root/manifest/index/create.go
+++ b/cmd/oras/root/manifest/index/create.go
@@ -38,6 +38,7 @@ import (
 	"oras.land/oras/cmd/oras/internal/option"
 	"oras.land/oras/internal/contentutil"
 	"oras.land/oras/internal/descriptor"
+	"oras.land/oras/internal/docker"
 	"oras.land/oras/internal/listener"
 )
 
@@ -241,12 +242,17 @@ func enrichDescriptor(ctx context.Context, target oras.ReadOnlyTarget, desc ocis
 			return ocispec.Descriptor{}, err
 		}
 		desc.ArtifactType = manifest.ArtifactType
-		if desc.ArtifactType == "" && manifest.Config.MediaType != ocispec.MediaTypeImageConfig {
+		if desc.ArtifactType == "" {
 			// Old-style artifacts predate the manifest artifactType field and
 			// convey their type through config.mediaType instead. Per the
 			// image-spec descriptor guidance, fall back to config.mediaType so
 			// the enriched descriptor still advertises an artifactType.
-			desc.ArtifactType = manifest.Config.MediaType
+			switch manifest.Config.MediaType {
+			case ocispec.MediaTypeImageConfig, ocispec.MediaTypeEmptyJSON, docker.MediaTypeConfig:
+				// standard image / empty config: not an artifact type, leave empty
+			default:
+				desc.ArtifactType = manifest.Config.MediaType
+			}
 		}
 	} else if descriptor.IsIndex(desc) {
 		var index ocispec.Index

--- a/cmd/oras/root/manifest/index/create_test.go
+++ b/cmd/oras/root/manifest/index/create_test.go
@@ -239,6 +239,54 @@ func Test_enrichDescriptor(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:   "old-style artifact, artifactType falls back to config mediaType",
+			target: NewTestReadOnlyTarget(`intentionally not valid JSON`),
+			manifestBytes: []byte(`
+				{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"config": {
+						"mediaType": "application/vnd.example.config",
+						"digest": "sha256:dc889043956f34871cc04ae96e03efc29dfe2f582c26195a72dd4827f4dd830d",
+						"size": 28
+					},
+					"layers": []
+				}
+			`),
+			manifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+			checkDesc: func(t *testing.T, gotDesc, _ ocispec.Descriptor) {
+				t.Helper()
+				if got, want := gotDesc.ArtifactType, "application/vnd.example.config"; got != want {
+					t.Errorf("ArtifactType = %s, want %s", got, want)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:   "empty artifactType with standard config type stays empty",
+			target: NewTestReadOnlyTarget(`intentionally not valid JSON`),
+			manifestBytes: []byte(`
+				{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"config": {
+						"mediaType": "application/vnd.oci.image.config.v1+json",
+						"digest": "sha256:dc889043956f34871cc04ae96e03efc29dfe2f582c26195a72dd4827f4dd830d",
+						"size": 28
+					},
+					"layers": []
+				}
+			`),
+			manifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+			checkDesc: func(t *testing.T, gotDesc, _ ocispec.Descriptor) {
+				t.Helper()
+				if got, want := gotDesc.ArtifactType, ""; got != want {
+					t.Errorf("ArtifactType = %q, want empty", got)
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name:              "child of unrecognized type",
 			target:            NewTestReadOnlyTarget("(unused)"),
 			manifestBytes:     []byte(`{}`),

--- a/cmd/oras/root/manifest/index/create_test.go
+++ b/cmd/oras/root/manifest/index/create_test.go
@@ -263,7 +263,7 @@ func Test_enrichDescriptor(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:   "empty artifactType with standard config type stays empty",
+			name:   "empty artifactType with OCI image config stays empty",
 			target: NewTestReadOnlyTarget(`intentionally not valid JSON`),
 			manifestBytes: []byte(`
 				{
@@ -280,7 +280,55 @@ func Test_enrichDescriptor(t *testing.T) {
 			manifestMediaType: "application/vnd.oci.image.manifest.v1+json",
 			checkDesc: func(t *testing.T, gotDesc, _ ocispec.Descriptor) {
 				t.Helper()
-				if got, want := gotDesc.ArtifactType, ""; got != want {
+				if got := gotDesc.ArtifactType; got != "" {
+					t.Errorf("ArtifactType = %q, want empty", got)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:   "empty artifactType with empty JSON config stays empty",
+			target: NewTestReadOnlyTarget(`intentionally not valid JSON`),
+			manifestBytes: []byte(`
+				{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"config": {
+						"mediaType": "application/vnd.oci.empty.v1+json",
+						"digest": "sha256:dc889043956f34871cc04ae96e03efc29dfe2f582c26195a72dd4827f4dd830d",
+						"size": 28
+					},
+					"layers": []
+				}
+			`),
+			manifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+			checkDesc: func(t *testing.T, gotDesc, _ ocispec.Descriptor) {
+				t.Helper()
+				if got := gotDesc.ArtifactType; got != "" {
+					t.Errorf("ArtifactType = %q, want empty", got)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:   "empty artifactType with docker image config stays empty",
+			target: NewTestReadOnlyTarget(`intentionally not valid JSON`),
+			manifestBytes: []byte(`
+				{
+					"schemaVersion": 2,
+					"mediaType": "application/vnd.oci.image.manifest.v1+json",
+					"config": {
+						"mediaType": "application/vnd.docker.container.image.v1+json",
+						"digest": "sha256:dc889043956f34871cc04ae96e03efc29dfe2f582c26195a72dd4827f4dd830d",
+						"size": 28
+					},
+					"layers": []
+				}
+			`),
+			manifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+			checkDesc: func(t *testing.T, gotDesc, _ ocispec.Descriptor) {
+				t.Helper()
+				if got := gotDesc.ArtifactType; got != "" {
 					t.Errorf("ArtifactType = %q, want empty", got)
 				}
 			},

--- a/internal/docker/mediatype.go
+++ b/internal/docker/mediatype.go
@@ -19,4 +19,5 @@ package docker
 const (
 	MediaTypeManifest     = "application/vnd.docker.distribution.manifest.v2+json"
 	MediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+	MediaTypeConfig       = "application/vnd.docker.container.image.v1+json"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses Issue 1 of #2015 (the `config.mediaType` fallback for descriptor `artifactType`), following @TerryHowe's assessment on the issue.

When `oras manifest index create`/`update` enriches a child image manifest descriptor, `enrichDescriptor` set `desc.ArtifactType = manifest.ArtifactType` and left it empty for **old-style artifacts** — those created before the manifest `artifactType` field existed, which convey their type through `config.mediaType` instead (e.g. historically-created artifacts like OpenTofu providers).

The image-spec [descriptor guidance](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#properties) says `artifactType` "is the value of the config descriptor `mediaType` when the descriptor references an image manifest", and the [manifest guidelines](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage) explicitly call for tooling to "fallback to the `config.mediaType` value". This change does that: when `artifactType` is empty and the config is not a standard OCI image config, the enriched descriptor falls back to `config.mediaType`.

`enrichDescriptor` is shared by both the index `create` and `update` paths, so a single change fixes both (the issue assessment expected two edits).

This PR intentionally scopes to Issue 1 only. Issue 2 (a mechanism/flag to attach platform to artifact descriptors) is a larger, separate change and is left for a follow-up.

**Which issue(s) this PR fixes**:
Fixes #2015

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test? — Added two `Test_enrichDescriptor` cases: the fallback path (empty `artifactType` + custom `config.mediaType`), and the guard that keeps `artifactType` empty when the config is the standard OCI image config type. This closes the "no test for the old-style fallback path" gap noted in the issue.
- [ ]  Does this change require a documentation update? — No; behavior now matches the documented spec expectation.
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version? — No; it only populates a descriptor field that was previously left empty for these artifacts.
- [x]  Do all new files have an appropriate license header? — No new files.
