### PR TITLE
test(display): cover the template and descriptor metadata handlers

### DIFF
--- a/cmd/oras/internal/display/metadata/descriptor/manifest_fetch_test.go
+++ b/cmd/oras/internal/display/metadata/descriptor/manifest_fetch_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package descriptor
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const testDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+var testDescriptor = ocispec.Descriptor{
+	MediaType: "application/vnd.oci.image.manifest.v1+json",
+	Digest:    testDigest,
+	Size:      100,
+}
+
+// errWriter fails every write, to exercise the output error path.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write error")
+}
+
+func TestNewManifestFetchHandler(t *testing.T) {
+	if got := NewManifestFetchHandler(&bytes.Buffer{}, false); got == nil {
+		t.Fatal("NewManifestFetchHandler() returned nil")
+	}
+}
+
+func TestManifestFetchHandler_OnFetched(t *testing.T) {
+	tests := []struct {
+		name   string
+		pretty bool
+	}{
+		{"compact", false},
+		{"pretty", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			handler := NewManifestFetchHandler(buf, tt.pretty)
+
+			if err := handler.OnFetched("localhost:5000/test:v1", testDescriptor, nil); err != nil {
+				t.Fatalf("OnFetched() error = %v, want nil", err)
+			}
+
+			// The output must round-trip back to the same descriptor whether or
+			// not it is indented.
+			var got ocispec.Descriptor
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("OnFetched() wrote invalid JSON %q: %v", buf.String(), err)
+			}
+			if !reflect.DeepEqual(got, testDescriptor) {
+				t.Errorf("OnFetched() descriptor = %v, want %v", got, testDescriptor)
+			}
+
+			// Only the pretty form is indented and newline-terminated; the
+			// compact form stays on a single line so it can be piped.
+			out := buf.String()
+			if indented := bytes.Contains(buf.Bytes(), []byte("\n  ")); indented != tt.pretty {
+				t.Errorf("OnFetched() indented = %v, want %v; output %q", indented, tt.pretty, out)
+			}
+			if gotNewline := len(out) > 0 && out[len(out)-1] == '\n'; gotNewline != tt.pretty {
+				t.Errorf("OnFetched() trailing newline = %v, want %v; output %q", gotNewline, tt.pretty, out)
+			}
+		})
+	}
+}
+
+func TestManifestFetchHandler_OnFetched_writeError(t *testing.T) {
+	handler := NewManifestFetchHandler(errWriter{}, false)
+	if err := handler.OnFetched("localhost:5000/test:v1", testDescriptor, nil); err == nil {
+		t.Error("OnFetched() error = nil, want an error when the writer fails")
+	}
+}
+
+func TestManifestFetchHandler_OnFetched_ignoresNameAndContent(t *testing.T) {
+	// OnFetched renders only the descriptor: the reference and the raw manifest
+	// bytes are accepted but must not reach the output.
+	buf := &bytes.Buffer{}
+	handler := NewManifestFetchHandler(buf, false)
+
+	if err := handler.OnFetched("localhost:5000/ignored:tag", testDescriptor, []byte(`{"ignored":true}`)); err != nil {
+		t.Fatalf("OnFetched() error = %v, want nil", err)
+	}
+	for _, unwanted := range []string{"ignored", "localhost:5000"} {
+		if bytes.Contains(buf.Bytes(), []byte(unwanted)) {
+			t.Errorf("OnFetched() output %q should not contain %q", buf.String(), unwanted)
+		}
+	}
+}

