### PR TITLE
feat(ci): add windows/arm64 build to github release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,8 +49,6 @@ builds:
   - goos: freebsd
     goarch: s390x
   - goos: windows
-    goarch: arm64
-  - goos: windows
     goarch: arm
   - goos: darwin
     goarch: arm

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
   ARCH = amd64
 endif
 
-TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz linux_riscv64.tar.gz linux_loong64.tar.gz windows_amd64.zip freebsd_amd64.tar.gz
+TARGET_OBJS ?= checksums.txt darwin_amd64.tar.gz darwin_arm64.tar.gz linux_amd64.tar.gz linux_arm64.tar.gz linux_armv7.tar.gz linux_s390x.tar.gz linux_ppc64le.tar.gz linux_riscv64.tar.gz linux_loong64.tar.gz windows_amd64.zip windows_arm64.zip freebsd_amd64.tar.gz
 
 LDFLAGS = -w
 ifdef VERSION


### PR DESCRIPTION
**What this PR does / why we need it**:
Windows ARM64 is common enough to be provided as one of the default [github runner types](https://github.com/actions/runner-images#available-images).

Expose windows/arm64 as a release artifact in `.goreleaser.yml`

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
