### PR TITLE
fix: avoid send on closed channel in progress messenger

### DIFF
--- a/cmd/oras/internal/display/status/progress/manager.go
+++ b/cmd/oras/internal/display/status/progress/manager.go
@@ -123,16 +123,11 @@ func (m *manager) Track(desc ocispec.Descriptor) (progress.Tracker, error) {
 }
 
 func (m *manager) newTracker(s *status) progress.Tracker {
-	ch := make(chan statusUpdate, bufferSize)
+	msg := newMessenger(m.prompts)
 	m.updating.Go(func() {
-		for update := range ch {
-			update(s)
-		}
+		msg.drain(s)
 	})
-	return &messenger{
-		update:  ch,
-		prompts: m.prompts,
-	}
+	return msg
 }
 
 // Close stops all status and waits for updating and rendering.

--- a/cmd/oras/internal/display/status/progress/messenger.go
+++ b/cmd/oras/internal/display/status/progress/messenger.go
@@ -15,45 +15,96 @@ limitations under the License.
 
 package progress
 
-import "oras.land/oras/internal/progress"
+import (
+	"sync"
+
+	"oras.land/oras/internal/progress"
+)
 
 // messenger is progress message channel.
+//
+// The update channel is deliberately never closed. Trackers are handed to
+// io.Reader / io.Writer wrappers that can outlive the operation they track,
+// most notably the net/http request body reader, which keeps being read by
+// the transport write loop after the round trip returns. Closing the channel
+// would let such a late Update or Fail send on a closed channel and panic.
+// Instead, Close closes the done channel and every send races the done signal,
+// so late updates are dropped instead of panicking.
 type messenger struct {
-	update  chan statusUpdate
-	closed  bool
-	prompts map[progress.State]string
+	update    chan statusUpdate
+	done      chan struct{}
+	closeOnce sync.Once
+	prompts   map[progress.State]string
+}
+
+// newMessenger creates a new messenger.
+func newMessenger(prompts map[progress.State]string) *messenger {
+	return &messenger{
+		update:  make(chan statusUpdate, bufferSize),
+		done:    make(chan struct{}),
+		prompts: prompts,
+	}
+}
+
+// send delivers the update unless the messenger is already closed.
+func (m *messenger) send(update statusUpdate) {
+	select {
+	case m.update <- update:
+	case <-m.done:
+		// the messenger is closed, drop the update
+	}
 }
 
 // Update sends the status to the message channel.
 func (m *messenger) Update(status progress.Status) error {
 	switch status.State {
 	case progress.StateInitialized:
-		m.update <- updateStatusStartTime()
+		m.send(updateStatusStartTime())
 	case progress.StateTransmitting:
 		select {
 		case m.update <- updateStatusMessage(m.prompts[progress.StateTransmitting], status.Offset):
 		default:
-			// drop message if channel is full
+			// drop message if channel is full or the messenger is closed
 		}
 	default:
-		m.update <- updateStatusMessage(m.prompts[status.State], status.Offset)
+		m.send(updateStatusMessage(m.prompts[status.State], status.Offset))
 	}
 	return nil
 }
 
 // Fail sends the error to the message channel.
 func (m *messenger) Fail(err error) error {
-	m.update <- updateStatusError(err)
+	m.send(updateStatusError(err))
 	return nil
 }
 
-// Close marks the progress as completed and closes the message channel.
+// Close marks the progress as completed and stops the message channel.
 func (m *messenger) Close() error {
-	if m.closed {
-		return nil
-	}
-	m.update <- updateStatusEndTime()
-	close(m.update)
-	m.closed = true
+	m.closeOnce.Do(func() {
+		// the done channel is still open, so this update is guaranteed to be
+		// delivered to the drain goroutine before it stops
+		m.send(updateStatusEndTime())
+		close(m.done)
+	})
 	return nil
+}
+
+// drain applies the status updates to s until the messenger is closed.
+func (m *messenger) drain(s *status) {
+	for {
+		select {
+		case update := <-m.update:
+			update(s)
+		case <-m.done:
+			// apply the updates that are still buffered, then stop
+			for {
+				select {
+				case update := <-m.update:
+					update(s)
+				default:
+					return
+				}
+			}
+		}
+	}
 }

