### PR TITLE
fix(ci): resolve dependency license config path from repo root

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -43,7 +43,7 @@ header:
 
 dependency:
   files:
-    - go.mod
+    - ../go.mod
   licenses:
     # known issue: https://github.com/apache/skywalking-eyes/pull/107#issuecomment-1129761574
     - name: github.com/chzyer/logex


### PR DESCRIPTION
Fixes #2154

## Problem

`check-license` fails on any PR that touches dependencies (e.g. #2149, Dependabot bumping the `github-actions` group to `apache/skywalking-eyes` 0.9.0):

```
INFO  Loading configuration from file: .github/licenserc.yml
ERROR open /home/runner/work/oras/oras/.github/go.mod: no such file or directory
ERROR one or more errors occurred checking license compatibility
```

`.github/licenserc.yml` declares `dependency.files: [go.mod]`. skywalking-eyes' `ConfigDeps.Finalize()` joins relative `files` entries against the **config file's own directory**, so that entry has always meant `.github/go.mod` — which does not exist.

It passed by accident under 0.8.0: `GoModResolver.Resolve` only did `os.Chdir(filepath.Dir(goModFile))`, and chdir into `.github/` succeeds, after which `go mod download` walks *up* and finds the real root module. 0.9.0 added `validateGoModFile()`, which `os.ReadFile`s the declared path **before** the chdir and fails with ENOENT.

So this is a pre-existing misconfiguration in this repo that 0.9.0 surfaces, not a regression in skywalking-eyes. The dependency check has been silently scanning the root module by accident.

## Fix

One line: point the entry at `../go.mod`, so `filepath.Join(".github", "../go.mod")` cleans to the repo-root `go.mod`. That is the same module 0.8.0 was reaching accidentally, so **the set of dependencies checked is unchanged**.

Deliberately left alone:
- `header.paths-ignore` — header globs are matched against the repo root, so its `go.mod` / `go.sum` / `go.work` entries are already correct.
- The `config: .github/licenserc.yml` input in `license-checker.yml` — the config location is fine; only the path *inside* it was wrong.

## Verification

Locally with `license-eye` v0.9.0:

```console
$ go install github.com/apache/skywalking-eyes/cmd/license-eye@v0.9.0

# before
$ license-eye -v info -c .github/licenserc.yml dependency check
INFO  Loading configuration from file: .github/licenserc.yml
ERROR open .../oras/.github/go.mod: no such file or directory

# after
$ license-eye -v info -c .github/licenserc.yml dependency check
INFO  Loading configuration from file: .github/licenserc.yml
$ echo $?
0
```

`dependency resolve` after the change lists the root module's tree (`oras.land/oras-go/v2 v2.6.2`, `spf13/cobra`, `sirupsen/logrus`, `golang.org/x/crypto`, …), confirming it resolves the intended module rather than silently doing nothing.

## Prior art

Identical bug and fix in oras-go: oras-project/oras-go#1359, fixed by oras-project/oras-go#1366. This repo never received the port.
