### PR TITLE
fix: route logger output to command stderr

### DIFF
--- a/cmd/oras/internal/command/logger_test.go
+++ b/cmd/oras/internal/command/logger_test.go
@@ -16,17 +16,23 @@ limitations under the License.
 package command
 
 import (
+	"bytes"
 	"context"
+	"strings"
+	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"oras.land/oras/cmd/oras/internal/option"
-	"oras.land/oras/internal/trace"
 )
 
-// GetLogger returns a new FieldLogger and an associated Context derived from command context.
-func GetLogger(cmd *cobra.Command, opts *option.Common) (context.Context, logrus.FieldLogger) {
-	ctx, logger := trace.NewLogger(cmd.Context(), opts.Debug, cmd.ErrOrStderr())
-	cmd.SetContext(ctx)
-	return ctx, logger
+func TestGetLoggerUsesCommandErrorWriter(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	_, logger := GetLogger(cmd, &option.Common{})
+	logger.Warn("warning")
+	if !strings.Contains(stderr.String(), "warning") {
+		t.Fatalf("GetLogger() output = %q, want warning", stderr.String())
+	}
 }

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -17,6 +17,7 @@ package trace
 
 import (
 	"context"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -27,7 +28,7 @@ type contextKey int
 const loggerKey contextKey = iota
 
 // NewLogger returns a logger.
-func NewLogger(ctx context.Context, debug bool) (context.Context, logrus.FieldLogger) {
+func NewLogger(ctx context.Context, debug bool, output io.Writer) (context.Context, logrus.FieldLogger) {
 	var logLevel logrus.Level
 	if debug {
 		logLevel = logrus.DebugLevel
@@ -38,6 +39,7 @@ func NewLogger(ctx context.Context, debug bool) (context.Context, logrus.FieldLo
 	logger := logrus.New()
 	logger.SetFormatter(&TextFormatter{})
 	logger.SetLevel(logLevel)
+	logger.SetOutput(output)
 	entry := logger.WithContext(ctx)
 	return context.WithValue(ctx, loggerKey, entry), entry
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Routes logger output through Cobra's configured error writer so applications using `Command.SetErr` capture warning and debug logs consistently with other stderr output.

Adds a focused unit test covering the configured writer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1431

**Please check the following list**:
- [x] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have an appropriate license header?

**Local validation**:
- `golangci-lint run ./...`
- `go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... ./...`
- `make build-mac-arm64`

Linux-only E2E was not run locally; this embedding behavior is covered at the Cobra command/logger boundary by the focused unit test.