--- a/cmd/oras/internal/display/status/progress/messenger_test.go
+++ b/cmd/oras/internal/display/status/progress/messenger_test.go
@@ -17,6 +17,7 @@ package progress
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -24,14 +25,11 @@ import (
 )
 
 func Test_messenger_Update(t *testing.T) {
-	m := &messenger{
-		update: make(chan statusUpdate, 1),
-		prompts: map[progress.State]string{
-			progress.StateInitialized:  "initialized",
-			progress.StateTransmitting: "testing",
-			progress.StateTransmitted:  "tested",
-		},
-	}
+	m := newMessenger(map[progress.State]string{
+		progress.StateInitialized:  "initialized",
+		progress.StateTransmitting: "testing",
+		progress.StateTransmitted:  "tested",
+	})
 	defer func() { _ = m.Close() }()
 	desc := ocispec.Descriptor{
 		MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
@@ -110,9 +108,7 @@ func Test_messenger_Update(t *testing.T) {
 }
 
 func Test_messenger_Fail(t *testing.T) {
-	m := &messenger{
-		update: make(chan statusUpdate, 1),
-	}
+	m := newMessenger(nil)
 	defer func() { _ = m.Close() }()
 	s := new(status)
 	errTest := errors.New("test error")
@@ -128,14 +124,63 @@ func Test_messenger_Fail(t *testing.T) {
 }
 
 func Test_messenger_Close(t *testing.T) {
-	m := &messenger{
-		update: make(chan statusUpdate, 1),
-	}
+	m := newMessenger(nil)
 	if err := m.Close(); err != nil {
 		t.Fatalf("messenger.Close() error = %v, wantErr nil", err)
 	}
 	// double close should not panic or return an error
 	if err := m.Close(); err != nil {
 		t.Fatalf("messenger.Close() error = %v, wantErr nil", err)
+	}
+}
+
+// Test_messenger_Close_concurrentUpdate reproduces the "send on closed
+// channel" panic reported in #2125: a tracked reader owned by another
+// goroutine, e.g. the net/http transport write loop, keeps calling Update and
+// Fail after the tracker has been closed.
+func Test_messenger_Close_concurrentUpdate(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		m := newMessenger(map[progress.State]string{
+			progress.StateTransmitting: "testing",
+			progress.StateTransmitted:  "tested",
+		})
+		s := new(status)
+		var wg sync.WaitGroup
+
+		// drain the updates the same way manager.newTracker does
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.drain(s)
+		}()
+
+		// keep reporting progress and failures while the messenger is closed
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if err := m.Update(progress.Status{
+					State:  progress.StateTransmitted,
+					Offset: int64(j),
+				}); err != nil {
+					t.Errorf("messenger.Update() error = %v, wantErr nil", err)
+					return
+				}
+				if err := m.Fail(errors.New("test error")); err != nil {
+					t.Errorf("messenger.Fail() error = %v, wantErr nil", err)
+					return
+				}
+			}
+		}()
+
+		if err := m.Close(); err != nil {
+			t.Fatalf("messenger.Close() error = %v, wantErr nil", err)
+		}
+		wg.Wait()
+
+		// Close must always be recorded, even when it races with updates
+		if s.endTime.IsZero() {
+			t.Error("messenger.Close() endTime = zero, want non-zero")
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`oras copy` can panic with `send on closed channel` in the progress display.

The race, precisely:

- `messenger.Close()` did `m.update <- updateStatusEndTime(); close(m.update)`. It is called from `Reader.StopTracker()`, which runs via `defer r.StopTracker()` in `referenceGraphTarget.PushReference` / `Push` — i.e. as soon as the push call returns.
- The tracked reader handed to the push is the HTTP request body. `net/http`'s `persistConn.writeLoop` goroutine keeps reading it after the round trip has returned. When one of those late reads returns a non-EOF error, `readTracker.Read` calls `tracker.Fail(err)`, which was an unguarded `m.update <- updateStatusError(err)`.
- So the closing goroutine (the caller of `PushReference`) and the sending goroutine (`net/http` `writeLoop`) are unsynchronized, and a send can land after the close. That is exactly the reported stack: `writeLoop → doBodyCopy → readTracker.Read → messenger.Fail`. `writeTracker.Write` has the same `Fail` path.

The existing `closed bool` only short-circuited a second `Close()`; it was unsynchronized and did not guard `Update`/`Fail`.

The fix: the messenger no longer closes the update channel at all. It owns a `done` channel that `Close` closes (once, via `sync.Once`), every blocking send selects on `done`, and the drain goroutine in `manager.newTracker` now stops on `done` after applying whatever is still buffered. A late `Update`/`Fail` therefore takes the `done` branch and drops the update instead of panicking. `Close` sends the end-time update *before* closing `done`, so the final status is never lost.

Note on the approach: adding a `select` on `done` while still closing the update channel would not have fixed it. `select` commits to a ready send case and then performs the send, so a concurrent `close` in that window still panics. Not closing the channel is what actually serializes the two goroutines — the only cross-goroutine transition left is `close(done)`, and a closed `done` is permanently ready, so senders can neither panic nor block. A mutex held across the blocking send was rejected as it couples sender liveness to the drain goroutine.

Reproduced before the fix with `go test -race` (drain goroutine + a goroutine calling `Fail` while `Close` runs):

```
==================
WARNING: DATA RACE
Read at 0x00c00013b6d0 by goroutine 9:
  runtime.chansend1()
  oras.land/oras/cmd/oras/internal/display/status/progress.(*messenger).Fail()
      cmd/oras/internal/display/status/progress/messenger.go:46 +0xa4
...
panic: send on closed channel
```

`Test_messenger_Close_concurrentUpdate` is the regression test for it; it fails if the channel close is put back.

Verified: `go build ./...`, `go vet ./...`, `go test -race ./...` (all packages pass), `golangci-lint run ./...` (0 issues).

**Which issue(s) this PR fixes**:
Fixes #2125

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x]  Does this change require a documentation update? — no, all internal packages, no user-facing or API change
- [x]  Does this introduce breaking changes that would require an announcement or bumping the major version? — no
- [x]  Do all new files have an appropriate license header? — no new files
