### PR TITLE
ci: fetch full history so goreleaser builds a complete changelog

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # goreleaser derives the release changelog from the commit history;
+          # the default shallow clone leaves it with only the tagged commit.
+          fetch-depth: 0
       - name: setup go environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

`release-github.yml` checks out with the default `actions/checkout` depth of 1, so the runner only has the tagged commit. GoReleaser derives the release changelog from the commit history, so the generated notes contain a single entry — the version bump commit — instead of everything since the previous tag.

This was visible on the v1.3.4 draft release, whose entire changelog was:

```
## Changelog
* db9e29505c3059f2b8fde34ae8cae266c5c765e9 bump: tag and release ORAS CLI v1.3.4 (#2136)
```

There are 29 commits in `v1.3.3..v1.3.4`.

Setting `fetch-depth: 0` gives GoReleaser the full history it needs. The other release workflows (`release-ghcr.yml`, `release-snap.yml`) do not read git history, so they are left unchanged.

**Which issue(s) this PR resolves**:

None.