### PR TITLE
test(credential): fix TestNewStoreError failing on Windows

### DIFF
--- a/internal/credential/store_test.go
+++ b/internal/credential/store_test.go
@@ -17,33 +17,63 @@ package credential
 
 import (
 	"os"
-	"path"
-	"reflect"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
+// TestNewStoreMalformedConfig covers the error path on every platform: JSON
+// decoding fails the same way everywhere, unlike file permissions.
+func TestNewStoreMalformedConfig(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(filename, []byte("{not json"), 0600); err != nil {
+		t.Fatalf("cannot create config file: %v", err)
+	}
+
+	credStore, err := NewStore(filename)
+	if credStore != nil {
+		t.Errorf("expected NewStore to return a nil store, got %v", credStore)
+	}
+	if err == nil {
+		t.Fatal("expected NewStore to return an error, got nil")
+	}
+	if want := "failed to decode config file"; !strings.Contains(err.Error(), want) {
+		t.Errorf("expected error to contain %q, got %q", want, err.Error())
+	}
+}
+
 func TestNewStoreError(t *testing.T) {
-	tmpDir := t.TempDir()
-	filename := path.Join(tmpDir, "testfile.txt")
+	if runtime.GOOS == "windows" {
+		// os.Chmod on Windows only toggles the read-only attribute and cannot
+		// clear the read permission, so the file stays readable and NewStore
+		// succeeds. See https://pkg.go.dev/os#Chmod.
+		t.Skip("os.Chmod cannot make a file unreadable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		// Permission bits do not restrict root, so the file stays readable.
+		t.Skip("root bypasses file permissions")
+	}
+
+	filename := filepath.Join(t.TempDir(), "testfile.txt")
 	file, err := os.Create(filename)
 	if err != nil {
-		t.Errorf("error: cannot create file : %v", err)
+		t.Fatalf("cannot create file: %v", err)
 	}
 	defer func() { _ = file.Close() }()
 
-	err = os.Chmod(filename, 000)
-	if err != nil {
-		t.Errorf("error: cannot change file permissions: %v", err)
+	if err := os.Chmod(filename, 000); err != nil {
+		t.Fatalf("cannot change file permissions: %v", err)
 	}
+
 	credStore, err := NewStore(filename)
 	if credStore != nil {
-		t.Errorf("Expected NewStore to return nil but actually returned %v ", credStore)
+		t.Errorf("expected NewStore to return a nil store, got %v", credStore)
 	}
-	if err != nil {
-		ok := strings.Contains(err.Error(), "failed to open config file")
-		reflect.DeepEqual(ok, true)
-	} else {
-		t.Errorf("Expected err to be not nil")
+	if err == nil {
+		t.Fatal("expected NewStore to return an error, got nil")
+	}
+	if want := "failed to open config file"; !strings.Contains(err.Error(), want) {
+		t.Errorf("expected error to contain %q, got %q", want, err.Error())
 	}
 }


### PR DESCRIPTION
## Problem

`go test ./...` fails on Windows on a clean checkout of `main`:

```
=== RUN   TestNewStoreError
    store_test.go:41: Expected NewStore to return nil but actually returned &{0x...  {true false}  ...}
    store_test.go:47: Expected err to be not nil
--- FAIL: TestNewStoreError (0.00s)
FAIL    oras.land/oras/internal/credential
```

The test makes a config file unreadable with `os.Chmod(filename, 000)` and expects `NewStore` to fail opening it. On Windows [`os.Chmod`](https://pkg.go.dev/os#Chmod) can only toggle the read-only attribute — it cannot clear the read permission. The file stays readable, `NewStore` succeeds, and both assertions fire.

`build.yml` runs `ubuntu-latest` only (the matrix is over Go versions, not OS), so CI never sees this. It only bites people developing on Windows.

## Changes

**Skip the permission case where permissions don't apply** — on Windows, and on Unix when running as root (a root container hits the same failure for the same underlying reason: the file remains readable).

**Add `TestNewStoreMalformedConfig` so the error path stays covered everywhere.** It reaches the same `NewStore` failure through JSON decoding, which behaves identically on every platform, so skipping the permission case does not leave the error path untested on Windows.

**Assert the error message, which the test never actually did:**

```go
ok := strings.Contains(err.Error(), "failed to open config file")
reflect.DeepEqual(ok, true)   // result discarded — no-op
```

`reflect.DeepEqual` returns a `bool` that was thrown away, so the test passed on *any* error. Now checked with `strings.Contains`. Both expected strings are verified against the code that produces them, [`credentials/internal/config/config.go`](https://github.com/oras-project/oras-go/blob/v2.6.2/registry/remote/credentials/internal/config/config.go#L126-L138):

```go
return nil, fmt.Errorf("failed to open config file at %s: %w", configPath, err)
return nil, fmt.Errorf("failed to decode config file %s: %w: %v", configPath, ErrInvalidConfigFormat, err)
```

**`path.Join` → `filepath.Join`** — `path` is for slash-separated paths, not filesystem paths.

**`t.Errorf` → `t.Fatalf` for setup failures**, which previously let the test continue against a file it had failed to create or chmod.

## Verification

Windows, before → `FAIL`. After:

```console
$ go test ./internal/credential/ -v -cover
=== RUN   TestNewStoreMalformedConfig
--- PASS: TestNewStoreMalformedConfig (0.08s)
=== RUN   TestNewStoreError
    store_test.go:51: os.Chmod cannot make a file unreadable on Windows
--- SKIP: TestNewStoreError (0.00s)
PASS
ok      oras.land/oras/internal/credential      coverage: 76.9% of statements
```

On Linux both tests run; the permission case keeps its original behaviour, now with the assertion actually enforced.

`gofmt` and `go vet` are clean.
