### PR TITLE
fix(ci): resolve licenserc go.mod path relative to config directory

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -43,7 +43,7 @@ header:
 
 dependency:
   files:
-    - go.mod
+    - ../go.mod
   licenses:
     # known issue: https://github.com/apache/skywalking-eyes/pull/107#issuecomment-1129761574
     - name: github.com/chzyer/logex


### PR DESCRIPTION
## Summary

The `dependency.files` path in `.github/licenserc.yml` is resolved relative to the config file's directory (`.github/`), not the repo root. The previous value `go.mod` pointed to `.github/go.mod` which does not exist.

skywalking-eyes 0.9.0 added a `validateGoModFile()` check that opens the declared path before chdir, surfacing this pre-existing misconfiguration. Every other check on the skywalking-eyes bump PR #2149 passes — only `check-license` fails.

## The Fix

```diff
 dependency:
   files:
-    - go.mod
+    - ../go.mod
```

`filepath.Join(".github", "../go.mod")` cleans to `go.mod` at the repo root, which is the module we actually want scanned — the same module 0.8.0 was reaching accidentally via `go mod download` walking up from `.github/`. So the set of dependencies checked does not change.

## Why this is safe under 0.8.0

The fix is also correct under the currently pinned 0.8.0 (it resolves to the same root `go.mod` that version reaches by walking up), so it can land on its own first. Once on `main`, #2149 needs a rebase for its `check-license` run to go green.

## Prior art

Identical bug and fix in oras-go: oras-project/oras-go#1359 → oras-project/oras-go#1366. This repo never received the port.

Fixes #2154