### PR TITLE
bump: tag and release ORAS CLI v1.3.4

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras.
-	Version = "1.3.3"
+	Version = "1.3.4"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = ""
 	// GitCommit is the git sha1


### PR DESCRIPTION
## Release v1.3.4

This PR bumps the version to v1.3.4 for the upcoming release.

### Checklist
- [ ] Version updated in `internal/version/version.go`
- [ ] CI checks pass
- [ ] Vote called in the ORAS Slack channel
- [ ] Super-majority of approval from ORAS maintainers