### PR TITLE
fix(cli): pluralize "argument" in argument-count errors

### DIFF
--- a/cmd/oras/internal/argument/checker.go
+++ b/cmd/oras/internal/argument/checker.go
@@ -20,13 +20,22 @@ import "fmt"
 // Exactly checks if the number of arguments is exactly cnt.
 func Exactly(cnt int) func(args []string) (bool, string) {
 	return func(args []string) (bool, string) {
-		return len(args) == cnt, fmt.Sprintf("exactly %d argument", cnt)
+		return len(args) == cnt, fmt.Sprintf("exactly %d %s", cnt, noun(cnt))
 	}
 }
 
 // AtLeast checks if the number of arguments is larger or equal to cnt.
 func AtLeast(cnt int) func(args []string) (bool, string) {
 	return func(args []string) (bool, string) {
-		return len(args) >= cnt, fmt.Sprintf("at least %d argument", cnt)
+		return len(args) >= cnt, fmt.Sprintf("at least %d %s", cnt, noun(cnt))
 	}
+}
+
+// noun returns the correctly pluralized noun for cnt arguments, as specified in
+// docs/proposals/error-handling-guideline.md.
+func noun(cnt int) string {
+	if cnt == 1 {
+		return "argument"
+	}
+	return "arguments"
 }

--- a/cmd/oras/internal/argument/checker_test.go
+++ b/cmd/oras/internal/argument/checker_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package argument
+
+import "testing"
+
+func TestExactly(t *testing.T) {
+	tests := []struct {
+		name    string
+		cnt     int
+		args    []string
+		wantOK  bool
+		wantMsg string
+	}{
+		{"none required, none given", 0, nil, true, "exactly 0 arguments"},
+		{"none required, one given", 0, []string{"a"}, false, "exactly 0 arguments"},
+		{"one required, none given", 1, nil, false, "exactly 1 argument"},
+		{"one required, one given", 1, []string{"a"}, true, "exactly 1 argument"},
+		{"one required, two given", 1, []string{"a", "b"}, false, "exactly 1 argument"},
+		{"two required, one given", 2, []string{"a"}, false, "exactly 2 arguments"},
+		{"two required, two given", 2, []string{"a", "b"}, true, "exactly 2 arguments"},
+		{"two required, three given", 2, []string{"a", "b", "c"}, false, "exactly 2 arguments"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOK, gotMsg := Exactly(tt.cnt)(tt.args)
+			if gotOK != tt.wantOK {
+				t.Errorf("Exactly(%d)(%v) ok = %v, want %v", tt.cnt, tt.args, gotOK, tt.wantOK)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Errorf("Exactly(%d)(%v) msg = %q, want %q", tt.cnt, tt.args, gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	tests := []struct {
+		name    string
+		cnt     int
+		args    []string
+		wantOK  bool
+		wantMsg string
+	}{
+		{"none required, none given", 0, nil, true, "at least 0 arguments"},
+		{"none required, one given", 0, []string{"a"}, true, "at least 0 arguments"},
+		{"one required, none given", 1, nil, false, "at least 1 argument"},
+		{"one required, one given", 1, []string{"a"}, true, "at least 1 argument"},
+		{"one required, two given", 1, []string{"a", "b"}, true, "at least 1 argument"},
+		{"two required, one given", 2, []string{"a"}, false, "at least 2 arguments"},
+		{"two required, two given", 2, []string{"a", "b"}, true, "at least 2 arguments"},
+		{"two required, three given", 2, []string{"a", "b", "c"}, true, "at least 2 arguments"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOK, gotMsg := AtLeast(tt.cnt)(tt.args)
+			if gotOK != tt.wantOK {
+				t.Errorf("AtLeast(%d)(%v) ok = %v, want %v", tt.cnt, tt.args, gotOK, tt.wantOK)
+			}
+			if gotMsg != tt.wantMsg {
+				t.Errorf("AtLeast(%d)(%v) msg = %q, want %q", tt.cnt, tt.args, gotMsg, tt.wantMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`Exactly` and `AtLeast` hardcode the singular noun, so any command requiring more than one argument reports a count that disagrees with it:

```console
$ oras cp foo
Error: "oras cp" requires exactly 2 argument but got 1
Usage: oras cp [flags] <from>{:<tag>|@<digest>} <to>[:<tag>[,<tag>][...]]
Please specify exactly 2 argument as the source and destination for copying. Run "oras cp -h" for more options and examples
```

The text appears **twice per failure**, since `errors.CheckArgs` reuses the same string in both the error and the recommendation. It affects `oras cp` and `oras blob push`, the commands taking exactly 2 arguments.

## Why this wording

[`docs/proposals/error-handling-guideline.md`](https://github.com/oras-project/oras/blob/main/docs/proposals/error-handling-guideline.md#example-1-when-no-reference-provided-in-oras-copy) already specifies the plural form as the intended output:

```console
$ oras cp
Error: "oras copy" requires exactly 2 arguments but received 0.
```

So this is the implementation catching up with the documented guideline, not a new style choice.

## After

```console
$ oras cp foo
Error: "oras cp" requires exactly 2 arguments but got 1
Please specify exactly 2 arguments as the source and destination for copying. ...

$ oras login
Error: "oras login" requires exactly 1 argument but got 0     # singular preserved

$ oras attach
Error: "oras attach" requires at least 1 argument but got 0   # singular preserved
```

A count of 0 reads "exactly 0 arguments", which matches ordinary English usage.

## Tests

This package had no test file (0% statement coverage). Added table-driven tests covering both checkers across counts 0–2, asserting the boolean result *and* the exact message. The package is now at **100%** statement coverage.

```console
$ go test ./cmd/oras/internal/argument/ -cover
ok      oras.land/oras/cmd/oras/internal/argument       coverage: 100.0% of statements
```

Nothing in the repo asserts on the old string — no e2e suite or unit test matches `requires exactly` / `at least ... argument` — so no other tests needed updating. `go test ./...`, `gofmt` and `go vet` are clean.
