### PR TITLE
fix: attribute recursive copy tag failures to the destination

### DIFF
--- a/cmd/oras/root/cp.go
+++ b/cmd/oras/root/cp.go
@@ -276,7 +276,16 @@ func recursiveCopy(ctx context.Context, src oras.ReadOnlyGraphTarget, dst oras.T
 		return err
 	}
 	if dstRef != "" && dstRef != root.Digest.String() {
-		return dst.Tag(ctx, root, dstRef)
+		if err := dst.Tag(ctx, root, dstRef); err != nil {
+			// oras.Copy reports a failed root tagging as a destination-side
+			// copy error. Do the same here so that the error is attributed to
+			// the destination instead of the source.
+			return &oras.CopyError{
+				Op:     "Tag",
+				Origin: oras.CopyErrorOriginDestination,
+				Err:    err,
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/oras/root/cp_test.go
+++ b/cmd/oras/root/cp_test.go
@@ -35,6 +35,7 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras/cmd/oras/internal/display/status"
 	"oras.land/oras/internal/testutils"
@@ -564,5 +565,39 @@ func Test_getMountPoint(t *testing.T) {
 				t.Errorf("checkMount() gotRepo = %v, want %v", gotMount, tt.wantMount)
 			}
 		})
+	}
+}
+
+// tagFailingTarget is a mock implementation of oras.Target whose Tag always
+// fails, simulating a destination registry that rejects the root tag.
+type tagFailingTarget struct {
+	oras.Target
+}
+
+// Tag simulates a not found failure at the destination.
+func (t *tagFailingTarget) Tag(_ context.Context, _ ocispec.Descriptor, _ string) error {
+	return errdef.ErrNotFound
+}
+
+func Test_recursiveCopy_tagFailure(t *testing.T) {
+	ctx := context.Background()
+	dst := &tagFailingTarget{Target: memory.New()}
+
+	err := recursiveCopy(ctx, memStore, dst, "v1", memDesc, oras.DefaultExtendedCopyGraphOptions)
+	if err == nil {
+		t.Fatal("recursiveCopy() error = nil, wantErr true")
+	}
+	var copyErr *oras.CopyError
+	if !errors.As(err, &copyErr) {
+		t.Fatalf("recursiveCopy() error = %v, want *oras.CopyError", err)
+	}
+	if copyErr.Op != "Tag" {
+		t.Errorf("recursiveCopy() error Op = %q, want %q", copyErr.Op, "Tag")
+	}
+	if copyErr.Origin != oras.CopyErrorOriginDestination {
+		t.Errorf("recursiveCopy() error Origin = %v, want %v", copyErr.Origin, oras.CopyErrorOriginDestination)
+	}
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("recursiveCopy() error = %v, want to wrap %v", err, errdef.ErrNotFound)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`oras cp -r` blames the source registry when it is the destination that failed. If the final tagging of the root fails, the user sees `Error response from registry: not found`, with no host and nothing saying which side answered, so the source registry looks broken.

The cause is in `recursiveCopy` (cmd/oras/root/cp.go:279), which tags the root with a bare `dst.Tag` call and returns the error unwrapped. That error is not an `oras.CopyError`, so `BinaryTarget.ModifyError` (cmd/oras/internal/option/binary_target.go:73) has no origin to read and falls through to the generic handler, which asks the source target first. The source then claims the error and sets the plain registry prefix.

oras-go wraps exactly the same root tagging in a destination `CopyError` inside `prepareCopy` (oras-go v2.6.2, copy.go:480 and copy.go:513), which is why a plain `oras cp` gets the attribution right and only `-r` does not. This change wraps the tag error the same way, which is all `BinaryTarget.ModifyError` needs.

Before: `Error response from registry: not found`

After: `Error from destination registry for "localhost:5000/gitlab-workhorse-ee:v19.3.0": not found`

This PR is limited to the copy path. The second change suggested in the issue, adding a host check to the `errdef.ErrNotFound` branch of `Target.ModifyError`, touches every command that uses a remote target and is left out of this one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2156

**Please check the following list**:
- [x]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x]  Do all new files have an appropriate license header?

**Local validation** (macOS arm64, Go 1.26.4):

`go test -run Test_recursiveCopy_tagFailure ./cmd/oras/root/` on unmodified main: `FAIL cp_test.go:592: recursiveCopy() error = not found, want *oras.CopyError`. With the change: `ok oras.land/oras/cmd/oras/root 0.266s`.

`go test ./cmd/oras/... ./internal/...`: all packages ok.

`golangci-lint run ./...`: 0 issues.

`go build ./cmd/oras`: ok.

E2E was not run locally since it needs a registry and Docker. No E2E case asserts the message for this path; the only `cp` case that checks a destination prefix is the not-logged-in one in test/e2e/suite/command/cp.go:130, which already expects `Error from destination registry for`.
