### PR TITLE
chore: group github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/" 


### PR DESCRIPTION
Group all `github-actions` Dependabot updates into a single PR (pattern `*`), matching the configuration used in [oras-go](https://github.com/oras-project/oras-go/blob/main/.github/dependabot.yml).

This bundles related action bumps — e.g. `github/codeql-action/init` and `github/codeql-action/analyze` — into one grouped PR instead of opening a separate PR per sub-action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)