### PR TITLE
ci: fetch full history for release changelog

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: setup go environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures the GitHub release workflow to fetch the complete repository history. This lets GoReleaser include every commit since the previous tag when it generates the release changelog.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2142

**Please check the following list**:
- [x] N/A — this is a workflow-only change; the changed workflow passes `actionlint`.
- [x] N/A — no documentation update is needed.
- [x] No — this does not introduce breaking changes.
- [x] N/A — this PR adds no new files.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->
