### PR TITLE
release-github.yml: float Go version to match other workflows

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -29,7 +29,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.7'
+          go-version: '1.25'
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:


### PR DESCRIPTION
## Summary
- `.github/workflows/release-github.yml` pinned an exact Go patch version (`1.25.7`) for the job that builds and GPG-signs the release binaries.
- Every other workflow in the repo (`build.yml`, `codeql-analysis.yml`, `golangci-lint.yml`, `vulnerability-check.yml`, `snapcraft.yaml`) already uses the floating minor `'1.25'`, which `actions/setup-go` resolves to the latest patch at run time.
- The pin was 6 patches stale and missed a stdlib security fix (GO-2026-5026 / CVE-2026-39821, fixed in 1.25.13), and nothing bumps it automatically since Dependabot's `gomod`/`github-actions` ecosystems don't rewrite `go-version:` string literals.
- Fix: switch `release-github.yml` to the same floating minor used everywhere else in the repo, so release binaries pick up patch releases automatically like every other build path.

Fixes #2132

## Test plan
- [x] Confirmed the old exact pin (`1.25.7`) is gone and matches the floating-minor pattern (`'1.25'`) used by the other 5 workflows in the same repo
- Workflow itself can only be exercised on an actual release run (`workflow_dispatch`/tag push) in CI on merge — the change is a one-line value swap of an already-used, valid `setup-go` input