### PR TITLE
build(deps): bump library/golang from 1.26.5-alpine to 1.26.6-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.5-alpine as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26.6-alpine as builder
 ARG TARGETPLATFORM
 RUN apk add git make
 ENV ORASPKG /oras


### PR DESCRIPTION
## What
Bumps the `Dockerfile` builder stage from `golang:1.26.5-alpine` to `golang:1.26.6-alpine`.

## Why
`1.26.5` is vulnerable to CVE-2026-39821 (GO-2026-5026): incorrect Punycode/IDNA label handling in `golang.org/x/net/idna`, vendored into `net/http`, which can lead to privilege escalation in programs that perform hostname checks before Unicode conversion. Fixed upstream in Go 1.25.13, 1.26.6, and 1.27.0-rc.3. `golang:1.26.6-alpine` has been published on Docker Hub since 2026-08-16.

Found via Aikido SCA scanning a downstream image (mirantis/cluster-upgrade-controller) that pulls `ghcr.io/oras-project/oras:v1.3.3`.

## How
- One-line `FROM` tag bump in `Dockerfile`; no other file in the repo pins `golang:1.26.5`.
- Follows the same pattern as this repo's existing Dependabot golang-bump PRs (#2050, #2071, #2107).

## Testing
- Not independently rebuilt in this PR; existing CI will build and test against the new base image.