--- a/cmd/oras/internal/display/metadata/template/attach_test.go
+++ b/cmd/oras/internal/display/metadata/template/attach_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras/cmd/oras/internal/option"
+)
+
+const testDigest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+var testDescriptor = ocispec.Descriptor{
+	MediaType: "application/vnd.oci.image.manifest.v1+json",
+	Digest:    testDigest,
+	Size:      100,
+}
+
+func TestNewAttachHandler(t *testing.T) {
+	if got := NewAttachHandler(&bytes.Buffer{}, "{{.reference}}"); got == nil {
+		t.Fatal("NewAttachHandler() returned nil")
+	}
+}
+
+func TestAttachHandler_Render(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewAttachHandler(buf, "{{.reference}} {{.size}}").(*AttachHandler)
+
+	handler.OnAttached(&option.Target{Path: "localhost:5000/test"}, testDescriptor, ocispec.Descriptor{})
+	if handler.path != "localhost:5000/test" {
+		t.Errorf("OnAttached() path = %q, want %q", handler.path, "localhost:5000/test")
+	}
+
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+	want := "localhost:5000/test@" + testDigest + " 100"
+	if got := buf.String(); got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestAttachHandler_Render_invalidTemplate(t *testing.T) {
+	handler := NewAttachHandler(&bytes.Buffer{}, "{{.reference")
+	handler.OnAttached(&option.Target{Path: "localhost:5000/test"}, testDescriptor, ocispec.Descriptor{})
+	if err := handler.Render(); err == nil {
+		t.Error("Render() error = nil, want an error for an unparsable template")
+	}
+}

--- a/cmd/oras/internal/display/metadata/template/discover_test.go
+++ b/cmd/oras/internal/display/metadata/template/discover_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const referrerDigest = "sha256:9f6ad1a2d9ec1d0e4b5b1f9f6c9c9a4c6e9f1d4b7a2c5e8f1a4d7b0c3e6f9a2d"
+
+var testReferrer = ocispec.Descriptor{
+	MediaType:    "application/vnd.oci.image.manifest.v1+json",
+	ArtifactType: "application/vnd.example.sbom",
+	Digest:       referrerDigest,
+	Size:         42,
+}
+
+func TestNewDiscoverHandler(t *testing.T) {
+	if got := NewDiscoverHandler(&bytes.Buffer{}, testDescriptor, "localhost:5000/test", "{{.reference}}"); got == nil {
+		t.Fatal("NewDiscoverHandler() returned nil")
+	}
+}
+
+func TestDiscoverHandler_OnDiscovered(t *testing.T) {
+	handler := NewDiscoverHandler(&bytes.Buffer{}, testDescriptor, "localhost:5000/test", "{{.reference}}")
+
+	// the root is a known subject, so its referrer is accepted
+	if err := handler.OnDiscovered(testReferrer, testDescriptor); err != nil {
+		t.Fatalf("OnDiscovered() error = %v, want nil", err)
+	}
+
+	// a referrer of the first referrer is accepted too, since discovering a
+	// node registers it as a possible subject
+	nested := testReferrer
+	nested.Digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	if err := handler.OnDiscovered(nested, testReferrer); err != nil {
+		t.Errorf("OnDiscovered() error = %v, want nil for a referrer of a known referrer", err)
+	}
+}
+
+func TestDiscoverHandler_OnDiscovered_unknownSubject(t *testing.T) {
+	handler := NewDiscoverHandler(&bytes.Buffer{}, testDescriptor, "localhost:5000/test", "{{.reference}}")
+
+	unknown := testDescriptor
+	unknown.Digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+	err := handler.OnDiscovered(testReferrer, unknown)
+	if err == nil {
+		t.Fatal("OnDiscovered() error = nil, want an error for an unknown subject")
+	}
+	if !strings.Contains(err.Error(), "unexpected subject descriptor") {
+		t.Errorf("OnDiscovered() error = %q, want it to mention an unexpected subject descriptor", err.Error())
+	}
+}
+
+func TestDiscoverHandler_Render(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewDiscoverHandler(buf, testDescriptor, "localhost:5000/test", "{{.reference}}|{{len .referrers}}")
+
+	if err := handler.OnDiscovered(testReferrer, testDescriptor); err != nil {
+		t.Fatalf("OnDiscovered() error = %v, want nil", err)
+	}
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+
+	want := "localhost:5000/test@" + testDigest + "|1"
+	if got := buf.String(); got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverHandler_Render_invalidTemplate(t *testing.T) {
+	handler := NewDiscoverHandler(&bytes.Buffer{}, testDescriptor, "localhost:5000/test", "{{.reference")
+	if err := handler.Render(); err == nil {
+		t.Error("Render() error = nil, want an error for an unparsable template")
+	}
+}

--- a/cmd/oras/internal/display/metadata/template/manifest_fetch_test.go
+++ b/cmd/oras/internal/display/metadata/template/manifest_fetch_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewManifestFetchHandler(t *testing.T) {
+	if got := NewManifestFetchHandler(&bytes.Buffer{}, "{{.reference}}"); got == nil {
+		t.Fatal("NewManifestFetchHandler() returned nil")
+	}
+}
+
+func TestManifestFetchHandler_OnFetched(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewManifestFetchHandler(buf, "{{.reference}}|{{.content.schemaVersion}}")
+
+	content := []byte(`{"schemaVersion":2}`)
+	if err := handler.OnFetched("localhost:5000/test", testDescriptor, content); err != nil {
+		t.Fatalf("OnFetched() error = %v, want nil", err)
+	}
+
+	want := "localhost:5000/test@" + testDigest + "|2"
+	if got := buf.String(); got != want {
+		t.Errorf("OnFetched() = %q, want %q", got, want)
+	}
+}
+
+func TestManifestFetchHandler_OnFetched_invalidContent(t *testing.T) {
+	// Content that is not JSON is not an error: the manifest is reported as
+	// null and the descriptor fields are still rendered.
+	buf := &bytes.Buffer{}
+	handler := NewManifestFetchHandler(buf, "{{.size}}|{{.content}}")
+
+	if err := handler.OnFetched("localhost:5000/test", testDescriptor, []byte("not json")); err != nil {
+		t.Fatalf("OnFetched() error = %v, want nil for non-JSON content", err)
+	}
+
+	want := "100|<no value>"
+	if got := buf.String(); got != want {
+		t.Errorf("OnFetched() = %q, want %q", got, want)
+	}
+}
+
+func TestManifestFetchHandler_OnFetched_invalidTemplate(t *testing.T) {
+	handler := NewManifestFetchHandler(&bytes.Buffer{}, "{{.reference")
+	if err := handler.OnFetched("localhost:5000/test", testDescriptor, []byte(`{}`)); err == nil {
+		t.Error("OnFetched() error = nil, want an error for an unparsable template")
+	}
+}

--- a/cmd/oras/internal/display/metadata/template/push_test.go
+++ b/cmd/oras/internal/display/metadata/template/push_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"oras.land/oras/cmd/oras/internal/option"
+)
+
+func TestNewPushHandler(t *testing.T) {
+	if got := NewPushHandler(&bytes.Buffer{}, "{{.reference}}"); got == nil {
+		t.Fatal("NewPushHandler() returned nil")
+	}
+}
+
+func TestPushHandler_Render(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewPushHandler(buf, "{{.reference}}|{{range .referenceAsTags}}{{.}} {{end}}").(*PushHandler)
+
+	if err := handler.OnTagged(testDescriptor, "v1.0.0"); err != nil {
+		t.Fatalf("OnTagged() error = %v, want nil", err)
+	}
+	opts := &option.Target{
+		RawReference: "localhost:5000/test:latest",
+		Path:         "localhost:5000/test",
+		Reference:    "latest",
+	}
+	if err := handler.OnCopied(opts, testDescriptor); err != nil {
+		t.Fatalf("OnCopied() error = %v, want nil", err)
+	}
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+
+	// Tags are sorted, so "latest" precedes "v1.0.0" regardless of the order
+	// they were recorded in.
+	want := "localhost:5000/test@" + testDigest + "|localhost:5000/test:latest localhost:5000/test:v1.0.0 "
+	if got := buf.String(); got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+// A digest reference is not a tag, so OnCopied must not record it as one.
+func TestPushHandler_OnCopied_digestReferenceIsNotTagged(t *testing.T) {
+	handler := NewPushHandler(&bytes.Buffer{}, "{{.reference}}").(*PushHandler)
+
+	opts := &option.Target{
+		RawReference: "localhost:5000/test@" + testDigest,
+		Path:         "localhost:5000/test",
+		Reference:    testDigest,
+	}
+	if err := handler.OnCopied(opts, testDescriptor); err != nil {
+		t.Fatalf("OnCopied() error = %v, want nil", err)
+	}
+	if tags := handler.tagged.Tags(); len(tags) != 0 {
+		t.Errorf("OnCopied() recorded tags = %v, want none for a digest reference", tags)
+	}
+}
+
+// An empty raw reference means nothing was tagged.
+func TestPushHandler_OnCopied_noReference(t *testing.T) {
+	handler := NewPushHandler(&bytes.Buffer{}, "{{.reference}}").(*PushHandler)
+
+	opts := &option.Target{Path: "localhost:5000/test"}
+	if err := handler.OnCopied(opts, testDescriptor); err != nil {
+		t.Fatalf("OnCopied() error = %v, want nil", err)
+	}
+	if tags := handler.tagged.Tags(); len(tags) != 0 {
+		t.Errorf("OnCopied() recorded tags = %v, want none when no reference is given", tags)
+	}
+	if handler.path != "localhost:5000/test" {
+		t.Errorf("OnCopied() path = %q, want %q", handler.path, "localhost:5000/test")
+	}
+}
+
+func TestPushHandler_OnTagged(t *testing.T) {
+	handler := NewPushHandler(&bytes.Buffer{}, "{{.reference}}").(*PushHandler)
+
+	for _, tag := range []string{"v1.0.0", "latest"} {
+		if err := handler.OnTagged(testDescriptor, tag); err != nil {
+			t.Fatalf("OnTagged(%q) error = %v, want nil", tag, err)
+		}
+	}
+	tags := handler.tagged.Tags()
+	for _, want := range []string{"v1.0.0", "latest"} {
+		if !slices.Contains(tags, want) {
+			t.Errorf("OnTagged() tags = %v, want to contain %q", tags, want)
+		}
+	}
+}
+
+func TestPushHandler_Render_invalidTemplate(t *testing.T) {
+	handler := NewPushHandler(&bytes.Buffer{}, "{{.reference")
+	if err := handler.Render(); err == nil {
+		t.Error("Render() error = nil, want an error for an unparsable template")
+	}
+}

--- a/cmd/oras/internal/display/metadata/template/repo_test.go
+++ b/cmd/oras/internal/display/metadata/template/repo_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewRepoListHandler(t *testing.T) {
+	if got := NewRepoListHandler(&bytes.Buffer{}, "{{.registry}}", "localhost:5000"); got == nil {
+		t.Fatal("NewRepoListHandler() returned nil")
+	}
+}
+
+func TestRepoListHandler_Render(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewRepoListHandler(buf, "{{.registry}}|{{range .repositories}}{{.}} {{end}}", "localhost:5000")
+
+	for _, repo := range []string{"team/alpha", "team/beta"} {
+		if err := handler.OnRepositoryListed(repo); err != nil {
+			t.Fatalf("OnRepositoryListed(%q) error = %v, want nil", repo, err)
+		}
+	}
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+
+	want := "localhost:5000|team/alpha team/beta "
+	if got := buf.String(); got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+// With nothing listed the model still renders, with an empty repository list.
+func TestRepoListHandler_Render_empty(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewRepoListHandler(buf, "{{len .repositories}}", "localhost:5000")
+
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+	if got, want := buf.String(), "0"; got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRepoListHandler_Render_invalidTemplate(t *testing.T) {
+	handler := NewRepoListHandler(&bytes.Buffer{}, "{{.registry", "localhost:5000")
+	if err := handler.Render(); err == nil {
+		t.Error("Render() error = nil, want an error for an unparsable template")
+	}
+}
+
+func TestNewRepoTagsHandler(t *testing.T) {
+	if got := NewRepoTagsHandler(&bytes.Buffer{}, "{{.tags}}"); got == nil {
+		t.Fatal("NewRepoTagsHandler() returned nil")
+	}
+}
+
+func TestRepoTagsHandler_Render(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewRepoTagsHandler(buf, "{{range .tags}}{{.}} {{end}}")
+
+	for _, tag := range []string{"v1.0.0", "latest"} {
+		if err := handler.OnTagListed(tag); err != nil {
+			t.Fatalf("OnTagListed(%q) error = %v, want nil", tag, err)
+		}
+	}
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+
+	want := "v1.0.0 latest "
+	if got := buf.String(); got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRepoTagsHandler_Render_empty(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewRepoTagsHandler(buf, "{{len .tags}}")
+
+	if err := handler.Render(); err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+	if got, want := buf.String(), "0"; got != want {
+		t.Errorf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRepoTagsHandler_Render_invalidTemplate(t *testing.T) {
+	handler := NewRepoTagsHandler(&bytes.Buffer{}, "{{.tags")
+	if err := handler.Render(); err == nil {
+		t.Error("Render() error = nil, want an error for an unparsable template")
+	}
+}


### PR DESCRIPTION
## Problem

Two metadata packages had **no test file at all**:

```
cmd/oras/internal/display/metadata/template     0.0% of statements
cmd/oras/internal/display/metadata/descriptor   0.0% of statements
```

Both render user-facing output — `--format go-template` for every command that supports it, and `oras manifest fetch --descriptor` — so a regression in either is immediately visible to users but was caught by nothing.

## Changes

Tests for every handler in both packages. They assert the **rendered bytes**, not merely that no error came back, so a change in output format fails the test.

**`descriptor`**
- compact and pretty output both round-trip back to the same descriptor
- only the pretty form is indented and newline-terminated; the compact form stays on one line so it can be piped
- a failing writer surfaces its error
- the reference and raw manifest bytes handed to `OnFetched` do not leak into the output

**`template`** — attach, discover, manifest fetch, push, repo ls, repo tags: each over its `Render` path and an unparsable template, plus the branches worth pinning down:
- `discover` rejects a referrer whose subject was never seen, and accepts a referrer of a previously discovered referrer
- `manifest fetch` tolerates non-JSON content by rendering a null manifest rather than failing
- `push` does not record a digest reference as a tag, and records nothing when no reference is given

```
cmd/oras/internal/display/metadata/template     85.3% of statements
cmd/oras/internal/display/metadata/descriptor   80.0% of statements
```

**No production code is changed.** `go test ./...`, `gofmt` and `go vet` are clean.

## One thing noticed while writing these

`model.NewPush` builds `ReferenceAsTags` with `var refAsTags []string` and only ever appends, so when nothing is tagged the field marshals as `null` rather than `[]`. `model.Repositories` and `model.Tags` both initialise their slices to `[]string{}` instead.

The visible effect is that a template calling `{{len .referenceAsTags}}` errors with `len of nil pointer` after an untagged push, while the same template shape works for `repo ls` and `repo tags`. I left it alone here to keep this PR test-only — happy to open an issue or a follow-up PR if you'd like it made consistent.
