### PR TITLE
test: expect scrubbed custom header values in e2e

### DIFF
--- a/test/e2e/suite/command/custom_header.go
+++ b/test/e2e/suite/command/custom_header.go
@@ -29,11 +29,13 @@ var _ = Describe("1.1 registry users:", func() {
 	headerTestRepo := func(text string) string {
 		return fmt.Sprintf("command/headertest/%d/%s", GinkgoRandomSeed(), text)
 	}
+	// Custom header values are scrubbed from --debug output since they may
+	// carry credentials, so only the header names are expected in the logs.
 	var (
 		FoobarHeaderInput = "Foo:bar"
-		FoobarHeader      = "\"Foo\": \"bar\"\n"
+		FoobarHeader      = "\"Foo\": \"*****\"\n"
 		AbHeaderInput     = "A: b"
-		AbHeader          = "\"A\": \" b\"\n"
+		AbHeader          = "\"A\": \"*****\"\n"
 	)
 	When("custom header is provided", func() {
 		It("attach", func() {


### PR DESCRIPTION
## What this PR does

Fixes the 9 failing `1.1 registry users: when custom header is provided` e2e specs that have broken `main` since the GHSA-5jhf-2qmf-m8c5 fix landed.

## Why

That fix scrubs configured custom header names from `--debug` trace output, since `--header` is commonly used to pass credential headers:

- `cmd/oras/internal/option/remote.go` collects every `--header` name into `sensitiveHeaders` and passes them to `trace.NewTransport`
- `internal/trace/transport.go` replaces those values with `*****`

The e2e specs were not updated, so they still assert the raw values:

```
FoobarHeader = "\"Foo\": \"bar\"\n"
AbHeader     = "\"A\": \" b\"\n"
```

while the debug output now contains:

```
"A": "*****"
"Foo": "*****"
```

Every spec fails at `test/e2e/internal/utils/match/request.go:58` with `failed to match all headers`. This affects `attach`, `blob`, `manifest`, `pull`, `push`, `repo`, `tag`, and both `cp` specs, and it fails on every PR branched after the fix (for example #2130, where it is unrelated to that PR's dependency bump).

## The change

Expect the scrubbed values. The specs still verify that each custom header name is present on every matching request, which is what they were really guarding.

## Verification

The full e2e suite could not be run locally (macOS AirPlay Receiver holds port 5000, so the test registry is unreachable), so the expected literals were checked directly against the real `trace.logHeader` with a throwaway unit test: `"Foo": "*****"\n` and `"A": "*****"\n` are both produced, and neither raw value leaks. CI on this PR exercises the real suite.

## Note, not addressed here

The `login` spec in the same block passes only vacuously — it omits `-d`, so `getRequests` finds no requests and the matcher's loop never runs. Worth a follow-up.